### PR TITLE
feat: keep large GitHub star libraries smooth

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -3,7 +3,17 @@ import { githubStarSource } from '@/api/github-star-source';
 import { getMessages } from '@/i18n';
 import { idbTagStore } from '@/storage/idb-tag-store';
 import { db, liveStarCount } from '@/storage/db';
-import { queryStars, invalidateCache, type QueryParams, type QueryResult } from './query';
+import {
+  queryMeta,
+  queryPage,
+  queryStars,
+  invalidateCache,
+  type QueryMetaResult,
+  type QueryPageResult,
+  type QueryParams,
+  type QueryResult,
+  type StarFilter,
+} from './query';
 import { suggestTags } from '@/ui/suggest';
 import { translateError } from '@/api/errors';
 import type { OnboardingStage, SyncProgress } from '@/types';
@@ -31,6 +41,8 @@ type Req =
   | { type: 'getUsername' }
   | { type: 'getAccount' }
   | { type: 'fetchAccount' }
+  | { type: 'queryMeta'; filter: StarFilter }
+  | { type: 'queryPage'; params: QueryParams }
   | { type: 'query'; params: QueryParams }
   | { type: 'setTags'; full_name: string; tags: string[] }
   | { type: 'setNotes'; full_name: string; notes: string }
@@ -372,6 +384,10 @@ async function handle(req: Req): Promise<Res> {
           return { ok: true, data: await authStore.getAccount() };
         }
       }
+      case 'queryMeta':
+        return { ok: true, data: await queryMeta(req.filter) as QueryMetaResult };
+      case 'queryPage':
+        return { ok: true, data: await queryPage(req.params) as QueryPageResult };
       case 'query':
         return { ok: true, data: await queryStars(req.params) as QueryResult };
       case 'setTags':

--- a/src/background/query.ts
+++ b/src/background/query.ts
@@ -2,40 +2,59 @@ import { db } from '@/storage/db';
 import type { Star, Tag } from '@/types';
 import type { FilterState, SortKey } from '@/ui/filter-store';
 
-/**
- * Star query engine (runs in the SW, owns IDB); returns a filtered+sorted window
- * + sidebar facet counts, never the full row set.
- */
+export type StarFilter = Pick<
+  FilterState,
+  'query' | 'languages' | 'tags' | 'tagMode' | 'showTombstone' | 'onlyFavorite' | 'onlyUntagged' | 'onlyArchived' | 'sortKey' | 'sortDir'
+>;
 
 export interface QueryParams {
-  filter: Pick<
-    FilterState,
-    'query' | 'languages' | 'tags' | 'tagMode' | 'showTombstone' | 'onlyFavorite' | 'onlyUntagged' | 'sortKey' | 'sortDir'
-  >;
+  filter: StarFilter;
   offset: number;
   limit: number;
 }
 
