### PR TITLE
修复：“清除筛选结果”按钮显示不符合预期

### DIFF
--- a/src/ui/ManagerPanel.tsx
+++ b/src/ui/ManagerPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+﻿import { useEffect, useMemo, useRef, useState } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { AlertTriangle, Heart, RefreshCw, Sparkles } from 'lucide-react';
 import { useStars } from '@/ui/use-stars';
@@ -284,9 +284,11 @@ export function ManagerPanel() {
           </div>
         )}
 
-        <div className={cn('filter-row-anim border-b border-border', !hasActiveFilter && 'collapsed')}>
-          <ActiveFilterChips f={f} count={total} />
-        </div>
+        {hasActiveFilter && (
+          <div className="border-b border-border">
+            <ActiveFilterChips f={f} count={total} />
+          </div>
+        )}
 
         {info && (
           <div className="border-b border-border bg-card px-3 py-1 text-[11px] text-muted-foreground">{info}</div>
@@ -571,7 +573,7 @@ function CoachOverlay({
   return (
     // Full-screen click shield: blocks pointer events from reaching the page beneath
     // (toolbar buttons can't be clicked OR hovered). Several highlights are destructive
-    // if clicked — step 1 would start a real sync, step 4 would unmount the panel and
+    // if clicked 鈥?step 1 would start a real sync, step 4 would unmount the panel and
     // kill the tour. The card below opts back into pointer-events-auto.
     <div className="pointer-events-auto absolute inset-0 z-50">
       {spot && (
@@ -611,3 +613,4 @@ function CoachOverlay({
     </div>
   );
 }
+

--- a/src/ui/ManagerPanel.tsx
+++ b/src/ui/ManagerPanel.tsx
@@ -573,7 +573,7 @@ function CoachOverlay({
   return (
     // Full-screen click shield: blocks pointer events from reaching the page beneath
     // (toolbar buttons can't be clicked OR hovered). Several highlights are destructive
-    // if clicked 鈥?step 1 would start a real sync, step 4 would unmount the panel and
+    // if clicked — step 1 would start a real sync, step 4 would unmount the panel and
     // kill the tour. The card below opts back into pointer-events-auto.
     <div className="pointer-events-auto absolute inset-0 z-50">
       {spot && (


### PR DESCRIPTION
Fixed #10

已将逻辑改为：如果没有任何筛选将不显示 `ActiveFilterChips` 组件