-export interface QueryResult {
-  rows: Star[];
-  total: number; // filtered total
-  grandTotal: number; // all stars in DB
-  tagsForRows: Record<string, Tag | undefined>;
-  languages: [string, number][]; // facet over ALL stars
+export interface QueryMetaResult {
+  total: number;
+  grandTotal: number;
+  languages: [string, number][];
   tagTree: { name: string; count: number }[];
   tagTotal: number;
 }
 
-let cache: { stars: Star[]; tags: Map<string, Tag>; excluded: Set<string>; version: number } | null = null;
+export interface QueryPageResult {
+  offset: number;
+  limit: number;
+  rows: Star[];
+  tagsForRows: Record<string, Tag | undefined>;
+}
+
+export interface QueryResult extends QueryMetaResult, Omit<QueryPageResult, 'offset' | 'limit'> {}
+
+interface BaseCache {
+  stars: Star[];
+  tags: Map<string, Tag>;
+  excluded: Set<string>;
+  version: number;
+}
+
+interface FilteredCache {
+  key: string;
+  baseVersion: number;
+  filtered: Star[];
+  meta: QueryMetaResult;
+}
+
+let cache: BaseCache | null = null;
+let filteredCache: FilteredCache | null = null;
 let cacheVersion = 0;
 
-/** Invalidate the in-memory cache (called after any sync/write). */
 export function invalidateCache() {
   cacheVersion++;
   cache = null;
+  filteredCache = null;
 }
 
-async function ensureCache() {
+async function ensureCache(): Promise<BaseCache> {
   if (cache && cache.version === cacheVersion) return cache;
   const [stars, tags, tagMeta] = await Promise.all([
     db.stars.toArray(),
@@ -43,10 +62,10 @@ async function ensureCache() {
     db.tagMeta.toArray(),
   ]);
   const tagMap = new Map<string, Tag>();
-  for (const t of tags) tagMap.set(t.full_name, t);
+  for (const tag of tags) tagMap.set(tag.full_name, tag);
   const excluded = new Set<string>();
-  for (const m of tagMeta) {
-    if (m.excluded) excluded.add(m.name);
+  for (const meta of tagMeta) {
+    if (meta.excluded) excluded.add(meta.name);
   }
   cache = { stars, tags: tagMap, excluded, version: cacheVersion };
   return cache;
@@ -72,68 +91,116 @@ function sortRows(rows: Star[], key: SortKey, dir: 'asc' | 'desc'): Star[] {
   });
 }
 
-export async function queryStars(params: QueryParams): Promise<QueryResult> {
-  const { filter, offset, limit } = params;
-  const { stars, tags, excluded } = await ensureCache();
+function buildFilterKey(filter: StarFilter): string {
+  return JSON.stringify(filter);
+}
 
+function filterRows(stars: Star[], tags: Map<string, Tag>, filter: StarFilter): Star[] {
   const q = filter.query.trim().toLowerCase();
   const langSet = filter.languages.length ? new Set(filter.languages) : null;
   const tagSet = filter.tags.length ? new Set(filter.tags) : null;
 
-  const filtered = stars.filter((s) => {
-    if (!filter.showTombstone && s.tombstone) return false;
-    if (langSet && (s.language === null || !langSet.has(s.language))) return false;
-    const tagRecord = tags.get(s.full_name);
+  return stars.filter((star) => {
+    if (!filter.showTombstone && star.tombstone) return false;
+    if (filter.onlyArchived && !star.archived) return false;
+    if (langSet && (star.language === null || !langSet.has(star.language))) return false;
+    const tagRecord = tags.get(star.full_name);
     const myTags = tagRecord?.tags ?? [];
     if (filter.onlyFavorite && !tagRecord?.favorite) return false;
     if (filter.onlyUntagged && myTags.length > 0) return false;
     if (tagSet) {
       if (filter.tagMode === 'all') {
-        if (!filter.tags.every((t) => myTags.includes(t))) return false;
-      } else if (!myTags.some((t) => tagSet.has(t))) return false;
+        if (!filter.tags.every((tag) => myTags.includes(tag))) return false;
+      } else if (!myTags.some((tag) => tagSet.has(tag))) return false;
     }
     if (q) {
       const notes = tagRecord?.notes ?? '';
-      const hay = `${s.full_name} ${s.description} ${s.topics.join(' ')} ${notes}`.toLowerCase();
+      const hay = `${star.full_name} ${star.description} ${star.topics.join(' ')} ${notes}`.toLowerCase();
       if (!hay.includes(q)) return false;
     }
     return true;
   });
+}
 
-  sortRows(filtered, filter.sortKey, filter.sortDir);
-
-  // Languages facet over ALL stars (stable sidebar regardless of filter).
+function buildMeta(stars: Star[], tags: Map<string, Tag>, excluded: Set<string>, total: number): QueryMetaResult {
   const langCounts = new Map<string, number>();
-  for (const s of stars) if (s.language) langCounts.set(s.language, (langCounts.get(s.language) ?? 0) + 1);
+  for (const star of stars) {
+    if (!star.language) continue;
+    langCounts.set(star.language, (langCounts.get(star.language) ?? 0) + 1);
+  }
   const languages: [string, number][] = [...langCounts.entries()]
     .sort((a, b) => b[1] - a[1])
     .slice(0, 40);
 
-  // Tag tree facet over ALL stars' tags. Excluded (deleted) tags are omitted from
-  // the sidebar tree — they're tombstones, not live filters. The tree is a flat
-  // list sorted by count (no dimension grouping); topic-derived and user-authored
-  // tags sit side by side.
   const tagCounts = new Map<string, number>();
-  for (const t of tags.values()) for (const tag of t.tags) {
-    if (excluded.has(tag)) continue;
-    tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+  for (const tagRecord of tags.values()) {
+    for (const tag of tagRecord.tags) {
+      if (excluded.has(tag)) continue;
+      tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+    }
   }
-  const tagTree: QueryResult['tagTree'] = [...tagCounts.entries()]
+  const tagTree = [...tagCounts.entries()]
     .map(([name, count]) => ({ name, count }))
     .sort((a, b) => b.count - a.count);
 
-  // Slice for the requested window.
-  const rows = filtered.slice(offset, offset + limit);
-  const tagsForRows: Record<string, Tag | undefined> = {};
-  for (const r of rows) tagsForRows[r.full_name] = tags.get(r.full_name);
-
   return {
-    rows,
-    total: filtered.length,
+    total,
     grandTotal: stars.length,
-    tagsForRows,
     languages,
     tagTree,
     tagTotal: tagCounts.size,
+  };
+}
+
+async function ensureFilteredCache(filter: StarFilter): Promise<FilteredCache> {
+  const base = await ensureCache();
+  const key = buildFilterKey(filter);
+  if (filteredCache && filteredCache.key === key && filteredCache.baseVersion === base.version) {
+    return filteredCache;
+  }
+
+  const filtered = sortRows(filterRows(base.stars, base.tags, filter), filter.sortKey, filter.sortDir);
+  const meta = buildMeta(base.stars, base.tags, base.excluded, filtered.length);
+  filteredCache = {
+    key,
+    baseVersion: base.version,
+    filtered,
+    meta,
+  };
+  return filteredCache;
+}
+
+export async function queryMeta(filter: StarFilter): Promise<QueryMetaResult> {
+  return (await ensureFilteredCache(filter)).meta;
+}
+
+export async function queryPage(params: QueryParams): Promise<QueryPageResult> {
+  const { filter, offset, limit } = params;
+  const [{ filtered }, { tags }] = await Promise.all([
+    ensureFilteredCache(filter),
+    ensureCache(),
+  ]);
+  const safeOffset = Math.max(0, offset);
+  const safeLimit = Math.max(0, limit);
+  const rows = filtered.slice(safeOffset, safeOffset + safeLimit);
+  const tagsForRows: Record<string, Tag | undefined> = {};
+  for (const row of rows) tagsForRows[row.full_name] = tags.get(row.full_name);
+  return {
+    offset: safeOffset,
+    limit: safeLimit,
+    rows,
+    tagsForRows,
+  };
+}
+
+export async function queryStars(params: QueryParams): Promise<QueryResult> {
+  const [meta, page] = await Promise.all([
+    queryMeta(params.filter),
+    queryPage(params),
+  ]);
+  return {
+    ...meta,
+    rows: page.rows,
+    tagsForRows: page.tagsForRows,
   };
 }

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -73,6 +73,7 @@ export interface MessageCatalog {
   activeFilters: {
     onlyFavorite: string;
     onlyUntagged: string;
+    onlyArchived: string;
     summary: (count: number) => string;
     clearOne: string;
     clearAll: string;
@@ -83,6 +84,8 @@ export interface MessageCatalog {
     onlyFavoriteHint: string;
     onlyUntaggedLabel: string;
     onlyUntaggedHint: string;
+    onlyArchivedLabel: string;
+    onlyArchivedHint: string;
     showTombstoneLabel: string;
     showTombstoneHint: string;
     languages: (count: number) => string;
@@ -394,6 +397,7 @@ const messages: Record<Locale, MessageCatalog> = {
     activeFilters: {
       onlyFavorite: "Favorites",
       onlyUntagged: "Untagged only",
+      onlyArchived: "Archived",
       summary: (count) => `${count} results · filtered`,
       clearOne: "Remove this filter",
       clearAll: "Clear all filters",
@@ -404,6 +408,8 @@ const messages: Record<Locale, MessageCatalog> = {
       onlyFavoriteHint: "",
       onlyUntaggedLabel: "Untagged only",
       onlyUntaggedHint: "",
+      onlyArchivedLabel: "Archived",
+      onlyArchivedHint: "",
       showTombstoneLabel: "Show unstarred",
       showTombstoneHint: "tombstoned repos",
       languages: (count) => `Languages${count > 0 ? ` · ${count}` : ""}`,
@@ -741,6 +747,7 @@ const messages: Record<Locale, MessageCatalog> = {
     activeFilters: {
       onlyFavorite: "收藏",
       onlyUntagged: "仅未标注",
+      onlyArchived: "已归档",
       summary: (count) => `${count} 个结果 · 已筛选`,
       clearOne: "移除该筛选",
       clearAll: "清除全部筛选",
@@ -751,6 +758,8 @@ const messages: Record<Locale, MessageCatalog> = {
       onlyFavoriteHint: "",
       onlyUntaggedLabel: "仅未标注",
       onlyUntaggedHint: "",
+      onlyArchivedLabel: "已归档",
+      onlyArchivedHint: "",
       showTombstoneLabel: "显示已 unstar",
       showTombstoneHint: "tombstoned repos",
       languages: (count) => `Languages${count > 0 ? ` · ${count}` : ""}`,

--- a/src/ui/ManagerPanel.tsx
+++ b/src/ui/ManagerPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { AlertTriangle, Heart, RefreshCw, Sparkles } from 'lucide-react';
+import type { Tag } from '@/types';
 import { useStars } from '@/ui/use-stars';
 import { useFilterStore } from '@/ui/filter-store';
 import { StarRow } from '@/ui/components/StarRow';
@@ -26,7 +27,23 @@ const ROW_HEIGHT = 64;
 const GRID_COLS = 'grid-cols-[minmax(180px,1.4fr)_2fr_80px_64px_84px_1.6fr_28px_20px]';
 
 export function ManagerPanel() {
-  const { rows, total, grandTotal, loading, phase, languages, tagTree, tagsByFullName, refresh: refreshStars } = useStars();
+  const {
+    total,
+    grandTotal,
+    loading,
+    loadingMore,
+    phase,
+    languages,
+    tagTree,
+    tagsByFullName,
+    refresh: refreshStars,
+    getRow,
+    getTagForRow,
+    ensureRange,
+    ensureIndex,
+    updateCachedRowTag,
+    loadedIndexByFullName,
+  } = useStars();
   const f = useFilterStore();
   const [status, setStatus] = useState<SyncStatus | null>(null);
   const [statusLoaded, setStatusLoaded] = useState(false);
@@ -34,7 +51,8 @@ export function ManagerPanel() {
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const [successAction, setSuccessAction] = useState<string | null>(null);
   const [info, setInfo] = useState<string | null>(null);
-  const [selected, setSelected] = useState<string | null>(null);
+  const [selected, setSelected] = useState<{ fullName: string; indexHint: number | null } | null>(null);
+  const [pendingSelectionIndex, setPendingSelectionIndex] = useState<number | null>(null);
   const [coachStep, setCoachStep] = useState<number | null>(null);
   const [favoriteOverrides, setFavoriteOverrides] = useState<Record<string, FavoriteOverrideState>>({});
   const searchRef = useRef<HTMLInputElement>(null);
@@ -49,8 +67,8 @@ export function ManagerPanel() {
   };
 
   const finalizeOnboardingAfterSync = async (hasToken: boolean) => {
-    const q = await bgCall<{ grandTotal: number }>('query', {
-      params: { filter: emptyFilter(), offset: 0, limit: 1 },
+    const q = await bgCall<{ grandTotal: number }>('queryMeta', {
+      filter: emptyFilter(),
     }).catch(() => null);
     if (!q) return;
     await setOnboardingStage(resolveOnboardingStageAfterSync(hasToken, q.grandTotal));
@@ -73,8 +91,8 @@ export function ManagerPanel() {
       setStatus((current) => mergeStatusSnapshot(current, st));
       setStatusLoaded(true);
       if (st?.hasToken) {
-        const q = await bgCall<{ grandTotal: number }>('query', {
-          params: { filter: emptyFilter(), offset: 0, limit: 1 },
+        const q = await bgCall<{ grandTotal: number }>('queryMeta', {
+          filter: emptyFilter(),
         }).catch(() => null);
         const syncType = pickInitialSyncAction(st, q?.grandTotal ?? 0);
         if (!syncType) return;
@@ -112,11 +130,19 @@ export function ManagerPanel() {
   }, []);
 
   const rowVirtualizer = useVirtualizer({
-    count: rows.length,
+    count: total,
     getScrollElement: () => listRef.current,
     estimateSize: () => ROW_HEIGHT,
     overscan: 12,
   });
+  const virtualItems = rowVirtualizer.getVirtualItems();
+
+  useEffect(() => {
+    if (virtualItems.length === 0) return;
+    const start = virtualItems[0].index;
+    const end = virtualItems[virtualItems.length - 1].index + 24;
+    ensureRange(start, end);
+  }, [ensureRange, total, virtualItems]);
 
   const successTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const flashSuccess = (type: string) => {
@@ -203,19 +229,51 @@ export function ManagerPanel() {
     await dismissOnboarding();
   };
 
-  const selectedIdx = useMemo(
-    () => (selected ? rows.findIndex((r) => r.full_name === selected) : -1),
-    [selected, rows],
-  );
-  const selectedStar = selectedIdx >= 0 ? rows[selectedIdx] : null;
-  const selectedTag = selectedStar ? tagsByFullName.get(selectedStar.full_name) : undefined;
+  const selectedIdx = useMemo(() => {
+    if (!selected) return -1;
+    if (selected.indexHint !== null) {
+      const hinted = getRow(selected.indexHint);
+      if (hinted?.full_name === selected.fullName) return selected.indexHint;
+    }
+    return loadedIndexByFullName.get(selected.fullName) ?? -1;
+  }, [getRow, loadedIndexByFullName, selected]);
+  const selectedStar = selectedIdx >= 0 ? getRow(selectedIdx) : null;
+  const selectedTag = selectedStar ? getTagForRow(selectedStar.full_name) : undefined;
 
   useEffect(() => {
-    setFavoriteOverrides((current) => pruneFavoriteOverrides(current, tagsByFullName, rows));
-  }, [rows, tagsByFullName]);
+    setFavoriteOverrides((current) => pruneFavoriteOverrides(current, tagsByFullName));
+  }, [tagsByFullName]);
 
-  const handleSelect = (full_name: string) => {
-    setSelected((cur) => (cur === full_name ? null : full_name));
+  useEffect(() => {
+    if (!selected) return;
+    if (selectedIdx >= 0) {
+      setSelected((current) => {
+        if (!current || current.fullName !== selected.fullName || current.indexHint === selectedIdx) return current;
+        return { ...current, indexHint: selectedIdx };
+      });
+      return;
+    }
+    if (selected.indexHint !== null) ensureIndex(selected.indexHint);
+  }, [ensureIndex, selected, selectedIdx]);
+
+  useEffect(() => {
+    if (pendingSelectionIndex === null) return;
+    if (pendingSelectionIndex < 0 || pendingSelectionIndex >= total) {
+      setPendingSelectionIndex(null);
+      return;
+    }
+    const row = getRow(pendingSelectionIndex);
+    if (!row) {
+      ensureIndex(pendingSelectionIndex);
+      return;
+    }
+    setSelected({ fullName: row.full_name, indexHint: pendingSelectionIndex });
+    setPendingSelectionIndex(null);
+  }, [ensureIndex, getRow, pendingSelectionIndex, total]);
+
+  const handleSelect = (full_name: string, index: number) => {
+    setPendingSelectionIndex(null);
+    setSelected((cur) => (cur?.fullName === full_name ? null : { fullName: full_name, indexHint: index }));
   };
 
   const handleToggleFavorite = async (full_name: string, favorite: boolean) => {
@@ -225,6 +283,7 @@ export function ManagerPanel() {
     }));
     try {
       await bgCall('setFavorite', { full_name, favorite });
+      updateCachedRowTag(full_name, { favorite, mtime: new Date().toISOString() });
       setFavoriteOverrides((current) => ({
         ...current,
         [full_name]: { value: favorite, pending: false },
@@ -243,7 +302,7 @@ export function ManagerPanel() {
   };
 
   const hasActiveFilter =
-    f.languages.length > 0 || f.tags.length > 0 || f.onlyFavorite || f.onlyUntagged;
+    f.languages.length > 0 || f.tags.length > 0 || f.onlyFavorite || f.onlyUntagged || f.onlyArchived;
 
   return (
     <PortalProvider containerRef={rootRef}>
@@ -340,15 +399,25 @@ export function ManagerPanel() {
               </span>
               <span />
             </div>
-            {rows.length === 0 ? (
+            {total === 0 ? (
               <div className="p-10 text-center text-sm text-muted-foreground">
                 {loading ? m.common.loading : m.manager.emptyState}
               </div>
             ) : (
               <div style={{ height: rowVirtualizer.getTotalSize(), position: 'relative' }}>
                 {rowVirtualizer.getVirtualItems().map((vi) => {
-                  const star = rows[vi.index];
-                  const tag = tagsByFullName.get(star.full_name);
+                  const star = getRow(vi.index);
+                  if (!star) {
+                    return (
+                      <div
+                        key={`skeleton-${vi.index}`}
+                        style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: ROW_HEIGHT, transform: `translateY(${vi.start}px)` }}
+                      >
+                        <RowSkeleton />
+                      </div>
+                    );
+                  }
+                  const tag = getTagForRow(star.full_name);
                   const { favorite, busy: favoriteBusy } = resolveFavoriteState(
                     tag,
                     favoriteOverrides[star.full_name],
@@ -367,12 +436,20 @@ export function ManagerPanel() {
                         selectedTags={f.tags}
                         onToggleTag={f.toggleTag}
                         onToggleFavorite={handleToggleFavorite}
-                        selected={selected === star.full_name}
-                        onSelect={handleSelect}
+                        selected={selected?.fullName === star.full_name}
+                        onSelect={(fullName) => handleSelect(fullName, vi.index)}
                       />
                     </div>
                   );
                 })}
+              </div>
+            )}
+            {loadingMore && (
+              <div className="border-t border-border bg-card px-3 py-2 text-center text-xs text-muted-foreground">
+                <span className="inline-flex items-center gap-2">
+                  <Spinner className="size-3" />
+                  {m.common.loading}
+                </span>
               </div>
             )}
             </div>
@@ -388,11 +465,40 @@ export function ManagerPanel() {
                 selectedTags={f.tags}
                 onToggleTag={f.toggleTag}
                 onDataChanged={refreshStars}
-                onClose={() => setSelected(null)}
-                onPrev={() => selectedIdx > 0 && setSelected(rows[selectedIdx - 1].full_name)}
-                onNext={() => selectedIdx >= 0 && selectedIdx < rows.length - 1 && setSelected(rows[selectedIdx + 1].full_name)}
+                onLocalTagPatched={(patch: DetailTagPatch) => {
+                  if (!selectedStar) return;
+                  updateCachedRowTag(selectedStar.full_name, patch);
+                }}
+                onClose={() => {
+                  setPendingSelectionIndex(null);
+                  setSelected(null);
+                }}
+                onPrev={() => {
+                  if (selectedIdx <= 0) return;
+                  const nextIndex = selectedIdx - 1;
+                  const prevRow = getRow(nextIndex);
+                  if (prevRow) {
+                    setPendingSelectionIndex(null);
+                    setSelected({ fullName: prevRow.full_name, indexHint: nextIndex });
+                  } else {
+                    setPendingSelectionIndex(nextIndex);
+                    ensureIndex(nextIndex);
+                  }
+                }}
+                onNext={() => {
+                  if (selectedIdx < 0 || selectedIdx >= total - 1) return;
+                  const nextIndex = selectedIdx + 1;
+                  const nextRow = getRow(nextIndex);
+                  if (nextRow) {
+                    setPendingSelectionIndex(null);
+                    setSelected({ fullName: nextRow.full_name, indexHint: nextIndex });
+                  } else {
+                    setPendingSelectionIndex(nextIndex);
+                    ensureIndex(nextIndex);
+                  }
+                }}
                 hasPrev={selectedIdx > 0}
-                hasNext={selectedIdx >= 0 && selectedIdx < rows.length - 1}
+                hasNext={selectedIdx >= 0 && selectedIdx < total - 1}
               />
             )}
           </div>
@@ -417,6 +523,31 @@ export function ManagerPanel() {
   );
 }
 
+function RowSkeleton() {
+  return (
+    <div
+      className={cn(
+        'grid h-16 animate-pulse items-center gap-2 border-b border-border px-3',
+        GRID_COLS,
+      )}
+    >
+      <div className="h-4 rounded bg-muted/70" />
+      <div className="h-3 rounded bg-muted/50" />
+      <div className="h-3 rounded bg-muted/40" />
+      <div className="ml-auto h-3 w-10 rounded bg-muted/40" />
+      <div className="h-3 rounded bg-muted/40" />
+      <div className="flex gap-1">
+        <span className="h-5 w-12 rounded-full bg-muted/50" />
+        <span className="h-5 w-10 rounded-full bg-muted/40" />
+      </div>
+      <div className="mx-auto h-4 w-4 rounded-full bg-muted/40" />
+      <div className="mx-auto h-3 w-3 rounded bg-muted/40" />
+    </div>
+  );
+}
+
+type DetailTagPatch = Partial<Tag> | null;
+
 function emptyFilter() {
   return {
     query: '',
@@ -426,6 +557,7 @@ function emptyFilter() {
     showTombstone: false,
     onlyFavorite: false,
     onlyUntagged: false,
+    onlyArchived: false,
     sortKey: 'starred_at' as const,
     sortDir: 'desc' as const,
   };

--- a/src/ui/components/ActiveFilterChips.tsx
+++ b/src/ui/components/ActiveFilterChips.tsx
@@ -21,6 +21,7 @@ export function ActiveFilterChips({
   }
   if (f.onlyFavorite) active.push({ label: m.activeFilters.onlyFavorite, clear: () => f.setOnlyFavorite(false), kind: 'special' });
   if (f.onlyUntagged) active.push({ label: m.activeFilters.onlyUntagged, clear: () => f.setOnlyUntagged(false), kind: 'special' });
+  if (f.onlyArchived) active.push({ label: m.activeFilters.onlyArchived, clear: () => f.setOnlyArchived(false), kind: 'special' });
   // "Show unstarred" (tombstone) chip — disabled for now.
   // if (f.showTombstone) active.push({ label: m.filterSidebar.showTombstoneLabel, clear: () => f.setShowTombstone(false), kind: 'special' });
 

--- a/src/ui/components/FilterSidebar.tsx
+++ b/src/ui/components/FilterSidebar.tsx
@@ -46,6 +46,12 @@ export function FilterSidebar({
           label={m.filterSidebar.onlyUntaggedLabel}
           hint={m.filterSidebar.onlyUntaggedHint}
         />
+        <FilterToggle
+          checked={f.onlyArchived}
+          onChange={() => f.setOnlyArchived(!f.onlyArchived)}
+          label={m.filterSidebar.onlyArchivedLabel}
+          hint={m.filterSidebar.onlyArchivedHint}
+        />
         {/* "Show unstarred" (tombstone) — disabled for now; keep commented to re-enable later.
         <FilterToggle
           checked={f.showTombstone}

--- a/src/ui/components/RepoDetailPanel.tsx
+++ b/src/ui/components/RepoDetailPanel.tsx
@@ -20,6 +20,8 @@ import { useImeBufferedInput } from '@/ui/hooks/use-ime-input';
 import { cn } from '@/lib/utils';
 import { useI18n } from '@/i18n';
 
+type DetailTagPatch = Partial<Tag> | null;
+
 /** single-repo detail drawer (tag/note/suggest deep-edit lives here so rows stay compact); flex aside, no portal. */
 export function RepoDetailPanel({
   star,
@@ -27,6 +29,7 @@ export function RepoDetailPanel({
   selectedTags,
   onToggleTag,
   onDataChanged,
+  onLocalTagPatched,
   onClose,
   onPrev,
   onNext,
@@ -38,6 +41,7 @@ export function RepoDetailPanel({
   selectedTags: string[];
   onToggleTag: (tag: string) => void;
   onDataChanged?: () => void;
+  onLocalTagPatched?: (patch: DetailTagPatch) => void;
   onClose: () => void;
   onPrev: () => void;
   onNext: () => void;
@@ -136,6 +140,7 @@ export function RepoDetailPanel({
     let ok = false;
     setTagsSavePhase('busy');
     try {
+      onLocalTagPatched?.({ tags: nextTags, mtime: new Date().toISOString() });
       await bgCall('setTags', { full_name: star.full_name, tags: nextTags });
       onDataChanged?.();
       ok = true;
@@ -152,6 +157,7 @@ export function RepoDetailPanel({
     let ok = false;
     setNotesSavePhase('busy');
     try {
+      onLocalTagPatched?.({ notes: nextNotes, mtime: new Date().toISOString() });
       await bgCall('setNotes', { full_name: star.full_name, notes: nextNotes });
       onDataChanged?.();
       ok = true;

--- a/src/ui/favorite-state.ts
+++ b/src/ui/favorite-state.ts
@@ -19,18 +19,18 @@ export function resolveFavoriteState(
 export function pruneFavoriteOverrides<T extends { full_name: string }>(
   overrides: Record<string, FavoriteOverrideState>,
   tagsByFullName: Map<string, Tag>,
-  rows: T[],
+  rows?: T[],
 ): Record<string, FavoriteOverrideState> {
   const names = Object.keys(overrides);
   if (names.length === 0) return overrides;
 
-  const rowSet = new Set(rows.map((row) => row.full_name));
+  const rowSet = rows ? new Set(rows.map((row) => row.full_name)) : null;
   let next: Record<string, FavoriteOverrideState> | null = null;
 
   for (const name of names) {
     const state = overrides[name];
     const persisted = !!tagsByFullName.get(name)?.favorite;
-    const shouldDrop = !state.pending && (persisted === state.value || !rowSet.has(name));
+    const shouldDrop = !state.pending && (persisted === state.value || (rowSet ? !rowSet.has(name) : false));
     if (!shouldDrop) continue;
     if (!next) next = { ...overrides };
     delete next[name];

--- a/src/ui/filter-store.ts
+++ b/src/ui/filter-store.ts
@@ -11,6 +11,7 @@ export interface FilterState {
   showTombstone: boolean;
   onlyFavorite: boolean;
   onlyUntagged: boolean;
+  onlyArchived: boolean;
   sortKey: SortKey;
   sortDir: SortDir;
   setQuery: (q: string) => void;
@@ -20,6 +21,7 @@ export interface FilterState {
   setShowTombstone: (v: boolean) => void;
   setOnlyFavorite: (v: boolean) => void;
   setOnlyUntagged: (v: boolean) => void;
+  setOnlyArchived: (v: boolean) => void;
   setSort: (k: SortKey, d?: SortDir) => void;
   resetFilters: () => void;
 }
@@ -32,6 +34,7 @@ export const useFilterStore = create<FilterState>((set) => ({
   showTombstone: false,
   onlyFavorite: false,
   onlyUntagged: false,
+  onlyArchived: false,
   sortKey: 'starred_at',
   sortDir: 'desc',
   setQuery: (query) => set({ query }),
@@ -49,7 +52,8 @@ export const useFilterStore = create<FilterState>((set) => ({
   setShowTombstone: (showTombstone) => set({ showTombstone }),
   setOnlyFavorite: (onlyFavorite) => set({ onlyFavorite }),
   setOnlyUntagged: (onlyUntagged) => set({ onlyUntagged }),
+  setOnlyArchived: (onlyArchived) => set({ onlyArchived }),
   setSort: (sortKey, sortDir) => set((s) => ({ sortKey, sortDir: sortDir ?? s.sortDir })),
   resetFilters: () =>
-    set({ query: '', languages: [], tags: [], showTombstone: false, onlyFavorite: false, onlyUntagged: false }),
+    set({ query: '', languages: [], tags: [], showTombstone: false, onlyFavorite: false, onlyUntagged: false, onlyArchived: false }),
 }));

--- a/src/ui/use-stars.ts
+++ b/src/ui/use-stars.ts
@@ -1,30 +1,32 @@
-import { useEffect, useState } from 'react';
-import { useFilterStore } from './filter-store';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { QueryMetaResult, QueryPageResult, StarFilter } from '@/background/query';
 import type { Star, Tag } from '@/types';
-import type { QueryResult } from '@/background/query';
+import { useFilterStore } from './filter-store';
 import { classifyStarsQueryTrigger } from './stars-refresh';
 
-// Transition timings for the list fade-out → swap → fade-in (see FADE_PHASE).
 const FADE_OUT_MS = 120;
 const FADE_IN_MS = 160;
+const PAGE_SIZE = 120;
+const PREFETCH_PADDING = 30;
 
-/**
- * Queries stars from the background service worker. On a filter change, fades
- * old rows out, fetches, then fades new rows in — avoiding a swap jolt and
- * keeping the list mounted so scroll position is preserved.
- */
-export function useStars() {
-  const f = useFilterStore();
-  const [committed, setCommitted] = useState<QueryResult | null>(null);
-  // Transition phase drives the list opacity. 'fading-out' keeps the committed
-  // (old) rows visible while dimming; 'fading-in' shows the freshly committed
-  // rows brightening back up. 'idle' = fully visible.
-  const [phase, setPhase] = useState<'idle' | 'fading-out' | 'fading-in'>('idle');
-  const [loading, setLoading] = useState(true);
-  const [refreshKey, setRefreshKey] = useState(0);
-  const [lastQueriedFilterKey, setLastQueriedFilterKey] = useState<string | null>(null);
+type FadePhase = 'idle' | 'fading-out' | 'fading-in';
 
-  const filter = {
+interface PageCache {
+  rowsByIndex: Map<number, Star>;
+  tagsByFullName: Map<string, Tag>;
+  loadedPages: Set<number>;
+}
+
+function createEmptyPageCache(): PageCache {
+  return {
+    rowsByIndex: new Map<number, Star>(),
+    tagsByFullName: new Map<string, Tag>(),
+    loadedPages: new Set<number>(),
+  };
+}
+
+function buildFilter(f: ReturnType<typeof useFilterStore.getState>): StarFilter {
+  return {
     query: f.query,
     languages: f.languages,
     tags: f.tags,
@@ -32,21 +34,88 @@ export function useStars() {
     showTombstone: f.showTombstone,
     onlyFavorite: f.onlyFavorite,
     onlyUntagged: f.onlyUntagged,
+    onlyArchived: f.onlyArchived,
     sortKey: f.sortKey,
     sortDir: f.sortDir,
   };
+}
+
+function nextCacheWithPage(current: PageCache, page: QueryPageResult): PageCache {
+  const nextRowsByIndex = new Map(current.rowsByIndex);
+  const nextTagsByFullName = new Map(current.tagsByFullName);
+  const nextLoadedPages = new Set(current.loadedPages);
+
+  for (let index = page.offset; index < page.offset + page.limit; index++) {
+    const stale = nextRowsByIndex.get(index);
+    if (stale) nextTagsByFullName.delete(stale.full_name);
+    nextRowsByIndex.delete(index);
+  }
+
+  page.rows.forEach((row, index) => {
+    nextRowsByIndex.set(page.offset + index, row);
+    const tag = page.tagsForRows[row.full_name];
+    if (tag) nextTagsByFullName.set(row.full_name, tag);
+    else nextTagsByFullName.delete(row.full_name);
+  });
+  nextLoadedPages.add(Math.floor(page.offset / Math.max(1, page.limit || PAGE_SIZE)));
+
+  return {
+    rowsByIndex: nextRowsByIndex,
+    tagsByFullName: nextTagsByFullName,
+    loadedPages: nextLoadedPages,
+  };
+}
+
+export function useStars() {
+  const f = useFilterStore();
+  const filter = buildFilter(f);
   const filterKey = JSON.stringify(filter);
 
-  // A pending refresh (from refresh() or a dataChanged broadcast) bypasses the
-  // fade-out — it's a same-filter reload, so there's nothing to transition
-  // away from; we just refetch and fade the new rows in.
+  const [meta, setMeta] = useState<QueryMetaResult | null>(null);
+  const [pageCache, setPageCache] = useState<PageCache>(() => createEmptyPageCache());
+  const [phase, setPhase] = useState<FadePhase>('idle');
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [lastQueriedFilterKey, setLastQueriedFilterKey] = useState<string | null>(null);
+
+  const inFlightPagesRef = useRef(new Set<number>());
+  const activeFilterKeyRef = useRef(filterKey);
+  const pageCacheRef = useRef(pageCache);
+
+  useEffect(() => {
+    pageCacheRef.current = pageCache;
+  }, [pageCache]);
+
   const refresh = () => {
     setRefreshKey((key) => key + 1);
   };
 
-  // Filter changes still use the fade-out → query → fade-in transition.
-  // Same-filter reloads (dataChanged broadcasts or explicit refresh()) update
-  // the committed rows in place so the list does not flash.
+  const fetchPage = useCallback(async (
+    targetFilter: StarFilter,
+    targetFilterKey: string,
+    pageIndex: number,
+    options?: { force?: boolean },
+  ) => {
+    if (pageIndex < 0) return;
+    if (inFlightPagesRef.current.has(pageIndex)) return;
+    if (!options?.force && pageCacheRef.current.loadedPages.has(pageIndex)) return;
+    inFlightPagesRef.current.add(pageIndex);
+    if (pageIndex > 0) setLoadingMore(true);
+    try {
+      const page = await chrome.runtime.sendMessage({
+        type: 'queryPage',
+        params: { filter: targetFilter, offset: pageIndex * PAGE_SIZE, limit: PAGE_SIZE },
+      }) as { ok: boolean; data?: QueryPageResult };
+      if (!page?.ok || !page.data) return;
+      if (activeFilterKeyRef.current !== targetFilterKey) return;
+      setPageCache((current) => nextCacheWithPage(current, page.data!));
+    } finally {
+      inFlightPagesRef.current.delete(pageIndex);
+      setLoadingMore(inFlightPagesRef.current.size > 0);
+    }
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     let fadeOut: ReturnType<typeof setTimeout> | null = null;
@@ -54,41 +123,62 @@ export function useStars() {
     const trigger = classifyStarsQueryTrigger(lastQueriedFilterKey, filterKey);
     const shouldFade = trigger === 'filter-change';
     setLastQueriedFilterKey(filterKey);
-
+    activeFilterKeyRef.current = filterKey;
+    inFlightPagesRef.current.clear();
     setLoading(true);
+    setLoadingMore(false);
     if (shouldFade) setPhase('fading-out');
 
-    const runQuery = () => {
+    const runQuery = async () => {
       if (cancelled) return;
-      chrome.runtime
-        .sendMessage({ type: 'query', params: { filter, offset: 0, limit: Number.MAX_SAFE_INTEGER } })
-        .then((res: { ok: boolean; data?: QueryResult; error?: string }) => {
-          if (cancelled) return;
-          if (res?.ok && res.data) {
-            setCommitted(res.data);
-            if (shouldFade) {
-              setPhase('fading-in');
-              fadeIn = setTimeout(() => {
-                if (!cancelled) setPhase('idle');
-              }, FADE_IN_MS);
-            } else {
-              setPhase('idle');
-            }
-          }
-          setLoading(false);
-        })
-        .catch(() => {
+      try {
+        const res = await chrome.runtime.sendMessage({ type: 'queryMeta', filter }) as {
+          ok: boolean;
+          data?: QueryMetaResult;
+          error?: string;
+        };
+        if (cancelled || !res?.ok || !res.data) {
           if (!cancelled) {
             setLoading(false);
             if (!shouldFade) setPhase('idle');
           }
-        });
+          return;
+        }
+        if (cancelled || activeFilterKeyRef.current !== filterKey) return;
+
+        setMeta(res.data);
+        const reuseLoadedPages = !shouldFade && trigger === 'data-change' && pageCacheRef.current.loadedPages.size > 0;
+
+        if (res.data.total === 0) {
+          setPageCache(createEmptyPageCache());
+        } else if (reuseLoadedPages) {
+          const pages = [...pageCacheRef.current.loadedPages].sort((a, b) => a - b);
+          await Promise.all(pages.map((pageIndex) => fetchPage(filter, filterKey, pageIndex, { force: true })));
+        } else {
+          setPageCache(createEmptyPageCache());
+          await fetchPage(filter, filterKey, 0, { force: true });
+        }
+
+        if (cancelled || activeFilterKeyRef.current !== filterKey) return;
+        if (shouldFade) {
+          setPhase('fading-in');
+          fadeIn = setTimeout(() => {
+            if (!cancelled) setPhase('idle');
+          }, FADE_IN_MS);
+        } else {
+          setPhase('idle');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
     };
 
     if (shouldFade) {
-      fadeOut = setTimeout(runQuery, FADE_OUT_MS);
+      fadeOut = setTimeout(() => {
+        void runQuery();
+      }, FADE_OUT_MS);
     } else {
-      runQuery();
+      void runQuery();
     }
 
     return () => {
@@ -99,7 +189,6 @@ export function useStars() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filterKey, refreshKey]);
 
-  // Live refresh when background signals data changed (sync/write).
   useEffect(() => {
     const listener = (msg: { type?: string }) => {
       if (msg.type === 'dataChanged') {
@@ -110,23 +199,95 @@ export function useStars() {
     return () => chrome.runtime.onMessage.removeListener(listener);
   }, []);
 
-  const rows: Star[] = committed?.rows ?? [];
-  const tagsByFullName = new Map<string, Tag>();
-  if (committed?.tagsForRows) {
-    for (const [name, tag] of Object.entries(committed.tagsForRows)) {
-      if (tag) tagsByFullName.set(name, tag);
+  const rows = useMemo(() => {
+    const loaded = [...pageCache.rowsByIndex.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map((entry) => entry[1]);
+    return loaded;
+  }, [pageCache]);
+
+  const loadedIndexByFullName = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const [index, row] of pageCache.rowsByIndex.entries()) {
+      map.set(row.full_name, index);
     }
-  }
+    return map;
+  }, [pageCache.rowsByIndex]);
+
+  const ensureRange = useCallback((start: number, end: number) => {
+    const totalCount = meta?.total ?? 0;
+    if (totalCount === 0) return;
+    const safeStart = Math.max(0, start);
+    const safeEnd = Math.min(totalCount - 1, Math.max(safeStart, end));
+    const startPage = Math.floor(safeStart / PAGE_SIZE);
+    const endPage = Math.floor(safeEnd / PAGE_SIZE);
+    for (let pageIndex = startPage; pageIndex <= endPage; pageIndex++) {
+      if (pageCache.loadedPages.has(pageIndex) || inFlightPagesRef.current.has(pageIndex)) continue;
+      void fetchPage(filter, filterKey, pageIndex);
+    }
+  }, [fetchPage, filter, filterKey, meta?.total, pageCache.loadedPages]);
+
+  const ensureIndex = useCallback((index: number) => {
+    if (index < 0 || index >= (meta?.total ?? 0)) return;
+    ensureRange(index, index);
+  }, [ensureRange, meta?.total]);
+
+  const getRow = useCallback((index: number): Star | null => pageCache.rowsByIndex.get(index) ?? null, [pageCache.rowsByIndex]);
+
+  const getTagForRow = useCallback((fullName: string): Tag | undefined => pageCache.tagsByFullName.get(fullName), [pageCache.tagsByFullName]);
+
+  const updateCachedRowTag = useCallback((fullName: string, patch: Partial<Tag> | null) => {
+    setPageCache((current) => {
+      const nextTagsByFullName = new Map(current.tagsByFullName);
+      const existing = nextTagsByFullName.get(fullName);
+      if (patch === null) {
+        nextTagsByFullName.delete(fullName);
+      } else if (existing) {
+        nextTagsByFullName.set(fullName, { ...existing, ...patch });
+      } else {
+        nextTagsByFullName.set(fullName, {
+          full_name: fullName,
+          tags: patch.tags ?? [],
+          notes: patch.notes ?? '',
+          favorite: patch.favorite,
+          mtime: patch.mtime ?? new Date().toISOString(),
+        });
+      }
+      return { ...current, tagsByFullName: nextTagsByFullName };
+    });
+  }, []);
+
+  useEffect(() => {
+    const total = meta?.total ?? 0;
+    if (total === 0) return;
+    const maxLoadedIndex = Math.max(-1, ...pageCache.rowsByIndex.keys());
+    if (maxLoadedIndex < 0) {
+      ensureRange(0, Math.min(PAGE_SIZE - 1, total - 1));
+      return;
+    }
+    if (total - 1 - maxLoadedIndex <= PREFETCH_PADDING) {
+      ensureRange(maxLoadedIndex + 1, Math.min(maxLoadedIndex + PAGE_SIZE, total - 1));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [meta?.total, pageCache.loadedPages.size]);
 
   return {
     rows,
-    total: committed?.total ?? 0,
-    grandTotal: committed?.grandTotal ?? 0,
+    total: meta?.total ?? 0,
+    grandTotal: meta?.grandTotal ?? 0,
     loading,
+    loadingMore,
     phase,
-    languages: committed?.languages ?? [],
-    tagTree: { tags: committed?.tagTree ?? [], total: committed?.tagTotal ?? 0 },
-    tagsByFullName,
+    languages: meta?.languages ?? [],
+    tagTree: { tags: meta?.tagTree ?? [], total: meta?.tagTotal ?? 0 },
+    tagsByFullName: pageCache.tagsByFullName,
     refresh,
+    getRow,
+    getTagForRow,
+    ensureRange,
+    ensureIndex,
+    updateCachedRowTag,
+    pageSize: PAGE_SIZE,
+    loadedIndexByFullName,
   };
 }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -4,7 +4,7 @@
 // Run: pnpm exec tsx tests/integration.test.ts
 import 'fake-indexeddb/auto';
 import { db } from '../src/storage/db';
-import { queryStars, invalidateCache } from '../src/background/query';
+import { queryMeta, queryPage, queryStars, invalidateCache } from '../src/background/query';
 import type { Star, Tag, TagMeta } from '../src/types';
 
 const pass: string[] = [];
@@ -25,7 +25,7 @@ const base = {
 
 await db.stars.bulkPut([
   { ...base, full_name: 'a/ai', description: 'AI tool', language: 'Python', topics: ['ai'], starred_at: '2026-06-20', stargazers_count: 100, pushed_at: '2026-06-19' },
-  { ...base, full_name: 'b/rust', description: 'Rust lib', language: 'Rust', topics: [], starred_at: '2026-06-21', stargazers_count: 50, pushed_at: '2026-06-22' },
+  { ...base, full_name: 'b/rust', description: 'Rust lib', language: 'Rust', topics: [], starred_at: '2026-06-21', stargazers_count: 50, pushed_at: '2026-06-22', archived: true },
   { ...base, full_name: 'c/gone', description: 'unstarred', language: 'Python', topics: [], starred_at: '2026-01-01', stargazers_count: 5, pushed_at: '2025-01-01', tombstone: true },
 ] as Star[]);
 await db.tags.bulkPut([
@@ -43,6 +43,14 @@ await new Promise<void>((resolve) => {
     const r = await queryStars({ filter: defaultFilter(), offset: 0, limit: 100 });
     assert(r.grandTotal === 3, `grandTotal ${r.grandTotal}`);
     assert(r.total === 2, `total (excl tombstone) ${r.total}`); // tombstone hidden
+  });
+
+  test('queryMeta returns totals and stable facets without row payload', async () => {
+    const r = await queryMeta(defaultFilter());
+    assert(r.grandTotal === 3, `grandTotal ${r.grandTotal}`);
+    assert(r.total === 2, `filtered total ${r.total}`);
+    assert(Array.isArray(r.languages), 'languages facet missing');
+    assert(Array.isArray(r.tagTree), 'tag tree missing');
   });
 
   test('language facet computed over all stars', async () => {
@@ -83,6 +91,12 @@ await new Promise<void>((resolve) => {
     assert(r.tagsForRows['b/rust']?.favorite === true, 'favorite carried through');
   });
 
+  test('onlyArchived keeps archived repos only', async () => {
+    const r = await queryStars({ filter: { ...defaultFilter(), onlyArchived: true }, offset: 0, limit: 100 });
+    eq(r.rows.map((s) => s.full_name), ['b/rust'], 'archived only');
+    assert(r.rows[0]?.archived === true, 'archived flag carried through');
+  });
+
   test('sort by stargazers desc', async () => {
     const r = await queryStars({ filter: { ...defaultFilter(), sortKey: 'stargazers_count', sortDir: 'desc' }, offset: 0, limit: 100 });
     eq(r.rows.map((s) => s.stargazers_count), [100, 50], 'desc stars');
@@ -92,6 +106,14 @@ await new Promise<void>((resolve) => {
     const r = await queryStars({ filter: { ...defaultFilter(), sortKey: 'stargazers_count', sortDir: 'asc' }, offset: 0, limit: 1 });
     eq(r.rows.map((s) => s.full_name), ['b/rust'], 'first window');
     eq(r.total, 2, 'total still full');
+  });
+
+  test('queryPage returns only the requested slice with matching offset/limit', async () => {
+    const r = await queryPage({ filter: { ...defaultFilter(), sortKey: 'stargazers_count', sortDir: 'desc' }, offset: 1, limit: 1 });
+    eq(r.offset, 1, 'offset preserved');
+    eq(r.limit, 1, 'limit preserved');
+    eq(r.rows.map((s) => s.full_name), ['b/rust'], 'paged rows');
+    assert(!!r.tagsForRows['b/rust'], 'page tags returned');
   });
 
   test('showTombstone includes unstarred', async () => {
@@ -120,5 +142,5 @@ console.log(fail.length ? `\n❌ ${fail.length} FAILED` : '\n✅ All integration
 process.exit(fail.length ? 1 : 0);
 
 function defaultFilter() {
-  return { query: '', languages: [], tags: [], tagMode: 'any' as const, showTombstone: false, onlyFavorite: false, onlyUntagged: false, sortKey: 'starred_at' as const, sortDir: 'desc' as const };
+  return { query: '', languages: [], tags: [], tagMode: 'any' as const, showTombstone: false, onlyFavorite: false, onlyUntagged: false, onlyArchived: false, sortKey: 'starred_at' as const, sortDir: 'desc' as const };
 }

--- a/tests/logic.test.ts
+++ b/tests/logic.test.ts
@@ -81,14 +81,15 @@ test('remote-only repo → added to local', () => {
 });
 
 // --- Filter logic (mirrors query.ts filter) ---
-interface S { full_name: string; description: string; language: string | null; topics: string[]; notes?: string; tombstone: boolean; starred_at: string; pushed_at: string; stargazers_count: number; }
+interface S { full_name: string; description: string; language: string | null; topics: string[]; notes?: string; archived: boolean; tombstone: boolean; starred_at: string; pushed_at: string; stargazers_count: number; }
 
-function filterStars(stars: S[], opts: { query?: string; languages?: string[]; tags?: string[]; showTombstone?: boolean; onlyFavorite?: boolean; onlyUntagged?: boolean; tagsByRepo?: Map<string, string[]>; favoritesByRepo?: Map<string, boolean> }): S[] {
+function filterStars(stars: S[], opts: { query?: string; languages?: string[]; tags?: string[]; showTombstone?: boolean; onlyFavorite?: boolean; onlyUntagged?: boolean; onlyArchived?: boolean; tagsByRepo?: Map<string, string[]>; favoritesByRepo?: Map<string, boolean> }): S[] {
   const q = (opts.query ?? '').toLowerCase();
   const langSet = opts.languages?.length ? new Set(opts.languages) : null;
   const tagSet = opts.tags?.length ? new Set(opts.tags) : null;
   return stars.filter((s) => {
     if (!opts.showTombstone && s.tombstone) return false;
+    if (opts.onlyArchived && !s.archived) return false;
     if (langSet && (s.language === null || !langSet.has(s.language))) return false;
     const myTags = opts.tagsByRepo?.get(s.full_name) ?? [];
     if (opts.onlyFavorite && !opts.favoritesByRepo?.get(s.full_name)) return false;
@@ -104,9 +105,9 @@ function filterStars(stars: S[], opts: { query?: string; languages?: string[]; t
 
 console.log('\nFilter logic (query engine):');
 const sample: S[] = [
-  { full_name: 'a/ai-tool', description: 'AI helper', language: 'Python', topics: ['ai', 'agent'], notes: '', tombstone: false, starred_at: '2026-06-20', pushed_at: '2026-06-19', stargazers_count: 100 },
-  { full_name: 'b/rust-lib', description: 'A rust lib', language: 'Rust', topics: [], notes: 'review later', tombstone: false, starred_at: '2026-06-21', pushed_at: '2026-06-22', stargazers_count: 50 },
-  { full_name: 'c/old', description: 'archived thing', language: 'Python', topics: [], notes: '', tombstone: true, starred_at: '2026-01-01', pushed_at: '2025-01-01', stargazers_count: 5 },
+  { full_name: 'a/ai-tool', description: 'AI helper', language: 'Python', topics: ['ai', 'agent'], notes: '', archived: false, tombstone: false, starred_at: '2026-06-20', pushed_at: '2026-06-19', stargazers_count: 100 },
+  { full_name: 'b/rust-lib', description: 'A rust lib', language: 'Rust', topics: [], notes: 'review later', archived: true, tombstone: false, starred_at: '2026-06-21', pushed_at: '2026-06-22', stargazers_count: 50 },
+  { full_name: 'c/old', description: 'archived thing', language: 'Python', topics: [], notes: '', archived: false, tombstone: true, starred_at: '2026-01-01', pushed_at: '2025-01-01', stargazers_count: 5 },
 ];
 const tagsByRepo = new Map([['a/ai-tool', ['ai']], ['b/rust-lib', ['rust']]]);
 const favoritesByRepo = new Map([['b/rust-lib', true]]);
@@ -139,6 +140,11 @@ test('filter by tag', () => {
 });
 test('onlyFavorite keeps favorited repos only', () => {
   const r = filterStars(sample, { onlyFavorite: true, favoritesByRepo, tagsByRepo });
+  assert.equal(r.length, 1);
+  assert.equal(r[0].full_name, 'b/rust-lib');
+});
+test('onlyArchived keeps archived repos only', () => {
+  const r = filterStars(sample, { onlyArchived: true, favoritesByRepo, tagsByRepo });
   assert.equal(r.length, 1);
   assert.equal(r[0].full_name, 'b/rust-lib');
 });

--- a/tests/verify-e2e.ts
+++ b/tests/verify-e2e.ts
@@ -77,7 +77,7 @@ console.log(`   ✓ syncFull returned ${JSON.stringify(syncResult)} | DB now hol
 
 invalidateCache();
 const result = await queryStars({
-  filter: { query: '', languages: [], tags: [], tagMode: 'any', showTombstone: false, onlyFavorite: false, onlyUntagged: false, sortKey: 'starred_at', sortDir: 'desc' },
+  filter: { query: '', languages: [], tags: [], tagMode: 'any', showTombstone: false, onlyFavorite: false, onlyUntagged: false, onlyArchived: false, sortKey: 'starred_at', sortDir: 'desc' },
   offset: 0,
   limit: 5,
 });


### PR DESCRIPTION
## What changed
- switched the stars overlay from all-at-once row loading to a windowed query model backed by `queryMeta` plus `queryPage`
- kept the GitHub page experience continuous with virtual rows, row skeletons, near-tail prefetching, and stable selection while scrolling
- patched local tag and favorite edits into the loaded cache so the list and drawer stay in sync without a whole-list refresh
- added an archived-only filter to the sidebar, active chips, i18n catalog, and query engine

## Why
The old overlay fetched and rendered the full filtered result set every time, which does not scale well for large star libraries. This PR keeps the "one long library" UX, but moves the heavy lifting into background paging so search, filters, scrolling, and row edits stay smooth inside GitHub.

## User impact
- large star libraries should feel faster and less janky
- scrolling loads more rows automatically without visible pagination UI
- opening the drawer, editing notes/tags, and toggling favorites should no longer rely on full list refreshes to feel current
- archived repositories can now be isolated with a dedicated filter

## Validation
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- manual runtime evidence from a real extension environment previously confirmed overlay mount, full sync, background page queries, scrolling, and drawer open flow

## Known follow-up
- tag count drift was observed during one manual runtime verification path and should be watched during review, especially after scroll-triggered page loads
