### PR TITLE
Add GitHub Watch notifications inbox

### DIFF
--- a/src/agent-observability/provider-monitor-runtime.ts
+++ b/src/agent-observability/provider-monitor-runtime.ts
@@ -128,6 +128,7 @@ async function scrubFailureDetails(
 ): Promise<AgentProviderConnectionFailureDetails> {
   const settledSecrets = await Promise.allSettled([
     authStore.getToken(),
+    authStore.getWatchNotificationsToken(),
     authStore.getAgentApiKey(),
   ]);
   const secrets = settledSecrets.flatMap((result) => (

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -25,6 +25,24 @@ export const TOKEN_GIST_PROBE_BAD_SHAPE = 'TOKEN_GIST_PROBE_BAD_SHAPE';
 /** Followed by the HTTP status, e.g. `TOKEN_GIST_CLEANUP_STATUS:500`. */
 export const TOKEN_GIST_CLEANUP_STATUS = 'TOKEN_GIST_CLEANUP_STATUS:';
 export const TOKEN_GIST_CLEANUP_NETWORK = 'TOKEN_GIST_CLEANUP_NETWORK';
+export const TOKEN_WATCHING_FORBIDDEN = 'TOKEN_WATCHING_FORBIDDEN';
+export const TOKEN_WATCHING_BAD_SHAPE = 'TOKEN_WATCHING_BAD_SHAPE';
+export const TOKEN_WATCHING_STATUS = 'TOKEN_WATCHING_STATUS:';
+export const TOKEN_WATCHING_NETWORK = 'TOKEN_WATCHING_NETWORK';
+
+// Optional classic token used only by the Watch Inbox.
+export const WATCH_TOKEN_EMPTY = 'WATCH_TOKEN_EMPTY';
+export const WATCH_TOKEN_MAIN_ACCOUNT_REQUIRED = 'WATCH_TOKEN_MAIN_ACCOUNT_REQUIRED';
+export const WATCH_TOKEN_REJECTED = 'WATCH_TOKEN_REJECTED';
+export const WATCH_TOKEN_ACCOUNT_MISMATCH = 'WATCH_TOKEN_ACCOUNT_MISMATCH';
+export const WATCH_TOKEN_ACCOUNT_CHANGED = 'WATCH_TOKEN_ACCOUNT_CHANGED';
+export const WATCH_TOKEN_PROFILE_STATUS = 'WATCH_TOKEN_PROFILE_STATUS:';
+export const WATCH_TOKEN_PROFILE_BAD_SHAPE = 'WATCH_TOKEN_PROFILE_BAD_SHAPE';
+export const WATCH_TOKEN_PROFILE_NETWORK = 'WATCH_TOKEN_PROFILE_NETWORK';
+export const WATCH_TOKEN_NOTIFICATIONS_FORBIDDEN = 'WATCH_TOKEN_NOTIFICATIONS_FORBIDDEN';
+export const WATCH_TOKEN_NOTIFICATIONS_STATUS = 'WATCH_TOKEN_NOTIFICATIONS_STATUS:';
+export const WATCH_TOKEN_NOTIFICATIONS_NETWORK = 'WATCH_TOKEN_NOTIFICATIONS_NETWORK';
+export const WATCH_TOKEN_NOTIFICATIONS_BAD_SHAPE = 'WATCH_TOKEN_NOTIFICATIONS_BAD_SHAPE';
 
 // Sync / stars-fetch codes (thrown by github-star-source.ts).
 export const GH_TOKEN_REJECTED = 'GH_TOKEN_REJECTED';
@@ -79,6 +97,22 @@ export function translateError(e: unknown, m: MessageCatalog): string {
   if (raw === TOKEN_GIST_PROBE_BAD_SHAPE) return m.errors.tokenGistProbeBadShape;
   if (raw.startsWith(TOKEN_GIST_CLEANUP_STATUS)) return m.errors.tokenGistCleanupStatus(raw.slice(TOKEN_GIST_CLEANUP_STATUS.length));
   if (raw === TOKEN_GIST_CLEANUP_NETWORK) return m.errors.tokenGistCleanupNetwork;
+  if (raw === WATCH_TOKEN_EMPTY) return m.errors.watchTokenEmpty;
+  if (raw === WATCH_TOKEN_MAIN_ACCOUNT_REQUIRED) return m.errors.watchTokenMainAccountRequired;
+  if (raw === WATCH_TOKEN_REJECTED) return m.errors.watchTokenRejected;
+  if (raw === WATCH_TOKEN_ACCOUNT_MISMATCH) return m.errors.watchTokenAccountMismatch;
+  if (raw === WATCH_TOKEN_ACCOUNT_CHANGED) return m.errors.watchTokenAccountChanged;
+  if (raw.startsWith(WATCH_TOKEN_PROFILE_STATUS)) {
+    return m.errors.watchTokenProfileStatus(raw.slice(WATCH_TOKEN_PROFILE_STATUS.length));
+  }
+  if (raw === WATCH_TOKEN_PROFILE_BAD_SHAPE) return m.errors.watchTokenProfileBadShape;
+  if (raw === WATCH_TOKEN_PROFILE_NETWORK) return m.errors.watchTokenProfileNetwork;
+  if (raw === WATCH_TOKEN_NOTIFICATIONS_FORBIDDEN) return m.errors.watchTokenNotificationsForbidden;
+  if (raw.startsWith(WATCH_TOKEN_NOTIFICATIONS_STATUS)) {
+    return m.errors.watchTokenNotificationsStatus(raw.slice(WATCH_TOKEN_NOTIFICATIONS_STATUS.length));
+  }
+  if (raw === WATCH_TOKEN_NOTIFICATIONS_NETWORK) return m.errors.watchTokenNotificationsNetwork;
+  if (raw === WATCH_TOKEN_NOTIFICATIONS_BAD_SHAPE) return m.errors.watchTokenNotificationsBadShape;
 
   // Sync / stars-fetch codes.
   if (raw === GH_TOKEN_REJECTED) return m.errors.ghTokenRejected;

--- a/src/api/github-notifications-source.ts
+++ b/src/api/github-notifications-source.ts
@@ -1,0 +1,273 @@
+import {
+  GitHubWatchError,
+  dedupeNotificationThreads,
+  normalizeNotificationThread,
+  type GitHubNotificationThread,
+  type WatchNotificationSnapshot,
+} from '@/watch/watch-model';
+
+const API_ORIGIN = 'https://api.github.com';
+const NOTIFICATIONS_PATH = '/notifications';
+const PER_PAGE = 50;
+const DEFAULT_MAX_PAGES = 10;
+export const WATCH_DEFAULT_POLL_INTERVAL_SECONDS = 60;
+export const WATCH_MAX_POLL_INTERVAL_SECONDS = 24 * 60 * 60;
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+type FetchLike = typeof fetch;
+
+export interface FetchGitHubNotificationsOptions {
+  token: string;
+  before?: Date | string | number;
+  lastModified?: string | null;
+  fetchImpl?: FetchLike;
+  now?: () => Date | string | number;
+  maxPages?: number;
+  timeoutMs?: number;
+}
+
+function isoTimestamp(value: Date | string | number): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(date.getTime())) throw new GitHubWatchError('invalid_response');
+  return date.toISOString();
+}
+
+function responseError(response: Response, page: number): GitHubWatchError {
+  if (response.status === 401) {
+    return new GitHubWatchError('authentication_required', undefined, { status: response.status, page });
+  }
+  if (response.status === 403 || response.status === 429) {
+    const code = response.status === 429 ||
+      response.headers.get('x-ratelimit-remaining') === '0' ||
+      response.headers.has('retry-after')
+      ? 'rate_limited'
+      : 'permission_denied';
+    return new GitHubWatchError(code, undefined, { status: response.status, page });
+  }
+  if (response.status >= 500) {
+    return new GitHubWatchError('github_unavailable', undefined, { status: response.status, page });
+  }
+  return new GitHubWatchError('invalid_response', undefined, { status: response.status, page });
+}
+
+function pollIntervalSeconds(value: string | null): number {
+  if (!value || !/^\d+$/u.test(value.trim())) return WATCH_DEFAULT_POLL_INTERVAL_SECONDS;
+  const seconds = Number(value);
+  return Number.isSafeInteger(seconds) && seconds > 0 && seconds <= WATCH_MAX_POLL_INTERVAL_SECONDS
+    ? seconds
+    : WATCH_DEFAULT_POLL_INTERVAL_SECONDS;
+}
+
+function lastModifiedValidator(value: string | null | undefined): string | null {
+  const validator = value?.trim();
+  return validator && Number.isFinite(Date.parse(validator)) ? validator : null;
+}
+
+function nextPage(linkHeader: string | null, currentPage: number): number | null {
+  if (!linkHeader) return null;
+  const parts = linkHeader.split(',');
+  const nextParts = parts.filter((part) => /\brel="[^"]*\bnext\b[^"]*"/u.test(part));
+  if (nextParts.length === 0) {
+    if (/\brel\s*=\s*"?next\b/iu.test(linkHeader)) {
+      throw new GitHubWatchError('invalid_pagination', undefined, { page: currentPage });
+    }
+    return null;
+  }
+  if (nextParts.length !== 1) {
+    throw new GitHubWatchError('invalid_pagination', undefined, { page: currentPage });
+  }
+  const nextPart = nextParts[0]!;
+  const match = nextPart.match(/^\s*<([^>]+)>\s*;/u);
+  if (!match) throw new GitHubWatchError('invalid_pagination', undefined, { page: currentPage });
+  let url: URL;
+  try {
+    url = new URL(match[1]!);
+  } catch {
+    throw new GitHubWatchError('invalid_pagination', undefined, { page: currentPage });
+  }
+  const page = Number(url.searchParams.get('page'));
+  if (
+    url.origin !== API_ORIGIN ||
+    url.pathname !== NOTIFICATIONS_PATH ||
+    !Number.isSafeInteger(page) ||
+    page !== currentPage + 1 ||
+    url.searchParams.getAll('page').length !== 1 ||
+    url.searchParams.get('per_page') !== String(PER_PAGE) ||
+    url.searchParams.getAll('per_page').length !== 1
+  ) {
+    throw new GitHubWatchError('invalid_pagination', undefined, { page: currentPage });
+  }
+  return page;
+}
+
+async function requestPage(input: {
+  token: string;
+  before: string;
+  page: number;
+  lastModified: string | null;
+  fetchedAt: string;
+  fetchImpl: FetchLike;
+  timeoutMs: number;
+}): Promise<{
+  response: Response;
+  threads: GitHubNotificationThread[];
+  nextPage: number | null;
+}> {
+  const url = new URL(NOTIFICATIONS_PATH, API_ORIGIN);
+  url.searchParams.set('all', 'true');
+  url.searchParams.set('participating', 'false');
+  url.searchParams.set('per_page', String(PER_PAGE));
+  url.searchParams.set('before', input.before);
+  url.searchParams.set('page', String(input.page));
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${input.token}`,
+    Accept: 'application/vnd.github+json',
+  };
+  if (input.page === 1 && input.lastModified) {
+    headers['If-Modified-Since'] = input.lastModified;
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), input.timeoutMs);
+  try {
+    const response = await input.fetchImpl(url.toString(), {
+      headers,
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+    if (input.page === 1 && response.status === 304 && input.lastModified) {
+      return { response, threads: [], nextPage: null };
+    }
+    if (!response.ok) throw responseError(response, input.page);
+    const contentType = response.headers.get('content-type');
+    if (contentType && !contentType.toLowerCase().includes('json')) {
+      throw new GitHubWatchError('invalid_content_type', undefined, {
+        status: response.status,
+        page: input.page,
+      });
+    }
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new GitHubWatchError('deadline_exceeded', undefined, { page: input.page });
+      }
+      throw new GitHubWatchError('invalid_response', undefined, {
+        status: response.status,
+        page: input.page,
+      });
+    }
+    if (!Array.isArray(payload)) {
+      throw new GitHubWatchError('invalid_response', undefined, {
+        status: response.status,
+        page: input.page,
+      });
+    }
+    let threads: GitHubNotificationThread[];
+    try {
+      threads = payload.map((row) => normalizeNotificationThread(row, { fetchedAt: input.fetchedAt }));
+    } catch (error) {
+      if (error instanceof GitHubWatchError) {
+        throw new GitHubWatchError(error.code, undefined, { status: response.status, page: input.page });
+      }
+      throw new GitHubWatchError('invalid_response', undefined, {
+        status: response.status,
+        page: input.page,
+      });
+    }
+    const pageAfter = nextPage(response.headers.get('link'), input.page);
+    if (threads.length === 0 && pageAfter !== null) {
+      throw new GitHubWatchError('invalid_pagination', undefined, { page: input.page });
+    }
+    return { response, threads, nextPage: pageAfter };
+  } catch (error) {
+    if (error instanceof GitHubWatchError) throw error;
+    if (controller.signal.aborted) {
+      throw new GitHubWatchError('deadline_exceeded', undefined, { page: input.page });
+    }
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new GitHubWatchError('request_aborted', undefined, { page: input.page });
+    }
+    throw new GitHubWatchError('network_error', undefined, { page: input.page });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function fetchGitHubNotifications(
+  options: FetchGitHubNotificationsOptions,
+): Promise<WatchNotificationSnapshot> {
+  const token = options.token.trim();
+  if (!token) throw new GitHubWatchError('authentication_required');
+  const nowValue = options.now?.() ?? new Date();
+  const fetchedAt = isoTimestamp(nowValue);
+  const before = isoTimestamp(options.before ?? nowValue);
+  const maxPages = Number.isFinite(options.maxPages)
+    ? Math.max(1, Math.floor(options.maxPages!))
+    : DEFAULT_MAX_PAGES;
+  const timeoutMs = Number.isFinite(options.timeoutMs)
+    ? Math.max(1, Math.floor(options.timeoutMs!))
+    : DEFAULT_TIMEOUT_MS;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const conditionalLastModified = lastModifiedValidator(options.lastModified);
+  const allThreads: GitHubNotificationThread[] = [];
+  let page = 1;
+  let pageCount = 0;
+  let truncated = false;
+  let lastModified: string | null = null;
+  let pollSeconds = WATCH_DEFAULT_POLL_INTERVAL_SECONDS;
+  for (;;) {
+    const result = await requestPage({
+      token,
+      before,
+      page,
+      lastModified: conditionalLastModified,
+      fetchedAt,
+      fetchImpl,
+      timeoutMs,
+    });
+    pageCount++;
+    if (pageCount === 1) {
+      lastModified = result.response.status === 304
+        ? conditionalLastModified
+        : lastModifiedValidator(result.response.headers.get('last-modified'));
+      pollSeconds = pollIntervalSeconds(result.response.headers.get('x-poll-interval'));
+      if (result.response.status === 304) {
+        return {
+          threads: [],
+          candidateCount: 0,
+          matchedCount: 0,
+          pageCount,
+          truncated: false,
+          notModified: true,
+          before,
+          fetchedAt,
+          lastModified,
+          pollIntervalSeconds: pollSeconds,
+        };
+      }
+    }
+    allThreads.push(...result.threads);
+    if (result.nextPage === null) break;
+    if (pageCount >= maxPages) {
+      truncated = true;
+      break;
+    }
+    page = result.nextPage;
+  }
+  const threads = dedupeNotificationThreads(allThreads);
+  return {
+    threads,
+    candidateCount: threads.length,
+    matchedCount: threads.length,
+    pageCount,
+    truncated,
+    notModified: false,
+    before,
+    fetchedAt,
+    lastModified,
+    pollIntervalSeconds: pollSeconds,
+  };
+}
+
+export const fetchNotifications = fetchGitHubNotifications;

--- a/src/api/github-watch-scope-source.ts
+++ b/src/api/github-watch-scope-source.ts
@@ -7,6 +7,7 @@ import {
 const API_ORIGIN = 'https://api.github.com';
 const SCOPE_PATH = '/user/subscriptions';
 const PER_PAGE = 100;
+const MAX_SCOPE_PAGES = 100;
 const DEFAULT_TIMEOUT_MS = 30_000;
 
 type FetchLike = typeof fetch;
@@ -14,6 +15,7 @@ type FetchLike = typeof fetch;
 export interface FetchGitHubWatchScopeOptions {
   token: string;
   fetchImpl?: FetchLike;
+  maxPages?: number;
   now?: () => Date | string | number;
   timeoutMs?: number;
 }
@@ -149,6 +151,8 @@ async function fetchPage(
   }
 }
 
+/** Fetch one complete, bounded native Watch snapshot. Partial scope is never publishable.
+ * @see https://docs.github.com/en/rest/activity/watching#list-repositories-watched-by-the-authenticated-user */
 export async function fetchGitHubWatchScope(
   options: FetchGitHubWatchScopeOptions,
 ): Promise<WatchScopeSnapshot> {
@@ -158,6 +162,9 @@ export async function fetchGitHubWatchScope(
   const timeoutMs = Number.isFinite(options.timeoutMs)
     ? Math.max(1, Math.floor(options.timeoutMs!))
     : DEFAULT_TIMEOUT_MS;
+  const maxPages = Number.isFinite(options.maxPages)
+    ? Math.min(MAX_SCOPE_PAGES, Math.max(1, Math.floor(options.maxPages!)))
+    : MAX_SCOPE_PAGES;
   const fetchedAt = timestampFrom(options.now);
   const byName = new Map<string, ReturnType<typeof normalizeWatchRepository>>();
   let page = 1;
@@ -167,6 +174,9 @@ export async function fetchGitHubWatchScope(
     pageCount++;
     for (const repository of result.repositories) byName.set(repository.full_name, repository);
     if (result.nextPage === null) break;
+    if (pageCount >= maxPages) {
+      throw new GitHubWatchError('page_limit_exceeded', undefined, { page });
+    }
     page = result.nextPage;
   }
   return {

--- a/src/api/github-watch-scope-source.ts
+++ b/src/api/github-watch-scope-source.ts
@@ -1,0 +1,179 @@
+import {
+  GitHubWatchError,
+  normalizeWatchRepository,
+  type WatchScopeSnapshot,
+} from '@/watch/watch-model';
+
+const API_ORIGIN = 'https://api.github.com';
+const SCOPE_PATH = '/user/subscriptions';
+const PER_PAGE = 100;
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+type FetchLike = typeof fetch;
+
+export interface FetchGitHubWatchScopeOptions {
+  token: string;
+  fetchImpl?: FetchLike;
+  now?: () => Date | string | number;
+  timeoutMs?: number;
+}
+
+function timestampFrom(now: FetchGitHubWatchScopeOptions['now']): string {
+  const value = now?.() ?? new Date();
+  const date = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(date.getTime())) {
+    throw new GitHubWatchError('invalid_response');
+  }
+  return date.toISOString();
+}
+
+function responseError(response: Response, page: number): GitHubWatchError {
+  if (response.status === 401) {
+    return new GitHubWatchError('authentication_required', undefined, { status: response.status, page });
+  }
+  if (response.status === 403 || response.status === 429) {
+    const code = response.status === 429 ||
+      response.headers.get('x-ratelimit-remaining') === '0' ||
+      response.headers.has('retry-after')
+      ? 'rate_limited'
+      : 'permission_denied';
+    return new GitHubWatchError(code, undefined, { status: response.status, page });
+  }
+  if (response.status >= 500) {
+    return new GitHubWatchError('github_unavailable', undefined, { status: response.status, page });
+  }
+  return new GitHubWatchError('invalid_response', undefined, { status: response.status, page });
+}
+
+function nextPage(linkHeader: string | null, currentPage: number): number | null {
+  if (!linkHeader) return null;
+  const parts = linkHeader.split(',');
+  const nextParts = parts.filter((part) => /\brel="[^"]*\bnext\b[^"]*"/u.test(part));
+  if (nextParts.length === 0) {
+    if (/\brel\s*=\s*"?next\b/iu.test(linkHeader)) {
+      throw new GitHubWatchError('invalid_pagination', undefined, { page: currentPage });
+    }
+    return null;
+  }
+  if (nextParts.length !== 1) {
+    throw new GitHubWatchError('invalid_pagination', undefined, { page: currentPage });
+  }
+  const nextPart = nextParts[0]!;
+  const match = nextPart.match(/^\s*<([^>]+)>\s*;/u);
+  if (!match) throw new GitHubWatchError('invalid_pagination', undefined, { page: currentPage });
+  let url: URL;
+  try {
+    url = new URL(match[1]!);
+  } catch {
+    throw new GitHubWatchError('invalid_pagination', undefined, { page: currentPage });
+  }
+  const page = Number(url.searchParams.get('page'));
+  if (
+    url.origin !== API_ORIGIN ||
+    url.pathname !== SCOPE_PATH ||
+    !Number.isSafeInteger(page) ||
+    page !== currentPage + 1 ||
+    url.searchParams.getAll('page').length !== 1 ||
+    url.searchParams.get('per_page') !== String(PER_PAGE) ||
+    url.searchParams.getAll('per_page').length !== 1
+  ) {
+    throw new GitHubWatchError('invalid_pagination', undefined, { page: currentPage });
+  }
+  return page;
+}
+
+async function fetchPage(
+  token: string,
+  page: number,
+  fetchImpl: FetchLike,
+  timeoutMs: number,
+): Promise<{ repositories: ReturnType<typeof normalizeWatchRepository>[]; nextPage: number | null }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const url = new URL(SCOPE_PATH, API_ORIGIN);
+    url.searchParams.set('per_page', String(PER_PAGE));
+    url.searchParams.set('page', String(page));
+    const response = await fetchImpl(url.toString(), {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+      },
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+    if (!response.ok) throw responseError(response, page);
+    const contentType = response.headers.get('content-type');
+    if (contentType && !contentType.toLowerCase().includes('json')) {
+      throw new GitHubWatchError('invalid_content_type', undefined, { status: response.status, page });
+    }
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new GitHubWatchError('deadline_exceeded', undefined, { page });
+      }
+      throw new GitHubWatchError('invalid_response', undefined, { status: response.status, page });
+    }
+    if (!Array.isArray(payload)) {
+      throw new GitHubWatchError('invalid_response', undefined, { status: response.status, page });
+    }
+    let repositories: ReturnType<typeof normalizeWatchRepository>[];
+    try {
+      repositories = payload.map(normalizeWatchRepository);
+    } catch (error) {
+      if (error instanceof GitHubWatchError) {
+        throw new GitHubWatchError(error.code, undefined, { status: response.status, page });
+      }
+      throw new GitHubWatchError('invalid_response', undefined, { status: response.status, page });
+    }
+    const pageAfter = nextPage(response.headers.get('link'), page);
+    if (repositories.length === 0 && pageAfter !== null) {
+      throw new GitHubWatchError('invalid_pagination', undefined, { page });
+    }
+    return { repositories, nextPage: pageAfter };
+  } catch (error) {
+    if (error instanceof GitHubWatchError) {
+      throw error;
+    }
+    if (controller.signal.aborted) {
+      throw new GitHubWatchError('deadline_exceeded', undefined, { page });
+    }
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new GitHubWatchError('request_aborted', undefined, { page });
+    }
+    throw new GitHubWatchError('network_error', undefined, { page });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function fetchGitHubWatchScope(
+  options: FetchGitHubWatchScopeOptions,
+): Promise<WatchScopeSnapshot> {
+  const token = options.token.trim();
+  if (!token) throw new GitHubWatchError('authentication_required');
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = Number.isFinite(options.timeoutMs)
+    ? Math.max(1, Math.floor(options.timeoutMs!))
+    : DEFAULT_TIMEOUT_MS;
+  const fetchedAt = timestampFrom(options.now);
+  const byName = new Map<string, ReturnType<typeof normalizeWatchRepository>>();
+  let page = 1;
+  let pageCount = 0;
+  for (;;) {
+    const result = await fetchPage(token, page, fetchImpl, timeoutMs);
+    pageCount++;
+    for (const repository of result.repositories) byName.set(repository.full_name, repository);
+    if (result.nextPage === null) break;
+    page = result.nextPage;
+  }
+  return {
+    repositories: [...byName.values()].sort((left, right) => left.full_name.localeCompare(right.full_name)),
+    pageCount,
+    fetchedAt,
+  };
+}
+
+export const fetchWatchScope = fetchGitHubWatchScope;

--- a/src/auth/auth-store.ts
+++ b/src/auth/auth-store.ts
@@ -434,15 +434,19 @@ async function persistGitHubCredentialsUnlocked(
 
 async function mutateGitHubCredentials(
   update: (current: Config) => Config | Promise<Config>,
+  afterCommit?: (next: Config) => void,
 ): Promise<Config> {
   return runConfigExclusive(async () => {
     const current = await readStoredConfig();
-    return persistGitHubCredentialsUnlocked(current, await update(current));
+    const next = await persistGitHubCredentialsUnlocked(current, await update(current));
+    afterCommit?.(next);
+    return next;
   });
 }
 
 async function mutateStoredConfig(
   update: (current: Config) => Config | null | Promise<Config | null>,
+  afterCommit?: (next: Config) => void,
 ): Promise<Config> {
   return runConfigExclusive(async () => {
     const current = await readStoredConfig();
@@ -451,7 +455,9 @@ async function mutateStoredConfig(
       cache = current;
       return current;
     }
-    return persistConfigUnlocked(current, proposed);
+    const next = await persistConfigUnlocked(current, proposed);
+    afterCommit?.(next);
+    return next;
   });
 }
 
@@ -1095,8 +1101,9 @@ export const authStore = {
           ? null
           : current.watchNotificationsTokenCryptoMeta,
       };
+    }, () => {
+      plaintextToken = { cipher, cryptoMeta: JSON.stringify(meta), value: clean };
     });
-    plaintextToken = { cipher, cryptoMeta: JSON.stringify(meta), value: clean };
     return { username: login, watching };
   },
 
@@ -1115,9 +1122,10 @@ export const authStore = {
         watchNotificationsTokenEncrypted: null,
         watchNotificationsTokenCryptoMeta: null,
       };
+    }, () => {
+      plaintextToken = null;
+      plaintextWatchNotificationsToken = null;
     });
-    plaintextToken = null;
-    plaintextWatchNotificationsToken = null;
   },
 
   async setWatchNotificationsToken(token: string): Promise<{ username: string }> {
@@ -1141,12 +1149,13 @@ export const authStore = {
         watchNotificationsTokenEncrypted: cipher,
         watchNotificationsTokenCryptoMeta: meta,
       };
+    }, () => {
+      plaintextWatchNotificationsToken = {
+        cipher,
+        cryptoMeta: JSON.stringify(meta),
+        value: clean,
+      };
     });
-    plaintextWatchNotificationsToken = {
-      cipher,
-      cryptoMeta: JSON.stringify(meta),
-      value: clean,
-    };
     return { username: login };
   },
 
@@ -1155,8 +1164,9 @@ export const authStore = {
         ...current,
         watchNotificationsTokenEncrypted: null,
         watchNotificationsTokenCryptoMeta: null,
-    }));
-    plaintextWatchNotificationsToken = null;
+    }), () => {
+      plaintextWatchNotificationsToken = null;
+    });
   },
 
   async update(patch: Partial<Config>): Promise<void> {
@@ -1314,8 +1324,9 @@ export const authStore = {
           capability,
         }),
       };
+    }, () => {
+      plaintextAgentApiKey = nextPlaintextAgentApiKey;
     });
-    plaintextAgentApiKey = nextPlaintextAgentApiKey;
   },
 
   async clearAgentProviderApiKey(): Promise<void> {

--- a/src/auth/auth-store.ts
+++ b/src/auth/auth-store.ts
@@ -4,8 +4,13 @@ import type {
   Config,
 } from "@/types";
 import { encrypt, decrypt } from "./crypto";
-import { TOKEN_EMPTY } from "@/api/errors";
-import { probeTokenCapabilities } from "./token-probe";
+import {
+  TOKEN_EMPTY,
+  WATCH_TOKEN_ACCOUNT_CHANGED,
+  WATCH_TOKEN_EMPTY,
+  WATCH_TOKEN_MAIN_ACCOUNT_REQUIRED,
+} from "@/api/errors";
+import { probeTokenCapabilities, probeWatchNotificationsToken } from "./token-probe";
 import {
   normalizeOnboardingStage,
   stageMarksOnboardingSeen,
@@ -50,6 +55,18 @@ import {
  */
 
 export const CONFIG_STORAGE_KEY = "gsm_config";
+export const GITHUB_CREDENTIALS_STORAGE_KEY = 'gsm_github_credentials_v1';
+
+type StoredGitHubCredentials = Readonly<{
+  version: 1;
+  tokenEncrypted: string | null;
+  tokenCryptoMeta: Config['tokenCryptoMeta'];
+  watchNotificationsTokenEncrypted: string | null;
+  watchNotificationsTokenCryptoMeta: Config['watchNotificationsTokenCryptoMeta'];
+  username: string | null;
+  avatarUrl: string | null;
+  displayName: string | null;
+}>;
 
 export type AgentProviderCredentialSnapshot = Readonly<{
   provider: Config["agentProvider"]["provider"];
@@ -77,6 +94,8 @@ export type AgentProviderCredentialSnapshot = Readonly<{
 const DEFAULT_CONFIG: Config = {
   tokenEncrypted: null,
   tokenCryptoMeta: null,
+  watchNotificationsTokenEncrypted: null,
+  watchNotificationsTokenCryptoMeta: null,
   agentProvider: {
     provider: "openai",
     protocol: null,
@@ -116,18 +135,78 @@ const DEFAULT_CONFIG: Config = {
   backfills: {},
 };
 
+type PlaintextCredentialCache = {
+  cipher: string;
+  cryptoMeta: string;
+  value: string;
+};
+
+export type GitHubCredentialSnapshot = Readonly<{
+  accountLogin: string | null;
+  mainToken: string | null;
+  notificationsToken: string | null;
+  notificationsConfigured: boolean;
+  mainIdentity: string;
+  notificationsIdentity: string;
+}>;
+
+const CONFIG_OPERATION_LOCK = 'better-github-stars-manager:config:v1';
+
 let cache: Config | null = null;
-let plaintextToken: string | null = null; // in-memory only
+let plaintextToken: PlaintextCredentialCache | null = null; // in-memory only
+let plaintextWatchNotificationsToken: PlaintextCredentialCache | null = null; // in-memory only
 let plaintextAgentApiKey: {
   cipher: string;
   cryptoMeta: string;
   revision: string;
   value: string;
 } | null = null; // in-memory only
+let configOperationTail: Promise<void> = Promise.resolve();
+
+type ConfigLockManager = {
+  request<T>(name: string, callback: () => Promise<T>): Promise<T>;
+};
+
+function getConfigLockManager(): ConfigLockManager | null {
+  const locks = (globalThis as typeof globalThis & {
+    navigator?: { locks?: unknown };
+  }).navigator?.locks;
+  if (!locks || typeof (locks as { request?: unknown }).request !== 'function') return null;
+  return locks as ConfigLockManager;
+}
+
+/** Serialize whole-config reads/writes across extension pages and the MV3 worker. */
+function runConfigExclusive<T>(operation: () => Promise<T>): Promise<T> {
+  const execute = () => {
+    const locks = getConfigLockManager();
+    return locks ? locks.request(CONFIG_OPERATION_LOCK, operation) : operation();
+  };
+  const result = configOperationTail.then(execute, execute);
+  configOperationTail = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
 
 function mergeStoredConfig(stored: Partial<Config>): Config {
   const maxTagsPerRepo =
     stored.maxTagsPerRepo === undefined ? stored.autoTagLimit : stored.maxTagsPerRepo;
+  const watchTokenEncrypted = typeof stored.watchNotificationsTokenEncrypted === 'string' &&
+    stored.watchNotificationsTokenEncrypted.length > 0
+    ? stored.watchNotificationsTokenEncrypted
+    : null;
+  const watchTokenMeta = validCryptoMeta(stored.watchNotificationsTokenCryptoMeta)
+    ? stored.watchNotificationsTokenCryptoMeta
+    : null;
+  const hasBoundMainCredential = typeof stored.username === 'string' &&
+    stored.username.trim().length > 0 &&
+    typeof stored.tokenEncrypted === 'string' &&
+    stored.tokenEncrypted.length > 0 &&
+    validCryptoMeta(stored.tokenCryptoMeta);
+  const hasCompleteWatchToken = !!(
+    hasBoundMainCredential && watchTokenEncrypted && watchTokenMeta
+  );
   return {
     ...DEFAULT_CONFIG,
     ...stored,
@@ -140,11 +219,88 @@ function mergeStoredConfig(stored: Partial<Config>): Config {
     ),
     autoTagAgentPromptSeen: stored.autoTagAgentPromptSeen === true,
     maxTagsPerRepo: maxTagsPerRepo ?? DEFAULT_CONFIG.maxTagsPerRepo,
+    watchNotificationsTokenEncrypted: hasCompleteWatchToken ? watchTokenEncrypted : null,
+    watchNotificationsTokenCryptoMeta: hasCompleteWatchToken ? watchTokenMeta : null,
+  };
+}
+
+function validCryptoMeta(value: unknown): value is Config['tokenCryptoMeta'] & object {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const meta = value as { iv?: unknown; salt?: unknown };
+  return typeof meta.iv === 'string' && !!meta.iv && typeof meta.salt === 'string' && !!meta.salt;
+}
+
+function credentialsFromConfig(config: Config): StoredGitHubCredentials {
+  return {
+    version: 1,
+    tokenEncrypted: config.tokenEncrypted,
+    tokenCryptoMeta: config.tokenCryptoMeta,
+    watchNotificationsTokenEncrypted: config.watchNotificationsTokenEncrypted,
+    watchNotificationsTokenCryptoMeta: config.watchNotificationsTokenCryptoMeta,
+    username: config.username,
+    avatarUrl: config.avatarUrl,
+    displayName: config.displayName,
+  };
+}
+
+function normalizeStoredGitHubCredentials(value: unknown): StoredGitHubCredentials {
+  const stored = value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Partial<StoredGitHubCredentials>
+    : {};
+  const username = typeof stored.username === 'string' && stored.username.trim()
+    ? stored.username
+    : null;
+  const tokenEncrypted = typeof stored.tokenEncrypted === 'string' && stored.tokenEncrypted
+    ? stored.tokenEncrypted
+    : null;
+  const tokenCryptoMeta = validCryptoMeta(stored.tokenCryptoMeta)
+    ? stored.tokenCryptoMeta
+    : null;
+  const hasMainCredential = !!(username && tokenEncrypted && tokenCryptoMeta);
+  const watchTokenEncrypted = typeof stored.watchNotificationsTokenEncrypted === 'string' &&
+    stored.watchNotificationsTokenEncrypted
+    ? stored.watchNotificationsTokenEncrypted
+    : null;
+  const watchTokenCryptoMeta = validCryptoMeta(stored.watchNotificationsTokenCryptoMeta)
+    ? stored.watchNotificationsTokenCryptoMeta
+    : null;
+  const hasWatchCredential = !!(
+    hasMainCredential && watchTokenEncrypted && watchTokenCryptoMeta
+  );
+  return {
+    version: 1,
+    tokenEncrypted: hasMainCredential ? tokenEncrypted : null,
+    tokenCryptoMeta: hasMainCredential ? tokenCryptoMeta : null,
+    watchNotificationsTokenEncrypted: hasWatchCredential ? watchTokenEncrypted : null,
+    watchNotificationsTokenCryptoMeta: hasWatchCredential ? watchTokenCryptoMeta : null,
+    username: hasMainCredential ? username : null,
+    avatarUrl: hasMainCredential && typeof stored.avatarUrl === 'string'
+      ? stored.avatarUrl
+      : null,
+    displayName: hasMainCredential && typeof stored.displayName === 'string'
+      ? stored.displayName
+      : null,
+  };
+}
+
+function withGitHubCredentials(
+  config: Config,
+  credentials: StoredGitHubCredentials,
+): Config {
+  return {
+    ...config,
+    tokenEncrypted: credentials.tokenEncrypted,
+    tokenCryptoMeta: credentials.tokenCryptoMeta,
+    watchNotificationsTokenEncrypted: credentials.watchNotificationsTokenEncrypted,
+    watchNotificationsTokenCryptoMeta: credentials.watchNotificationsTokenCryptoMeta,
+    username: credentials.username,
+    avatarUrl: credentials.avatarUrl,
+    displayName: credentials.displayName,
   };
 }
 
 function withNormalizedConfig(config: Config): Config {
-  const hasTokenHint = !!(plaintextToken || config.tokenEncrypted);
+  const hasTokenHint = !!(plaintextToken?.value || config.tokenEncrypted);
   const onboardingStage = normalizeOnboardingStage(
     config.onboardingStage,
     config.seenOnboarding,
@@ -177,29 +333,220 @@ function withNormalizedConfig(config: Config): Config {
 }
 
 async function read(): Promise<Config> {
-  if (cache) return cache;
   cache = await readStoredConfig();
   return cache;
 }
 
 async function readStoredConfig(): Promise<Config> {
-  const raw = await chrome.storage.local.get(CONFIG_STORAGE_KEY);
+  const raw = await chrome.storage.local.get([
+    CONFIG_STORAGE_KEY,
+    GITHUB_CREDENTIALS_STORAGE_KEY,
+  ]);
   const stored = (raw[CONFIG_STORAGE_KEY] ?? {}) as Partial<Config>;
-  return withNormalizedConfig(mergeStoredConfig(stored));
+  const hasCredentialRecord = Object.prototype.hasOwnProperty.call(
+    raw,
+    GITHUB_CREDENTIALS_STORAGE_KEY,
+  );
+  const credentials = normalizeStoredGitHubCredentials(
+    hasCredentialRecord
+      ? raw[GITHUB_CREDENTIALS_STORAGE_KEY]
+      : { version: 1, ...stored },
+  );
+  return withNormalizedConfig(withGitHubCredentials(mergeStoredConfig(stored), credentials));
 }
 
-async function write(next: Config): Promise<void> {
-  const normalized = withNormalizedConfig(next);
-  await chrome.storage.local.set({ [CONFIG_STORAGE_KEY]: normalized });
+function normalizedAccountLogin(value: string | null | undefined): string | null {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || null;
+}
+
+function mainCredentialIdentity(config: Config): string {
+  return JSON.stringify([
+    normalizedAccountLogin(config.username),
+    config.tokenEncrypted,
+    config.tokenCryptoMeta,
+  ]);
+}
+
+function notificationsCredentialIdentity(config: Config): string {
+  return JSON.stringify([
+    config.watchNotificationsTokenEncrypted,
+    config.watchNotificationsTokenCryptoMeta,
+  ]);
+}
+
+function hasCompleteMainCredential(config: Config): boolean {
+  return !!(
+    normalizedAccountLogin(config.username) &&
+    config.tokenEncrypted &&
+    validCryptoMeta(config.tokenCryptoMeta)
+  );
+}
+
+function preserveCredentialBinding(previous: Config, proposed: Config): Config {
+  const accountChanged = normalizedAccountLogin(previous.username) !==
+    normalizedAccountLogin(proposed.username);
+  if (!accountChanged && hasCompleteMainCredential(proposed)) return proposed;
+  return {
+    ...proposed,
+    watchNotificationsTokenEncrypted: null,
+    watchNotificationsTokenCryptoMeta: null,
+  };
+}
+
+function updateCredentialCaches(previous: Config, normalized: Config): void {
   cache = normalized;
+  if (mainCredentialIdentity(previous) !== mainCredentialIdentity(normalized)) {
+    plaintextToken = null;
+  }
+  if (
+    notificationsCredentialIdentity(previous) !== notificationsCredentialIdentity(normalized) ||
+    normalizedAccountLogin(previous.username) !== normalizedAccountLogin(normalized.username)
+  ) {
+    plaintextWatchNotificationsToken = null;
+  }
+}
+
+async function persistConfigUnlocked(previous: Config, proposed: Config): Promise<Config> {
+  const normalized = withNormalizedConfig(withGitHubCredentials(
+    proposed,
+    credentialsFromConfig(previous),
+  ));
+  await chrome.storage.local.set({ [CONFIG_STORAGE_KEY]: normalized });
+  updateCredentialCaches(previous, normalized);
+  return normalized;
+}
+
+async function persistGitHubCredentialsUnlocked(
+  previous: Config,
+  proposed: Config,
+): Promise<Config> {
+  const normalized = withNormalizedConfig(preserveCredentialBinding(previous, proposed));
+  const credentials = normalizeStoredGitHubCredentials(credentialsFromConfig(normalized));
+  const next = withGitHubCredentials(normalized, credentials);
+  await chrome.storage.local.set({
+    [CONFIG_STORAGE_KEY]: next,
+    [GITHUB_CREDENTIALS_STORAGE_KEY]: credentials,
+  });
+  updateCredentialCaches(previous, next);
+  return next;
+}
+
+async function mutateGitHubCredentials(
+  update: (current: Config) => Config | Promise<Config>,
+): Promise<Config> {
+  return runConfigExclusive(async () => {
+    const current = await readStoredConfig();
+    return persistGitHubCredentialsUnlocked(current, await update(current));
+  });
+}
+
+async function mutateStoredConfig(
+  update: (current: Config) => Config | null | Promise<Config | null>,
+): Promise<Config> {
+  return runConfigExclusive(async () => {
+    const current = await readStoredConfig();
+    const proposed = await update(current);
+    if (proposed === null) {
+      cache = current;
+      return current;
+    }
+    return persistConfigUnlocked(current, proposed);
+  });
+}
+
+async function decryptCredential(
+  cipher: string | null,
+  meta: Config['tokenCryptoMeta'],
+  cached: PlaintextCredentialCache | null,
+): Promise<PlaintextCredentialCache | null> {
+  if (!cipher || !meta) return null;
+  const cryptoMeta = JSON.stringify(meta);
+  if (cached?.cipher === cipher && cached.cryptoMeta === cryptoMeta) return cached;
+  const value = await decrypt(cipher, meta);
+  return value ? { cipher, cryptoMeta, value } : null;
 }
 
 async function readDecryptedToken(): Promise<string | null> {
-  if (plaintextToken) return plaintextToken;
-  const c = await read();
-  if (!c.tokenEncrypted || !c.tokenCryptoMeta) return null;
-  plaintextToken = await decrypt(c.tokenEncrypted, c.tokenCryptoMeta);
-  return plaintextToken;
+  return runConfigExclusive(async () => {
+    const before = await readStoredConfig();
+    const decrypted = await decryptCredential(
+      before.tokenEncrypted,
+      before.tokenCryptoMeta,
+      plaintextToken,
+    );
+    const latest = await readStoredConfig();
+    if (mainCredentialIdentity(before) !== mainCredentialIdentity(latest)) return null;
+    cache = latest;
+    plaintextToken = decrypted;
+    return decrypted?.value ?? null;
+  });
+}
+
+async function readDecryptedWatchNotificationsToken(): Promise<string | null> {
+  return runConfigExclusive(async () => {
+    const before = await readStoredConfig();
+    const decrypted = await decryptCredential(
+      before.watchNotificationsTokenEncrypted,
+      before.watchNotificationsTokenCryptoMeta,
+      plaintextWatchNotificationsToken,
+    );
+    const latest = await readStoredConfig();
+    if (
+      normalizedAccountLogin(before.username) !== normalizedAccountLogin(latest.username) ||
+      notificationsCredentialIdentity(before) !== notificationsCredentialIdentity(latest)
+    ) return null;
+    cache = latest;
+    plaintextWatchNotificationsToken = decrypted;
+    return decrypted?.value ?? null;
+  });
+}
+
+async function readGitHubCredentialSnapshot(): Promise<GitHubCredentialSnapshot> {
+  return runConfigExclusive(async () => {
+    const before = await readStoredConfig();
+    const [main, notifications] = await Promise.all([
+      decryptCredential(before.tokenEncrypted, before.tokenCryptoMeta, plaintextToken),
+      decryptCredential(
+        before.watchNotificationsTokenEncrypted,
+        before.watchNotificationsTokenCryptoMeta,
+        plaintextWatchNotificationsToken,
+      ),
+    ]);
+    const latest = await readStoredConfig();
+    const mainIdentity = mainCredentialIdentity(before);
+    const notificationsIdentity = notificationsCredentialIdentity(before);
+    if (
+      mainIdentity !== mainCredentialIdentity(latest) ||
+      notificationsIdentity !== notificationsCredentialIdentity(latest)
+    ) {
+      return {
+        accountLogin: normalizedAccountLogin(latest.username),
+        mainToken: null,
+        notificationsToken: null,
+        notificationsConfigured: !!(
+          latest.watchNotificationsTokenEncrypted &&
+          latest.watchNotificationsTokenCryptoMeta
+        ),
+        mainIdentity: mainCredentialIdentity(latest),
+        notificationsIdentity: notificationsCredentialIdentity(latest),
+      };
+    }
+    cache = latest;
+    plaintextToken = main;
+    plaintextWatchNotificationsToken = notifications;
+    return {
+      accountLogin: normalizedAccountLogin(before.username),
+      mainToken: main?.value ?? null,
+      notificationsToken: notifications?.value ?? null,
+      notificationsConfigured: !!(
+        before.watchNotificationsTokenEncrypted &&
+        before.watchNotificationsTokenCryptoMeta
+      ),
+      mainIdentity,
+      notificationsIdentity,
+    };
+  });
 }
 
 async function readDecryptedAgentApiKey(
@@ -321,18 +668,34 @@ function createAgentCredentialRevision(): string {
 if (typeof chrome !== "undefined" && chrome.storage?.onChanged) {
   chrome.storage.onChanged.addListener((changes, areaName) => {
     if (areaName !== "local") return;
-    const change = changes[CONFIG_STORAGE_KEY];
-    if (!change) return;
+    const configChange = changes[CONFIG_STORAGE_KEY];
+    const credentialsChange = changes[GITHUB_CREDENTIALS_STORAGE_KEY];
+    if (!configChange && !credentialsChange) return;
 
     const prev = cache;
-    const stored = (change.newValue ?? {}) as Partial<Config>;
-    cache = withNormalizedConfig(mergeStoredConfig(stored));
+    const stored = (configChange?.newValue ?? cache ?? {}) as Partial<Config>;
+    const credentials = credentialsChange
+      ? normalizeStoredGitHubCredentials(credentialsChange.newValue)
+      : prev
+        ? credentialsFromConfig(prev)
+        : normalizeStoredGitHubCredentials({ version: 1, ...stored });
+    cache = withNormalizedConfig(withGitHubCredentials(
+      mergeStoredConfig(stored),
+      credentials,
+    ));
 
     const tokenChanged =
       prev?.tokenEncrypted !== cache.tokenEncrypted ||
       JSON.stringify(prev?.tokenCryptoMeta ?? null) !==
         JSON.stringify(cache.tokenCryptoMeta ?? null);
     if (tokenChanged) plaintextToken = null;
+
+    const watchTokenChanged =
+      prev?.watchNotificationsTokenEncrypted !== cache.watchNotificationsTokenEncrypted ||
+      JSON.stringify(prev?.watchNotificationsTokenCryptoMeta ?? null) !==
+        JSON.stringify(cache.watchNotificationsTokenCryptoMeta ?? null) ||
+      prev?.username?.trim().toLowerCase() !== cache.username?.trim().toLowerCase();
+    if (watchTokenChanged) plaintextWatchNotificationsToken = null;
 
     plaintextAgentApiKey = null;
   });
@@ -350,6 +713,19 @@ export const authStore = {
   /** The decrypted token, or null. Held only in memory. */
   async getToken(): Promise<string | null> {
     return readDecryptedToken();
+  },
+
+  /** A single account-bound credential view for background Watch operations. */
+  async getGitHubCredentialSnapshot(): Promise<GitHubCredentialSnapshot> {
+    return readGitHubCredentialSnapshot();
+  },
+
+  async hasWatchNotificationsToken(): Promise<boolean> {
+    return !!(await readDecryptedWatchNotificationsToken());
+  },
+
+  async getWatchNotificationsToken(): Promise<string | null> {
+    return readDecryptedWatchNotificationsToken();
   },
 
   /** The decrypted AI service API key, or null. Held only in memory. */
@@ -566,8 +942,10 @@ export const authStore = {
       origin: endpoint.canonicalOrigin,
       acceptedAt: input.acceptedAt ?? Date.now(),
     });
-    const current = await readStoredConfig();
-    await write({ ...current, agentDataDisclosureAcceptance: acceptance });
+    await mutateStoredConfig((current) => ({
+      ...current,
+      agentDataDisclosureAcceptance: acceptance,
+    }));
     return acceptance;
   },
 
@@ -588,13 +966,6 @@ export const authStore = {
       !Number.isSafeInteger(input.verifiedAt) ||
       input.verifiedAt < 0
     ) return false;
-    const current = await readStoredConfig();
-    const config = current.agentProvider;
-    if (
-      config.credentialRevision !== input.credentialRevision ||
-      !isSavedAgentCredentialEligible(config, input)
-    ) return false;
-    if (!matchesProviderTarget(config, input)) return false;
     const contextCapability = resolveAgentModelContextCapability({
       provider: input.provider,
       model: input.model,
@@ -610,46 +981,47 @@ export const authStore = {
       declaredContextWindow: input.declaredContextWindow ?? null,
       workingContextWindow: input.workingContextWindow ?? null,
     });
-    const latest = await readStoredConfig();
-    if (
-      latest.agentProvider.credentialRevision !== input.credentialRevision ||
-      !sameCredentialRecord(config, latest.agentProvider) ||
-      !matchesProviderTarget(latest.agentProvider, input)
-    ) return false;
-    await write({
-      ...latest,
-      agentProvider: {
-        ...latest.agentProvider,
-        capability: {
-          fingerprint,
-          verifiedAt: input.verifiedAt,
-          textChat: true,
-          namedToolRoundTrip: true,
-          contextCapability,
+    let recorded = false;
+    await mutateStoredConfig((current) => {
+      const config = current.agentProvider;
+      if (
+        config.credentialRevision !== input.credentialRevision ||
+        !isSavedAgentCredentialEligible(config, input) ||
+        !matchesProviderTarget(config, input)
+      ) return null;
+      recorded = true;
+      return {
+        ...current,
+        agentProvider: {
+          ...config,
+          capability: {
+            fingerprint,
+            verifiedAt: input.verifiedAt,
+            textChat: true,
+            namedToolRoundTrip: true,
+            contextCapability,
+          },
         },
-      },
+      };
     });
-    return true;
+    return recorded;
   },
 
   async invalidateAgentProviderCapability(fingerprint: string): Promise<boolean> {
     if (!/^pcf:v1:[A-Za-z0-9_-]{43}$/u.test(fingerprint)) return false;
-    const current = await readStoredConfig();
-    if (current.agentProvider.capability?.fingerprint !== fingerprint) return false;
-    const latest = await readStoredConfig();
-    if (
-      latest.agentProvider.capability?.fingerprint !== fingerprint ||
-      !sameCredentialRecord(current.agentProvider, latest.agentProvider) ||
-      !sameProviderConfiguration(current.agentProvider, latest.agentProvider)
-    ) return false;
-    await write({
-      ...latest,
-      agentProvider: {
-        ...latest.agentProvider,
-        capability: null,
-      },
+    let invalidated = false;
+    await mutateStoredConfig((current) => {
+      if (current.agentProvider.capability?.fingerprint !== fingerprint) return null;
+      invalidated = true;
+      return {
+        ...current,
+        agentProvider: {
+          ...current.agentProvider,
+          capability: null,
+        },
+      };
     });
-    return true;
+    return invalidated;
   },
 
   async getUsername(): Promise<string | null> {
@@ -681,11 +1053,11 @@ export const authStore = {
   },
 
   async setTheme(theme: "dark" | "light"): Promise<void> {
-    await write({ ...(await read()), theme });
+    await mutateStoredConfig((current) => ({ ...current, theme }));
   },
 
   async setLocale(locale: "en" | "zh-CN"): Promise<void> {
-    await write({ ...(await read()), locale });
+    await mutateStoredConfig((current) => ({ ...current, locale }));
   },
 
   /**
@@ -693,55 +1065,115 @@ export const authStore = {
    * encrypt+persist. Failure throws an errors.ts code; the token is never
    * persisted on failure.
    */
-  async setToken(token: string): Promise<{ username: string }> {
+  async setToken(token: string): Promise<{
+    username: string;
+    watching: Awaited<ReturnType<typeof probeTokenCapabilities>>['watching'];
+  }> {
     const clean = token.trim();
     if (!clean) throw new Error(TOKEN_EMPTY);
 
-    const { login, avatarUrl, displayName, scopesHeader } =
+    const { login, avatarUrl, displayName, watching } =
       await probeTokenCapabilities(clean);
-    const classicOk =
-      scopesHeader.includes("public_repo") && scopesHeader.includes("gist");
-    if (scopesHeader && !classicOk)
-      console.warn(
-        "[gsm] classic-token scopes may be insufficient:",
-        scopesHeader,
-      );
-
     const { cipher, meta } = await encrypt(clean);
-    const current = await read();
-    const onboardingStage =
-      current.onboardingStage === "done" ? "done" : "awaiting_sync";
-    await write({
-      ...current,
-      tokenEncrypted: cipher,
-      tokenCryptoMeta: meta,
-      username: login,
-      avatarUrl,
-      displayName,
-      onboardingStage,
+    await mutateGitHubCredentials((current) => {
+      const accountChanged = !!current.username &&
+        current.username.trim().toLowerCase() !== login.trim().toLowerCase();
+      const onboardingStage =
+        current.onboardingStage === "done" ? "done" : "awaiting_sync";
+      return {
+        ...current,
+        tokenEncrypted: cipher,
+        tokenCryptoMeta: meta,
+        username: login,
+        avatarUrl,
+        displayName,
+        onboardingStage,
+        watchNotificationsTokenEncrypted: accountChanged
+          ? null
+          : current.watchNotificationsTokenEncrypted,
+        watchNotificationsTokenCryptoMeta: accountChanged
+          ? null
+          : current.watchNotificationsTokenCryptoMeta,
+      };
     });
-    plaintextToken = clean;
-    return { username: login };
+    plaintextToken = { cipher, cryptoMeta: JSON.stringify(meta), value: clean };
+    return { username: login, watching };
   },
 
   async clearToken(): Promise<void> {
-    plaintextToken = null;
-    const current = await read();
-    const onboardingStage =
-      current.onboardingStage === "done" ? "done" : "needs_token";
-    await write({
-      ...current,
-      tokenEncrypted: null,
-      tokenCryptoMeta: null,
-      username: null,
-      avatarUrl: null,
-      displayName: null,
-      onboardingStage,
+    await mutateGitHubCredentials((current) => {
+      const onboardingStage =
+        current.onboardingStage === "done" ? "done" : "needs_token";
+      return {
+        ...current,
+        tokenEncrypted: null,
+        tokenCryptoMeta: null,
+        username: null,
+        avatarUrl: null,
+        displayName: null,
+        onboardingStage,
+        watchNotificationsTokenEncrypted: null,
+        watchNotificationsTokenCryptoMeta: null,
+      };
     });
+    plaintextToken = null;
+    plaintextWatchNotificationsToken = null;
+  },
+
+  async setWatchNotificationsToken(token: string): Promise<{ username: string }> {
+    const clean = token.trim();
+    if (!clean) throw new Error(WATCH_TOKEN_EMPTY);
+    const before = await readGitHubCredentialSnapshot();
+    if (!before.mainToken || !before.accountLogin) {
+      throw new Error(WATCH_TOKEN_MAIN_ACCOUNT_REQUIRED);
+    }
+    const { login } = await probeWatchNotificationsToken(clean, before.accountLogin);
+    const { cipher, meta } = await encrypt(clean);
+    await mutateGitHubCredentials((current) => {
+      if (
+        normalizedAccountLogin(current.username) !== before.accountLogin ||
+        !hasCompleteMainCredential(current)
+      ) {
+        throw new Error(WATCH_TOKEN_ACCOUNT_CHANGED);
+      }
+      return {
+        ...current,
+        watchNotificationsTokenEncrypted: cipher,
+        watchNotificationsTokenCryptoMeta: meta,
+      };
+    });
+    plaintextWatchNotificationsToken = {
+      cipher,
+      cryptoMeta: JSON.stringify(meta),
+      value: clean,
+    };
+    return { username: login };
+  },
+
+  async clearWatchNotificationsToken(): Promise<void> {
+    await mutateGitHubCredentials((current) => ({
+        ...current,
+        watchNotificationsTokenEncrypted: null,
+        watchNotificationsTokenCryptoMeta: null,
+    }));
+    plaintextWatchNotificationsToken = null;
   },
 
   async update(patch: Partial<Config>): Promise<void> {
-    await write({ ...(await read()), ...patch });
+    const touchesGitHubCredentials = [
+      'tokenEncrypted',
+      'tokenCryptoMeta',
+      'watchNotificationsTokenEncrypted',
+      'watchNotificationsTokenCryptoMeta',
+      'username',
+      'avatarUrl',
+      'displayName',
+    ].some((key) => Object.prototype.hasOwnProperty.call(patch, key));
+    if (touchesGitHubCredentials) {
+      await mutateGitHubCredentials((current) => ({ ...current, ...patch }));
+      return;
+    }
+    await mutateStoredConfig((current) => ({ ...current, ...patch }));
   },
 
   async updateAgentProviderConfig(patch: {
@@ -754,101 +1186,136 @@ export const authStore = {
     apiKey?: string;
     clearApiKey?: boolean;
   }): Promise<void> {
-    const current = await readStoredConfig();
-    const nextProvider = patch.provider ?? current.agentProvider.provider;
+    const initial = await readStoredConfig();
+    const initialProvider = initial.agentProvider;
+    const nextProvider = patch.provider ?? initialProvider.provider;
     const nextProtocol = patch.protocol === undefined
-      ? current.agentProvider.protocol
+      ? initialProvider.protocol
       : patch.protocol;
-    const nextModel =
-      patch.model === undefined ? current.agentProvider.model : patch.model;
+    const nextModel = patch.model === undefined ? initialProvider.model : patch.model;
     const nextDeclaredContextWindow = patch.declaredContextWindow === undefined
-      ? current.agentProvider.declaredContextWindow ?? null
+      ? initialProvider.declaredContextWindow ?? null
       : patch.declaredContextWindow;
     const nextWorkingContextWindow = patch.workingContextWindow === undefined
-      ? current.agentProvider.workingContextWindow ?? null
+      ? initialProvider.workingContextWindow ?? null
       : patch.workingContextWindow;
-    let apiKeyEncrypted = current.agentProvider.apiKeyEncrypted;
-    let apiKeyCryptoMeta = current.agentProvider.apiKeyCryptoMeta;
-    let credentialScope = current.agentProvider.credentialScope;
-    let credentialRevision = current.agentProvider.credentialRevision;
-    let capability = current.agentProvider.capability;
     const nextBaseUrl = patch.baseUrl === undefined
-      ? current.agentProvider.baseUrl
+      ? initialProvider.baseUrl
       : patch.baseUrl;
-    const targetChanged =
-      patch.provider !== undefined ||
-      patch.protocol !== undefined ||
-      patch.baseUrl !== undefined;
+    const targetChanged = patch.provider !== undefined ||
+      patch.protocol !== undefined || patch.baseUrl !== undefined;
     const validatedEndpoint = targetChanged
       ? resolveAgentProviderEndpoint(nextProvider, nextBaseUrl, nextProtocol)
       : null;
-    let savedReplacementCredential = false;
-
-    if (patch.clearApiKey) {
-      apiKeyEncrypted = null;
-      apiKeyCryptoMeta = null;
-      credentialScope = null;
-      credentialRevision = null;
-      capability = null;
-      plaintextAgentApiKey = null;
-    } else if (patch.apiKey !== undefined) {
-      const clean = patch.apiKey.trim();
-      if (clean) {
-        const endpoint = validatedEndpoint ?? resolveAgentProviderEndpoint(
-          nextProvider, nextBaseUrl, nextProtocol,
-        );
-        const { cipher, meta } = await encrypt(clean);
-        apiKeyEncrypted = cipher;
-        apiKeyCryptoMeta = meta;
-        credentialScope = {
-          provider: endpoint.provider,
-          origin: endpoint.canonicalOrigin,
-        };
-        credentialRevision = createAgentCredentialRevision();
-        capability = null;
-        plaintextAgentApiKey = {
-          cipher,
-          cryptoMeta: JSON.stringify(meta),
-          revision: credentialRevision,
-          value: clean,
-        };
-        savedReplacementCredential = true;
-      }
-    }
-
-    if (!patch.clearApiKey && !savedReplacementCredential) {
+    let replacementCredential: {
+      cipher: string;
+      meta: NonNullable<Config['agentProvider']['apiKeyCryptoMeta']>;
+      scope: NonNullable<Config['agentProvider']['credentialScope']>;
+      revision: string;
+      value: string;
+    } | null = null;
+    const cleanApiKey = patch.apiKey?.trim() ?? null;
+    if (!patch.clearApiKey && cleanApiKey) {
       const endpoint = validatedEndpoint ?? resolveAgentProviderEndpoint(
         nextProvider, nextBaseUrl, nextProtocol,
       );
-      const credentialTargetChanged = credentialScope?.provider !== endpoint.provider ||
-        credentialScope.origin !== endpoint.canonicalOrigin;
-      if (credentialTargetChanged) {
+      const { cipher, meta } = await encrypt(cleanApiKey);
+      const revision = createAgentCredentialRevision();
+      replacementCredential = {
+        cipher,
+        meta,
+        scope: {
+          provider: endpoint.provider,
+          origin: endpoint.canonicalOrigin,
+        },
+        revision,
+        value: cleanApiKey,
+      };
+    }
+    const initialMutationIdentity = JSON.stringify([
+      initialProvider.provider,
+      initialProvider.protocol,
+      initialProvider.baseUrl,
+      initialProvider.apiKeyEncrypted,
+      initialProvider.apiKeyCryptoMeta,
+      initialProvider.credentialRevision,
+      initialProvider.credentialScope,
+    ]);
+    let nextPlaintextAgentApiKey = plaintextAgentApiKey;
+    await mutateStoredConfig((current) => {
+      const currentProvider = current.agentProvider;
+      const currentMutationIdentity = JSON.stringify([
+        currentProvider.provider,
+        currentProvider.protocol,
+        currentProvider.baseUrl,
+        currentProvider.apiKeyEncrypted,
+        currentProvider.apiKeyCryptoMeta,
+        currentProvider.credentialRevision,
+        currentProvider.credentialScope,
+      ]);
+      if (
+        (patch.clearApiKey || replacementCredential || targetChanged) &&
+        currentMutationIdentity !== initialMutationIdentity
+      ) return null;
+
+      let apiKeyEncrypted = currentProvider.apiKeyEncrypted;
+      let apiKeyCryptoMeta = currentProvider.apiKeyCryptoMeta;
+      let credentialScope = currentProvider.credentialScope;
+      let credentialRevision = currentProvider.credentialRevision;
+      let capability = currentProvider.capability;
+      if (patch.clearApiKey) {
         apiKeyEncrypted = null;
         apiKeyCryptoMeta = null;
         credentialScope = null;
         credentialRevision = null;
         capability = null;
-        plaintextAgentApiKey = null;
+        nextPlaintextAgentApiKey = null;
+      } else if (replacementCredential) {
+        apiKeyEncrypted = replacementCredential.cipher;
+        apiKeyCryptoMeta = replacementCredential.meta;
+        credentialScope = replacementCredential.scope;
+        credentialRevision = replacementCredential.revision;
+        capability = null;
+        nextPlaintextAgentApiKey = {
+          cipher: replacementCredential.cipher,
+          cryptoMeta: JSON.stringify(replacementCredential.meta),
+          revision: replacementCredential.revision,
+          value: replacementCredential.value,
+        };
+      } else {
+        const endpoint = validatedEndpoint ?? resolveAgentProviderEndpoint(
+          nextProvider, nextBaseUrl, nextProtocol,
+        );
+        const credentialTargetChanged = credentialScope?.provider !== endpoint.provider ||
+          credentialScope?.origin !== endpoint.canonicalOrigin;
+        if (credentialTargetChanged) {
+          apiKeyEncrypted = null;
+          apiKeyCryptoMeta = null;
+          credentialScope = null;
+          credentialRevision = null;
+          capability = null;
+          nextPlaintextAgentApiKey = null;
+        }
       }
-    }
 
-    const latest = await readStoredConfig();
-    await write({
-      ...latest,
-      agentProvider: normalizeAgentProviderConfig({
-        provider: nextProvider,
-        protocol: nextProtocol,
-        baseUrl: nextBaseUrl,
-        model: nextModel,
-        declaredContextWindow: nextDeclaredContextWindow,
-        workingContextWindow: nextWorkingContextWindow,
-        apiKeyEncrypted,
-        apiKeyCryptoMeta,
-        credentialScope,
-        credentialRevision,
-        capability,
-      }),
+      return {
+        ...current,
+        agentProvider: normalizeAgentProviderConfig({
+          provider: nextProvider,
+          protocol: nextProtocol,
+          baseUrl: nextBaseUrl,
+          model: nextModel,
+          declaredContextWindow: nextDeclaredContextWindow,
+          workingContextWindow: nextWorkingContextWindow,
+          apiKeyEncrypted,
+          apiKeyCryptoMeta,
+          credentialScope,
+          credentialRevision,
+          capability,
+        }),
+      };
     });
+    plaintextAgentApiKey = nextPlaintextAgentApiKey;
   },
 
   async clearAgentProviderApiKey(): Promise<void> {
@@ -859,30 +1326,27 @@ export const authStore = {
     maxTagsPerRepo?: number;
     minTopicRepoCount?: number;
   }): Promise<void> {
-    // Fresh-read avoids stale module-cache clobbering across extension contexts.
-    const current = await readStoredConfig();
-    const maxTagsPerRepo = patch.maxTagsPerRepo === undefined
-      ? current.maxTagsPerRepo
-      : normalizeMaxTagsPerRepo(patch.maxTagsPerRepo, current.autoTagLimit);
-    const minTopicRepoCount = patch.minTopicRepoCount === undefined
-      ? current.minTopicRepoCount
-      : normalizeMinTopicRepoCount(patch.minTopicRepoCount);
-    await write({
-      ...current,
-      autoTagLimit: maxTagsPerRepo,
-      maxTagsPerRepo,
-      minTopicRepoCount,
+    await mutateStoredConfig((current) => {
+      const maxTagsPerRepo = patch.maxTagsPerRepo === undefined
+        ? current.maxTagsPerRepo
+        : normalizeMaxTagsPerRepo(patch.maxTagsPerRepo, current.autoTagLimit);
+      const minTopicRepoCount = patch.minTopicRepoCount === undefined
+        ? current.minTopicRepoCount
+        : normalizeMinTopicRepoCount(patch.minTopicRepoCount);
+      return {
+        ...current,
+        autoTagLimit: maxTagsPerRepo,
+        maxTagsPerRepo,
+        minTopicRepoCount,
+      };
     });
   },
 
   async updateLibraryViewPrefs(libraryView: Config['libraryView']): Promise<void> {
-    // Fresh-read avoids stale module-cache clobbering across extension contexts.
-    // This remains last-write-wins, not transactional compare-and-swap.
-    const current = await readStoredConfig();
-    await write({
+    await mutateStoredConfig((current) => ({
       ...current,
       libraryView: normalizeLibraryViewPrefs(libraryView),
-    });
+    }));
   },
 };
 

--- a/src/auth/token-probe.ts
+++ b/src/auth/token-probe.ts
@@ -12,6 +12,19 @@ import {
   TOKEN_GIST_PROBE_BAD_SHAPE,
   TOKEN_GIST_CLEANUP_STATUS,
   TOKEN_GIST_CLEANUP_NETWORK,
+  TOKEN_WATCHING_FORBIDDEN,
+  TOKEN_WATCHING_BAD_SHAPE,
+  TOKEN_WATCHING_STATUS,
+  TOKEN_WATCHING_NETWORK,
+  WATCH_TOKEN_REJECTED,
+  WATCH_TOKEN_ACCOUNT_MISMATCH,
+  WATCH_TOKEN_PROFILE_STATUS,
+  WATCH_TOKEN_PROFILE_BAD_SHAPE,
+  WATCH_TOKEN_PROFILE_NETWORK,
+  WATCH_TOKEN_NOTIFICATIONS_FORBIDDEN,
+  WATCH_TOKEN_NOTIFICATIONS_STATUS,
+  WATCH_TOKEN_NOTIFICATIONS_NETWORK,
+  WATCH_TOKEN_NOTIFICATIONS_BAD_SHAPE,
 } from '@/api/errors';
 
 type FetchLike = typeof fetch;
@@ -21,7 +34,12 @@ export interface TokenProbeIdentity {
   avatarUrl: string | null;
   displayName: string | null;
   scopesHeader: string;
+  watching: TokenWatchingCapability;
 }
+
+export type TokenWatchingCapability =
+  | { available: true }
+  | { available: false; errorCode: string };
 
 const API = 'https://api.github.com';
 
@@ -103,10 +121,89 @@ export async function probeTokenCapabilities(
   if (cleanup.status === 403 || cleanup.status === 404) throw new Error(TOKEN_GISTS_FORBIDDEN);
   if (!cleanup.ok) throw new Error(`${TOKEN_GIST_CLEANUP_STATUS}${cleanup.status}`);
 
+  let watching: TokenWatchingCapability;
+  try {
+    const response = await fetchImpl(`${API}/user/subscriptions?per_page=1&page=1`, {
+      headers: auth,
+      cache: 'no-store',
+    });
+    if (response.ok) {
+      try {
+        watching = Array.isArray(await response.json())
+          ? { available: true }
+          : { available: false, errorCode: TOKEN_WATCHING_BAD_SHAPE };
+      } catch {
+        watching = { available: false, errorCode: TOKEN_WATCHING_BAD_SHAPE };
+      }
+    } else if (response.status === 403) {
+      watching = { available: false, errorCode: TOKEN_WATCHING_FORBIDDEN };
+    } else {
+      watching = { available: false, errorCode: `${TOKEN_WATCHING_STATUS}${response.status}` };
+    }
+  } catch {
+    watching = { available: false, errorCode: TOKEN_WATCHING_NETWORK };
+  }
+
   return {
     login: body.login,
     avatarUrl: body.avatar_url ?? null,
     displayName: body.name ?? null,
     scopesHeader,
+    watching,
   };
+}
+
+export async function probeWatchNotificationsToken(
+  token: string,
+  expectedLogin: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<{ login: string }> {
+  const auth = authHeaders(token);
+  const profile = await fetchWithCode(
+    fetchImpl,
+    `${API}/user`,
+    { headers: auth, cache: 'no-store' },
+    WATCH_TOKEN_PROFILE_NETWORK,
+  );
+  if (profile.status === 401) throw new Error(WATCH_TOKEN_REJECTED);
+  if (!profile.ok) throw new Error(`${WATCH_TOKEN_PROFILE_STATUS}${profile.status}`);
+  let profileBody: unknown;
+  try {
+    profileBody = await profile.json();
+  } catch {
+    throw new Error(WATCH_TOKEN_PROFILE_BAD_SHAPE);
+  }
+  const login = profileBody && typeof profileBody === 'object' && !Array.isArray(profileBody)
+    ? (profileBody as { login?: unknown }).login
+    : null;
+  if (typeof login !== 'string' || !login.trim()) {
+    throw new Error(WATCH_TOKEN_PROFILE_BAD_SHAPE);
+  }
+  if (login.trim().toLowerCase() !== expectedLogin.trim().toLowerCase()) {
+    throw new Error(WATCH_TOKEN_ACCOUNT_MISMATCH);
+  }
+
+  const notifications = await fetchWithCode(
+    fetchImpl,
+    `${API}/notifications?all=true&per_page=1`,
+    { headers: auth, cache: 'no-store' },
+    WATCH_TOKEN_NOTIFICATIONS_NETWORK,
+  );
+  if (notifications.status === 401) throw new Error(WATCH_TOKEN_REJECTED);
+  if (notifications.status === 403 || notifications.status === 404) {
+    throw new Error(WATCH_TOKEN_NOTIFICATIONS_FORBIDDEN);
+  }
+  if (!notifications.ok) {
+    throw new Error(`${WATCH_TOKEN_NOTIFICATIONS_STATUS}${notifications.status}`);
+  }
+  let notificationsBody: unknown;
+  try {
+    notificationsBody = await notifications.json();
+  } catch {
+    throw new Error(WATCH_TOKEN_NOTIFICATIONS_BAD_SHAPE);
+  }
+  if (!Array.isArray(notificationsBody)) {
+    throw new Error(WATCH_TOKEN_NOTIFICATIONS_BAD_SHAPE);
+  }
+  return { login: login.trim() };
 }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,6 +1,12 @@
-import { authStore, CONFIG_STORAGE_KEY } from "@/auth/auth-store";
+import {
+  authStore,
+  CONFIG_STORAGE_KEY,
+  GITHUB_CREDENTIALS_STORAGE_KEY,
+} from "@/auth/auth-store";
 import { canonicalJson, sha256Base64Url } from '@/agent-harness/canonical-json';
 import { githubStarSource } from "@/api/github-star-source";
+import { fetchGitHubNotifications } from '@/api/github-notifications-source';
+import { fetchGitHubWatchScope } from '@/api/github-watch-scope-source';
 import { getMessages } from "@/i18n";
 import {
   addBgsmAgentManualTags,
@@ -8,6 +14,7 @@ import {
   resetDirtyForDev,
 } from "@/storage/idb-tag-store";
 import { db } from "@/storage/db";
+import * as watchStore from '@/storage/watch-store';
 import { DEV } from "@/dev";
 import { attachDevTracePort } from '@/agent-observability/dev-port';
 import { createDevAgentTurnTraceFactory } from '@/agent-observability/agent-turn-trace';
@@ -46,6 +53,8 @@ import {
   createQueuedAgentVisibleTagRemovalWriter,
 } from "./agent-manual-tag-writer";
 import { createSerializedRunner } from "./serialized-runner";
+import { createWatchRefreshCoordinator } from './watch-refresh';
+import { canonicalRepositoryFullName } from '@/watch/watch-model';
 import {
   createOrganizeApplyPump,
   type OrganizeApplyPumpLifecycleEvent,
@@ -247,6 +256,12 @@ type Req =
   | { type: "gistPush" }
   | { type: "gistPull" }
   | { type: "getStatus" }
+  | { type: "getWatchStatus" }
+  | { type: "queryWatchInbox"; unreadOnly?: unknown }
+  | { type: "getWatchRepositoryDetail"; fullName?: unknown }
+  | { type: "refreshWatchInbox" }
+  | { type: "disconnectWatchInbox" }
+  | { type: "clearWatchData" }
   | { type: "getUsername" }
   | { type: "getAccount" }
   | { type: "fetchAccount" }
@@ -292,6 +307,30 @@ type Res = { ok: true; data?: unknown } | {
 };
 
 const jobQueue = createSerializedRunner();
+const watchRefreshCoordinator = createWatchRefreshCoordinator({
+  runSerialized: (operation) => jobQueue.run(operation),
+  auth: authStore,
+  fetchScope: fetchGitHubWatchScope,
+  fetchNotifications: fetchGitHubNotifications,
+  loadLiveRepositoryNames: async () => (await db.stars.toArray())
+    .filter((star) => !star.tombstone)
+    .map((star) => star.full_name),
+  store: {
+    getState: watchStore.getWatchState,
+    getRepositories: watchStore.getWatchRepositories,
+    queryInbox: watchStore.queryStoredWatchInbox,
+    reconcileAccount: watchStore.reconcileWatchAccount,
+    reconcileLiveStars: watchStore.reconcileWatchLiveStars,
+    replaceScope: watchStore.replaceWatchScope,
+    recordScopeFailure: watchStore.recordWatchScopeFailure,
+    replaceInbox: watchStore.replaceWatchInbox,
+    revalidateInbox: watchStore.revalidateWatchInbox,
+    recordInboxFailure: watchStore.recordWatchInboxFailure,
+    disconnectInbox: watchStore.disconnectWatchInbox,
+    clearData: watchStore.clearWatchData,
+  },
+  broadcastChanged: broadcastWatchChanged,
+});
 const agentManualTagWriter = createQueuedAgentManualTagWriter({
   runSerialized: (operation, runOptions) => jobQueue.run(operation, runOptions),
   isBlocked: async () => organizeApplyBlocksAgentWrites(await getActiveOrganizeJob()),
@@ -399,6 +438,18 @@ if (DEV) {
     }
   });
 }
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  if (areaName !== 'local') return;
+  const configChange = changes[CONFIG_STORAGE_KEY] ??
+    changes[GITHUB_CREDENTIALS_STORAGE_KEY];
+  if (!configChange || !watchMainAccountChanged(configChange)) return;
+
+  // The coordinator clears the account-bound token and IDB stores through the
+  // shared queue. Wrapping it in another queued operation would deadlock it.
+  void watchRefreshCoordinator.reconcileAccount({
+    invalidateNotificationsIdentity: watchNotificationsIdentity(configChange.oldValue),
+  }).catch(() => {});
+});
 const organizeJobRunConnections = createBgsmOrganizeJobConnectionRegistry<chrome.runtime.Port>();
 let organizeJobRunMutationTail: Promise<void> = Promise.resolve();
 let pendingDurableOrganizeJobId: OrganizeJobId | null = null;
@@ -413,6 +464,7 @@ const devRawCaptureCoordinator = DEV
   ? createDevRawCaptureCoordinator({
       getConfiguredSecrets: async () => Promise.all([
         authStore.getToken(),
+        authStore.getWatchNotificationsToken(),
         authStore.getAgentApiKey(),
       ]),
     })
@@ -1058,6 +1110,51 @@ function broadcastDataChanged() {
   chrome.runtime.sendMessage({ type: "dataChanged" }).catch(() => {});
 }
 
+function broadcastWatchChanged() {
+  chrome.runtime.sendMessage({ type: 'watchChanged' }).catch(() => {});
+}
+
+async function reconcileWatchScopeAfterStarsChange(): Promise<void> {
+  try {
+    if (await watchStore.reconcileWatchLiveStars(await authStore.getUsername())) {
+      broadcastWatchChanged();
+    }
+  } catch {
+    // Watch is optional; a local cleanup failure must not fail a Stars mutation.
+  }
+}
+
+function watchAccountLogin(config: unknown): string | null {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) return null;
+  const username = (config as { username?: unknown }).username;
+  if (typeof username !== 'string') return null;
+  const normalized = username.trim().toLowerCase();
+  return normalized || null;
+}
+
+function watchMainAccountChanged(change: { oldValue?: unknown; newValue?: unknown }): boolean {
+  const previous = watchAccountLogin(change.oldValue);
+  const next = watchAccountLogin(change.newValue);
+  return previous !== next && (previous !== null || next !== null);
+}
+
+function watchNotificationsIdentity(config: unknown): string | null {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) return null;
+  const value = config as {
+    watchNotificationsTokenEncrypted?: unknown;
+    watchNotificationsTokenCryptoMeta?: unknown;
+  };
+  if (
+    typeof value.watchNotificationsTokenEncrypted !== 'string' ||
+    !value.watchNotificationsTokenEncrypted ||
+    !value.watchNotificationsTokenCryptoMeta
+  ) return null;
+  return JSON.stringify([
+    value.watchNotificationsTokenEncrypted,
+    value.watchNotificationsTokenCryptoMeta,
+  ]);
+}
+
 type BgsmAgentTurnResult = {
   turnAttemptId: string;
   sessionId: string;
@@ -1602,6 +1699,7 @@ async function performFullSyncJob() {
     message: m.background.fetchingPages(1),
   });
   const result = await githubStarSource.syncFull((p) => setProgress(p));
+  await reconcileWatchScopeAfterStarsChange();
   broadcastDataChanged();
   setIdleMessage(m.background.fullDone(result.added));
   return result;
@@ -1720,7 +1818,9 @@ async function handle(req: Req): Promise<Res> {
             total: null,
             message: m.background.incrementalSyncing,
           });
-          return githubStarSource.syncIncremental();
+          const syncResult = await githubStarSource.syncIncremental();
+          await reconcileWatchScopeAfterStarsChange();
+          return syncResult;
         });
         broadcastDataChanged();
         setIdleMessage(m.background.incrementalDone(result.added));
@@ -1744,7 +1844,9 @@ async function handle(req: Req): Promise<Res> {
             total: null,
             message: m.background.rescanningPages(1),
           });
-          return githubStarSource.syncRescan((p) => setProgress(p));
+          const syncResult = await githubStarSource.syncRescan((p) => setProgress(p));
+          await reconcileWatchScopeAfterStarsChange();
+          return syncResult;
         });
         broadcastDataChanged();
         setIdleMessage(
@@ -1822,6 +1924,63 @@ async function handle(req: Req): Promise<Res> {
       }
       case "getStatus":
         return { ok: true, data: await getStatusPayload() };
+      case 'getWatchStatus': {
+        try {
+          return { ok: true, data: await watchRefreshCoordinator.getStatus() };
+        } catch {
+          return { ok: false, error: 'Watch status is unavailable.' };
+        }
+      }
+      case 'queryWatchInbox': {
+        if (req.unreadOnly !== undefined && typeof req.unreadOnly !== 'boolean') {
+          return { ok: false, error: 'Invalid Watch inbox query.' };
+        }
+        const unreadOnly = req.unreadOnly ?? true;
+        try {
+          return { ok: true, data: await watchRefreshCoordinator.queryInbox(unreadOnly) };
+        } catch {
+          return { ok: false, error: 'Watch inbox is unavailable.' };
+        }
+      }
+      case 'getWatchRepositoryDetail': {
+        const fullName = canonicalRepositoryFullName(req.fullName);
+        if (!fullName) return { ok: false, error: 'Invalid Watch repository.' };
+        try {
+          const star = await db.stars
+            .filter((row) => !row.tombstone && row.full_name.toLowerCase() === fullName)
+            .first();
+          return {
+            ok: true,
+            data: {
+              star: star ?? null,
+              tag: star ? (await idbTagStore.get(star.full_name)) ?? null : null,
+            },
+          };
+        } catch {
+          return { ok: false, error: 'Watch repository detail is unavailable.' };
+        }
+      }
+      case 'refreshWatchInbox': {
+        try {
+          return { ok: true, data: await watchRefreshCoordinator.refresh() };
+        } catch {
+          return { ok: false, error: 'Watch refresh failed.' };
+        }
+      }
+      case 'disconnectWatchInbox': {
+        try {
+          return { ok: true, data: await watchRefreshCoordinator.disconnectInbox() };
+        } catch {
+          return { ok: false, error: 'Watch Inbox disconnect failed.' };
+        }
+      }
+      case 'clearWatchData': {
+        try {
+          return { ok: true, data: await watchRefreshCoordinator.clearData() };
+        } catch {
+          return { ok: false, error: 'Watch data could not be cleared.' };
+        }
+      }
       case "getUsername":
         return { ok: true, data: { username: await authStore.getUsername() } };
       case "getAccount":
@@ -1910,6 +2069,7 @@ async function handle(req: Req): Promise<Res> {
           if (!star) return null;
           await githubStarSource.unstar(req.full_name);
           await db.stars.put({ ...star, tombstone: true });
+          await reconcileWatchScopeAfterStarsChange();
           return { full_name: req.full_name, tombstone: true };
         });
         if (!result)

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -440,14 +440,15 @@ if (DEV) {
 }
 chrome.storage.onChanged.addListener((changes, areaName) => {
   if (areaName !== 'local') return;
-  const configChange = changes[CONFIG_STORAGE_KEY] ??
-    changes[GITHUB_CREDENTIALS_STORAGE_KEY];
-  if (!configChange || !watchMainAccountChanged(configChange)) return;
+  // Both keys can change atomically; the dedicated credential record owns identity.
+  const credentialsChange = changes[GITHUB_CREDENTIALS_STORAGE_KEY];
+  const accountChange = credentialsChange ?? changes[CONFIG_STORAGE_KEY];
+  if (!accountChange || !watchMainAccountChanged(accountChange)) return;
 
   // The coordinator clears the account-bound token and IDB stores through the
   // shared queue. Wrapping it in another queued operation would deadlock it.
   void watchRefreshCoordinator.reconcileAccount({
-    invalidateNotificationsIdentity: watchNotificationsIdentity(configChange.oldValue),
+    invalidateNotificationsIdentity: watchNotificationsIdentity(accountChange.oldValue),
   }).catch(() => {});
 });
 const organizeJobRunConnections = createBgsmOrganizeJobConnectionRegistry<chrome.runtime.Port>();
@@ -1925,26 +1926,29 @@ async function handle(req: Req): Promise<Res> {
       case "getStatus":
         return { ok: true, data: await getStatusPayload() };
       case 'getWatchStatus': {
+        const m = await getLocaleMessages();
         try {
           return { ok: true, data: await watchRefreshCoordinator.getStatus() };
         } catch {
-          return { ok: false, error: 'Watch status is unavailable.' };
+          return { ok: false, error: m.background.watchStatusUnavailable };
         }
       }
       case 'queryWatchInbox': {
+        const m = await getLocaleMessages();
         if (req.unreadOnly !== undefined && typeof req.unreadOnly !== 'boolean') {
-          return { ok: false, error: 'Invalid Watch inbox query.' };
+          return { ok: false, error: m.background.watchInboxQueryInvalid };
         }
         const unreadOnly = req.unreadOnly ?? true;
         try {
           return { ok: true, data: await watchRefreshCoordinator.queryInbox(unreadOnly) };
         } catch {
-          return { ok: false, error: 'Watch inbox is unavailable.' };
+          return { ok: false, error: m.background.watchInboxUnavailable };
         }
       }
       case 'getWatchRepositoryDetail': {
+        const m = await getLocaleMessages();
         const fullName = canonicalRepositoryFullName(req.fullName);
-        if (!fullName) return { ok: false, error: 'Invalid Watch repository.' };
+        if (!fullName) return { ok: false, error: m.background.watchRepositoryInvalid };
         try {
           const star = await db.stars
             .filter((row) => !row.tombstone && row.full_name.toLowerCase() === fullName)
@@ -1957,28 +1961,31 @@ async function handle(req: Req): Promise<Res> {
             },
           };
         } catch {
-          return { ok: false, error: 'Watch repository detail is unavailable.' };
+          return { ok: false, error: m.background.watchRepositoryDetailUnavailable };
         }
       }
       case 'refreshWatchInbox': {
+        const m = await getLocaleMessages();
         try {
           return { ok: true, data: await watchRefreshCoordinator.refresh() };
         } catch {
-          return { ok: false, error: 'Watch refresh failed.' };
+          return { ok: false, error: m.background.watchRefreshFailed };
         }
       }
       case 'disconnectWatchInbox': {
+        const m = await getLocaleMessages();
         try {
           return { ok: true, data: await watchRefreshCoordinator.disconnectInbox() };
         } catch {
-          return { ok: false, error: 'Watch Inbox disconnect failed.' };
+          return { ok: false, error: m.background.watchDisconnectFailed };
         }
       }
       case 'clearWatchData': {
+        const m = await getLocaleMessages();
         try {
           return { ok: true, data: await watchRefreshCoordinator.clearData() };
         } catch {
-          return { ok: false, error: 'Watch data could not be cleared.' };
+          return { ok: false, error: m.background.watchDataClearFailed };
         }
       }
       case "getUsername":

--- a/src/background/watch-refresh.ts
+++ b/src/background/watch-refresh.ts
@@ -1,0 +1,409 @@
+import type { authStore } from '@/auth/auth-store';
+import {
+  WATCH_DEFAULT_POLL_INTERVAL_SECONDS,
+  WATCH_MAX_POLL_INTERVAL_SECONDS,
+  type fetchGitHubNotifications,
+} from '@/api/github-notifications-source';
+import type { fetchGitHubWatchScope } from '@/api/github-watch-scope-source';
+import type {
+  clearWatchData,
+  disconnectWatchInbox,
+  getWatchRepositories,
+  getWatchState,
+  queryStoredWatchInbox,
+  reconcileWatchAccount,
+  reconcileWatchLiveStars,
+  recordWatchInboxFailure,
+  recordWatchScopeFailure,
+  replaceWatchInbox,
+  replaceWatchScope,
+  revalidateWatchInbox,
+} from '@/storage/watch-store';
+import {
+  GitHubWatchError,
+  canonicalRepositoryFullName,
+  projectWatchInbox,
+  type GitHubNotificationThread,
+} from '@/watch/watch-model';
+import type {
+  WatchInboxQueryResponse,
+  WatchRefreshResult,
+  WatchStatus,
+} from '@/watch/watch-contract';
+
+type WatchAuth = Pick<typeof authStore,
+  | 'getGitHubCredentialSnapshot'
+  | 'clearWatchNotificationsToken'
+>;
+
+export interface WatchRefreshCoordinatorDependencies {
+  runSerialized<T>(operation: () => Promise<T>): Promise<T>;
+  auth: WatchAuth;
+  fetchScope: typeof fetchGitHubWatchScope;
+  fetchNotifications: typeof fetchGitHubNotifications;
+  loadLiveRepositoryNames(): Promise<string[]>;
+  store: {
+    getState: typeof getWatchState;
+    getRepositories: typeof getWatchRepositories;
+    queryInbox: typeof queryStoredWatchInbox;
+    reconcileAccount: typeof reconcileWatchAccount;
+    reconcileLiveStars: typeof reconcileWatchLiveStars;
+    replaceScope: typeof replaceWatchScope;
+    recordScopeFailure: typeof recordWatchScopeFailure;
+    replaceInbox: typeof replaceWatchInbox;
+    revalidateInbox: typeof revalidateWatchInbox;
+    recordInboxFailure: typeof recordWatchInboxFailure;
+    disconnectInbox: typeof disconnectWatchInbox;
+    clearData: typeof clearWatchData;
+  };
+  now?: () => number;
+  broadcastChanged(): void;
+}
+
+export interface WatchRefreshCoordinator {
+  getStatus(): Promise<WatchStatus>;
+  queryInbox(unreadOnly: boolean): Promise<WatchInboxQueryResponse>;
+  refresh(): Promise<WatchRefreshResult>;
+  disconnectInbox(): Promise<WatchStatus>;
+  clearData(): Promise<WatchStatus>;
+  reconcileAccount(options?: {
+    invalidateNotificationsIdentity?: string | null;
+  }): Promise<void>;
+  isRefreshing(): boolean;
+}
+
+type AuthSnapshot = Awaited<ReturnType<WatchAuth['getGitHubCredentialSnapshot']>>;
+
+type RefreshOutcome = Omit<WatchRefreshResult, 'status'>;
+
+function stableErrorCode(error: unknown): string {
+  return error instanceof GitHubWatchError ? error.code : 'internal_error';
+}
+
+function nextAllowedAt(attemptedAtMs: number, pollIntervalSeconds: number): string {
+  const seconds = Number.isSafeInteger(pollIntervalSeconds) &&
+    pollIntervalSeconds > 0 &&
+    pollIntervalSeconds <= WATCH_MAX_POLL_INTERVAL_SECONDS
+    ? pollIntervalSeconds
+    : WATCH_DEFAULT_POLL_INTERVAL_SECONDS;
+  return new Date(attemptedAtMs + seconds * 1_000).toISOString();
+}
+
+export function createWatchRefreshCoordinator(
+  dependencies: WatchRefreshCoordinatorDependencies,
+): WatchRefreshCoordinator {
+  const now = dependencies.now ?? Date.now;
+  let inFlight: { identity: string; promise: Promise<WatchRefreshResult> } | null = null;
+
+  async function readAuth(): Promise<AuthSnapshot> {
+    return dependencies.auth.getGitHubCredentialSnapshot();
+  }
+
+  async function sameCredentials(
+    snapshot: AuthSnapshot,
+    includeNotifications: boolean,
+  ): Promise<boolean> {
+    const latest = await readAuth();
+    return latest.accountLogin === snapshot.accountLogin &&
+      latest.mainToken !== null &&
+      latest.mainIdentity === snapshot.mainIdentity &&
+      (!includeNotifications || (
+        latest.notificationsToken === snapshot.notificationsToken &&
+        latest.notificationsIdentity === snapshot.notificationsIdentity
+      ));
+  }
+
+  function refreshIdentity(auth: AuthSnapshot): string {
+    return JSON.stringify([
+      auth.accountLogin,
+      auth.mainIdentity,
+      auth.notificationsIdentity,
+      auth.mainToken !== null,
+      auth.notificationsConfigured,
+    ]);
+  }
+
+  function sameAuthSnapshot(left: AuthSnapshot, right: AuthSnapshot): boolean {
+    return refreshIdentity(left) === refreshIdentity(right);
+  }
+
+  async function deriveStatusForAuth(
+    auth: AuthSnapshot,
+    refreshing: boolean,
+    stateOverride?: WatchStatus['state'],
+  ): Promise<WatchStatus> {
+    const hasMainToken = !!(auth.accountLogin && auth.mainToken);
+    const hasNotificationsToken = !!auth.notificationsToken;
+    const state = stateOverride === undefined && hasMainToken && auth.accountLogin
+      ? await dependencies.store.getState(auth.accountLogin)
+      : stateOverride ?? null;
+    const scopeStatus: WatchStatus['scopeStatus'] = !hasMainToken
+      ? 'not_configured'
+      : !state?.scope.lastSuccessfulAt
+        ? state?.scope.errorCode ? 'error' : 'never_loaded'
+        : state.scope.errorCode ? 'stale' : 'fresh';
+    let inboxStatus: WatchStatus['inboxStatus'];
+    if (!hasNotificationsToken) {
+      inboxStatus = 'not_configured';
+    } else if (!state?.scope.lastSuccessfulAt) {
+      inboxStatus = 'scope_unavailable';
+    } else if (!state.inbox.lastSuccessfulAt) {
+      inboxStatus = state.inbox.errorCode ? 'error' : 'never_loaded';
+    } else if (state.inbox.errorCode) {
+      inboxStatus = 'stale';
+    } else if (
+      state.inbox.nextAllowedAt &&
+      Date.parse(state.inbox.nextAllowedAt) > now()
+    ) {
+      inboxStatus = 'cooldown';
+    } else {
+      inboxStatus = 'fresh';
+    }
+    return {
+      accountLogin: auth.accountLogin,
+      hasMainToken,
+      hasNotificationsToken,
+      refreshing,
+      scopeStatus,
+      inboxStatus,
+      state,
+    };
+  }
+
+  async function deriveStatus(refreshing = inFlight !== null): Promise<WatchStatus> {
+    return deriveStatusForAuth(await readAuth(), refreshing);
+  }
+
+  async function queryInbox(unreadOnly: boolean): Promise<WatchInboxQueryResponse> {
+    const auth = await readAuth();
+    const accountLogin = auth.mainToken
+      ? auth.accountLogin
+      : null;
+    const result = await dependencies.store.queryInbox({ accountLogin, unreadOnly });
+    const latest = await readAuth();
+    if (!sameAuthSnapshot(auth, latest)) {
+      return {
+        ...projectWatchInbox([], { unreadOnly }),
+        status: await deriveStatusForAuth(latest, inFlight !== null),
+      };
+    }
+    return {
+      threads: result.threads,
+      groups: result.groups,
+      unreadCount: result.unreadCount,
+      totalCount: result.totalCount,
+      status: await deriveStatusForAuth(auth, inFlight !== null, result.state),
+    };
+  }
+
+  async function performRefresh(auth: AuthSnapshot): Promise<RefreshOutcome> {
+    const empty: RefreshOutcome = {
+      scopePublished: false,
+      inboxPublished: false,
+      notModified: false,
+    };
+    if (!auth.accountLogin || !auth.mainToken || !await sameCredentials(auth, true)) {
+      return empty;
+    }
+    const refreshStartedAt = now();
+    const attemptedAt = new Date(refreshStartedAt).toISOString();
+    const previousState = await dependencies.store.getState(auth.accountLogin);
+    if (
+      previousState?.inbox.nextAllowedAt &&
+      Date.parse(previousState.inbox.nextAllowedAt) > refreshStartedAt
+    ) return empty;
+
+    let changed = false;
+    let scopeAvailable = false;
+    let scopeNames = new Set<string>();
+    let scopePublished = false;
+    try {
+      const [remoteScope, liveNames] = await Promise.all([
+        dependencies.fetchScope({ token: auth.mainToken, now: () => refreshStartedAt }),
+        dependencies.loadLiveRepositoryNames(),
+      ]);
+      if (!await sameCredentials(auth, false)) return empty;
+      const live = new Set(liveNames.flatMap((name) => {
+        const canonical = canonicalRepositoryFullName(name);
+        return canonical ? [canonical] : [];
+      }));
+      const repositories = remoteScope.repositories.filter((repository) => live.has(repository.full_name));
+      await dependencies.store.replaceScope({
+        accountLogin: auth.accountLogin,
+        repositories,
+        attemptedAt,
+        successfulAt: remoteScope.fetchedAt,
+      });
+      scopeNames = new Set(repositories.map((repository) => repository.full_name));
+      scopeAvailable = true;
+      scopePublished = true;
+      changed = true;
+    } catch (error) {
+      if (!await sameCredentials(auth, false)) return empty;
+      await dependencies.store.recordScopeFailure({
+        accountLogin: auth.accountLogin,
+        attemptedAt,
+        errorCode: stableErrorCode(error),
+      });
+      changed = true;
+      const state = await dependencies.store.getState(auth.accountLogin);
+      if (state?.scope.lastSuccessfulAt) {
+        const repositories = await dependencies.store.getRepositories(auth.accountLogin);
+        scopeNames = new Set(repositories.map((repository) => repository.full_name));
+        scopeAvailable = true;
+      }
+    }
+
+    let inboxPublished = false;
+    let notModified = false;
+    if (auth.notificationsToken && scopeAvailable && await sameCredentials(auth, true)) {
+      const state = await dependencies.store.getState(auth.accountLogin);
+      try {
+        const snapshot = await dependencies.fetchNotifications({
+          token: auth.notificationsToken,
+          before: refreshStartedAt,
+          lastModified: state?.inbox.lastModified ?? null,
+          now: () => refreshStartedAt,
+        });
+        if (!await sameCredentials(auth, true)) {
+          if (changed) dependencies.broadcastChanged();
+          return { ...empty, scopePublished };
+        }
+        const allowedThreads: GitHubNotificationThread[] = snapshot.threads.filter((thread) => (
+          scopeNames.has(thread.repositoryFullName)
+        ));
+        const allowedAt = nextAllowedAt(now(), snapshot.pollIntervalSeconds);
+        if (snapshot.notModified) {
+          await dependencies.store.revalidateInbox({
+            accountLogin: auth.accountLogin,
+            attemptedAt,
+            successfulAt: snapshot.fetchedAt,
+            nextAllowedAt: allowedAt,
+            lastModified: snapshot.lastModified,
+          });
+          notModified = true;
+        } else {
+          await dependencies.store.replaceInbox({
+            accountLogin: auth.accountLogin,
+            threads: allowedThreads,
+            attemptedAt,
+            successfulAt: snapshot.fetchedAt,
+            lastModified: snapshot.lastModified,
+            nextAllowedAt: allowedAt,
+            candidateCount: snapshot.candidateCount,
+            truncated: snapshot.truncated,
+          });
+          inboxPublished = true;
+        }
+        changed = true;
+      } catch (error) {
+        if (await sameCredentials(auth, true)) {
+          await dependencies.store.recordInboxFailure({
+            accountLogin: auth.accountLogin,
+            attemptedAt,
+            errorCode: stableErrorCode(error),
+          });
+          changed = true;
+        }
+      }
+    }
+    if (changed) dependencies.broadcastChanged();
+    return { scopePublished, inboxPublished, notModified };
+  }
+
+  async function refresh(): Promise<WatchRefreshResult> {
+    await reconcileAccount();
+    const requestedAuth = await readAuth();
+    const identity = refreshIdentity(requestedAuth);
+    const current = inFlight;
+    if (current) {
+      if (current.identity === identity) return current.promise;
+      try {
+        await current.promise;
+      } catch {
+        // The new credential identity still deserves its own queued attempt.
+      }
+      if (inFlight === current) inFlight = null;
+      return refresh();
+    }
+
+    const operation = dependencies.runSerialized(() => performRefresh(requestedAuth));
+    const promise = operation.then(async (outcome) => ({
+      ...outcome,
+      status: await deriveStatus(false),
+    }));
+    inFlight = { identity, promise };
+    void promise.finally(() => {
+      if (inFlight?.promise === promise) inFlight = null;
+    }).catch(() => {});
+    return promise;
+  }
+
+  async function disconnectInboxCommand(): Promise<WatchStatus> {
+    await reconcileAccount();
+    await dependencies.runSerialized(async () => {
+      const auth = await readAuth();
+      await dependencies.auth.clearWatchNotificationsToken();
+      await dependencies.store.disconnectInbox(auth.accountLogin);
+      dependencies.broadcastChanged();
+    });
+    return deriveStatus(false);
+  }
+
+  async function clearDataCommand(): Promise<WatchStatus> {
+    await reconcileAccount();
+    await dependencies.runSerialized(async () => {
+      await dependencies.auth.clearWatchNotificationsToken();
+      await dependencies.store.clearData();
+      dependencies.broadcastChanged();
+    });
+    return deriveStatus(false);
+  }
+
+  async function reconcileAccount(options: {
+    invalidateNotificationsIdentity?: string | null;
+  } = {}): Promise<void> {
+    await dependencies.runSerialized(async () => {
+      const auth = await readAuth();
+      const dataCleared = await dependencies.store.reconcileAccount(auth.accountLogin);
+      const scopePruned = !dataCleared && auth.accountLogin
+        ? await dependencies.store.reconcileLiveStars(auth.accountLogin)
+        : false;
+      const shouldClearNotifications = !auth.accountLogin || (
+        !!options.invalidateNotificationsIdentity &&
+        auth.notificationsConfigured &&
+        auth.notificationsIdentity === options.invalidateNotificationsIdentity
+      );
+      let credentialsCleared = false;
+      if (shouldClearNotifications) {
+        const latest = await readAuth();
+        if (
+          !latest.accountLogin || (
+            latest.notificationsConfigured &&
+            latest.notificationsIdentity === options.invalidateNotificationsIdentity
+          )
+        ) {
+          await dependencies.auth.clearWatchNotificationsToken();
+          credentialsCleared = true;
+        }
+      }
+      if (dataCleared || scopePruned || credentialsCleared) dependencies.broadcastChanged();
+    });
+  }
+
+  return {
+    async getStatus() {
+      await reconcileAccount();
+      return deriveStatus();
+    },
+    async queryInbox(unreadOnly) {
+      await reconcileAccount();
+      return queryInbox(unreadOnly);
+    },
+    refresh,
+    disconnectInbox: disconnectInboxCommand,
+    clearData: clearDataCommand,
+    reconcileAccount,
+    isRefreshing: () => inFlight !== null,
+  };
+}

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -755,6 +755,14 @@ export interface MessageCatalog {
     gistPushNoChanges: string;
     gistPullDone: (merged: number, total: number) => string;
     gistPullMissing: string;
+    watchStatusUnavailable: string;
+    watchInboxQueryInvalid: string;
+    watchInboxUnavailable: string;
+    watchRepositoryInvalid: string;
+    watchRepositoryDetailUnavailable: string;
+    watchRefreshFailed: string;
+    watchDisconnectFailed: string;
+    watchDataClearFailed: string;
   };
   /** Humanized error strings. Keys are matched against stable error codes thrown
    *  across the codebase (see src/api/errors.ts). `unknown` is the passthrough —
@@ -1752,6 +1760,14 @@ const messages: Record<Locale, MessageCatalog> = {
         `Pulled ${merged} updates from ${total} remote tag records`,
       gistPullMissing:
         "The linked sync Gist was missing; the app unbound it on this device. Push to create a new one.",
+      watchStatusUnavailable: "Watch status is unavailable.",
+      watchInboxQueryInvalid: "Invalid Watch inbox query.",
+      watchInboxUnavailable: "Watch inbox is unavailable.",
+      watchRepositoryInvalid: "Invalid Watch repository.",
+      watchRepositoryDetailUnavailable: "Watch repository detail is unavailable.",
+      watchRefreshFailed: "Watch refresh failed.",
+      watchDisconnectFailed: "Watch Inbox disconnect failed.",
+      watchDataClearFailed: "Watch data could not be cleared.",
     },
     errors: {
       tokenEmpty: "Please paste a token first.",
@@ -2765,6 +2781,14 @@ const messages: Record<Locale, MessageCatalog> = {
         `已从 ${total} 条远端标签记录中合并 ${merged} 条更新`,
       gistPullMissing:
         "已绑定的同步 Gist 不见了；本设备已解绑。你可以点 Push 重新创建。",
+      watchStatusUnavailable: "Watch 状态暂时不可用。",
+      watchInboxQueryInvalid: "Watch 收件箱查询无效。",
+      watchInboxUnavailable: "Watch 收件箱暂时不可用。",
+      watchRepositoryInvalid: "Watch 仓库无效。",
+      watchRepositoryDetailUnavailable: "Watch 仓库详情暂时不可用。",
+      watchRefreshFailed: "Watch 刷新失败。",
+      watchDisconnectFailed: "断开 Watch 收件箱失败。",
+      watchDataClearFailed: "无法清除 Watch 数据。",
     },
     errors: {
       tokenEmpty: "请先粘贴 token。",

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -51,6 +51,60 @@ export interface MessageCatalog {
     backfillSyncRunning: string;
     backfillSyncFailed: (error: string) => string;
   };
+  watch: {
+    starsSurface: string;
+    watchSurface: string;
+    watchSurfaceUnread: (count: number) => string;
+    title: string;
+    filterLabel: string;
+    searchPlaceholder: string;
+    clearSearch: string;
+    reasonFilter: string;
+    reasonFilterSelected: (count: number) => string;
+    reasonFilterClear: string;
+    reasonPresets: string;
+    reasonPresetAll: string;
+    reasonPresetDirect: string;
+    reasonPresetSecurity: string;
+    reasonPresetParticipation: string;
+    reasonPresetWatching: string;
+    reasonPresetOther: string;
+    reasonThreadCount: (count: number) => string;
+    unread: string;
+    all: string;
+    refresh: string;
+    refreshing: string;
+    openOptions: string;
+    configureMainToken: string;
+    configureNotificationsToken: string;
+    scopeNeverLoaded: string;
+    inboxNeverLoaded: string;
+    queryFailed: string;
+    refreshFailed: string;
+    retry: string;
+    scopePermissionDenied: string;
+    inboxPermissionDenied: string;
+    scopeUnavailable: string;
+    noWatchedRepositories: string;
+    noUnreadThreads: string;
+    noThreads: string;
+    noMatchingThreads: string;
+    staleSnapshot: string;
+    scopeFailed: string;
+    inboxFailed: string;
+    truncated: string;
+    cooldownUntil: (time: string) => string;
+    watchedRepositoryCount: (count: number) => string;
+    threadCount: (count: number) => string;
+    snapshotAt: (time: string) => string;
+    manageOnGitHub: string;
+    watchedOnGitHub: string;
+    repositoryUnreadCount: (count: number) => string;
+    openOnGitHub: string;
+    unreadSnapshot: string;
+    expandRepository: (repository: string) => string;
+    collapseRepository: (repository: string) => string;
+  };
   toolbar: {
     searchPlaceholder: string;
     searchClearTitle: string;
@@ -629,6 +683,7 @@ export interface MessageCatalog {
     tokenIntroSuffix: string;
     tokenPublicRepos: string;
     tokenGists: string;
+    tokenWatchingOptional: string;
     tokenGistNote: string;
     authenticatedAs: (username: string) => string;
     openVerifiedStars: string;
@@ -638,7 +693,22 @@ export interface MessageCatalog {
     saveVerify: string;
     verifying: string;
     tokenVerified: (username: string) => string;
+    tokenVerifiedWatchForbidden: (username: string) => string;
+    tokenVerifiedWatchUnverified: (username: string) => string;
     tokenRemoved: string;
+    watchTokenHeading: string;
+    watchTokenIntroPrefix: string;
+    watchTokenLinkLabel: string;
+    watchTokenIntroSuffix: string;
+    watchTokenAccountHint: string;
+    watchTokenLabel: string;
+    watchTokenMainRequired: string;
+    watchTokenConnect: string;
+    watchTokenReplace: string;
+    watchTokenDisconnect: string;
+    watchTokenVerifying: string;
+    watchTokenConnected: (username: string) => string;
+    watchTokenDisconnected: string;
     /** Detailed PAT-creation walkthrough (numbered steps + screenshot captions). */
     tokenStepsTitle: string;
     tokenStep1: string;
@@ -708,6 +778,18 @@ export interface MessageCatalog {
     /** Step 3 cleanup (DELETE /gists/{id}) — best-effort; surfaced as a soft warning. */
     tokenGistCleanupStatus: (status: number | string) => string;
     tokenGistCleanupNetwork: string;
+    watchTokenEmpty: string;
+    watchTokenMainAccountRequired: string;
+    watchTokenRejected: string;
+    watchTokenAccountMismatch: string;
+    watchTokenAccountChanged: string;
+    watchTokenProfileStatus: (status: number | string) => string;
+    watchTokenProfileBadShape: string;
+    watchTokenProfileNetwork: string;
+    watchTokenNotificationsForbidden: string;
+    watchTokenNotificationsStatus: (status: number | string) => string;
+    watchTokenNotificationsNetwork: string;
+    watchTokenNotificationsBadShape: string;
     ghTokenRejected: string;
     ghRateLimit: string;
     ghForbidden: string;
@@ -832,6 +914,60 @@ const messages: Record<Locale, MessageCatalog> = {
       backfillSyncLater: "Later",
       backfillSyncRunning: "Syncing your data…",
       backfillSyncFailed: (error) => `Sync failed: ${error}`,
+    },
+    watch: {
+      starsSurface: "Stars",
+      watchSurface: "Watch",
+      watchSurfaceUnread: (count) => `Watch, ${count} unread ${count === 1 ? "thread" : "threads"}`,
+      title: "Watched stars inbox",
+      filterLabel: "Inbox thread filter",
+      searchPlaceholder: "Search repositories and threads",
+      clearSearch: "Clear Watch search",
+      reasonFilter: "Notification reasons",
+      reasonFilterSelected: (count) => `Notification reasons, ${count} selected`,
+      reasonFilterClear: "Clear reasons",
+      reasonPresets: "Reason presets",
+      reasonPresetAll: "All",
+      reasonPresetDirect: "Direct",
+      reasonPresetSecurity: "Security",
+      reasonPresetParticipation: "Participation",
+      reasonPresetWatching: "Watching",
+      reasonPresetOther: "Other",
+      reasonThreadCount: (count) => `${count} ${count === 1 ? "thread" : "threads"}`,
+      unread: "Unread",
+      all: "All",
+      refresh: "Refresh Watch inbox",
+      refreshing: "Refreshing…",
+      openOptions: "Open options",
+      configureMainToken: "Add Watching: read to the main GitHub token to load watched repositories.",
+      configureNotificationsToken: "Connect a separate classic token with the notifications scope to load Inbox threads.",
+      scopeNeverLoaded: "Refresh to load watched repositories from GitHub.",
+      inboxNeverLoaded: "Refresh to load the latest bounded Inbox snapshot.",
+      queryFailed: "The Watch snapshot could not be loaded.",
+      refreshFailed: "The latest Watch refresh failed; the previous snapshot remains available.",
+      retry: "Retry",
+      scopePermissionDenied: "The main token cannot read Watching. Add the optional Watching: read permission and reconnect it in Options.",
+      inboxPermissionDenied: "The Notifications token cannot read GitHub Inbox. Reconnect a classic token with notifications access in Options.",
+      scopeUnavailable: "The watched-repository scope is not available yet, so Inbox threads cannot be matched.",
+      noWatchedRepositories: "None of the currently starred repositories are watched on GitHub.",
+      noUnreadThreads: "No unread threads in the latest Watch snapshot.",
+      noThreads: "No Inbox threads matched the watched starred repositories in this snapshot.",
+      noMatchingThreads: "No threads match the current Watch search and reason filters.",
+      staleSnapshot: "Showing the last successful snapshot because the latest refresh failed.",
+      scopeFailed: "Watched repositories could not be refreshed.",
+      inboxFailed: "Inbox threads could not be refreshed.",
+      truncated: "This is the newest bounded window; more GitHub threads exist beyond it.",
+      cooldownUntil: (time) => `GitHub asks clients to wait until ${time} before refreshing again.`,
+      watchedRepositoryCount: (count) => `${count} watched starred ${count === 1 ? "repository" : "repositories"}`,
+      threadCount: (count) => `${count} ${count === 1 ? "thread" : "threads"}`,
+      snapshotAt: (time) => `Snapshot checked ${time}`,
+      manageOnGitHub: "Manage Watch settings on GitHub",
+      watchedOnGitHub: "watched on GitHub",
+      repositoryUnreadCount: (count) => `${count} unread`,
+      openOnGitHub: "Open on GitHub",
+      unreadSnapshot: "Unread at the time of this snapshot",
+      expandRepository: (repository) => `Expand ${repository}`,
+      collapseRepository: (repository) => `Collapse ${repository}`,
     },
     toolbar: {
       searchPlaceholder:
@@ -1450,7 +1586,7 @@ const messages: Record<Locale, MessageCatalog> = {
     options: {
       title: "Better GitHub Stars Manager — Options",
       starRepoButton: "Like the project? Leave a star:)",
-      agentHeading: "2. Cubby",
+      agentHeading: "3. Cubby",
       agentIntro:
         "Connect an AI service. Cubby sends requests directly to it and shows the results in the extension.",
       agentServiceLabel: "AI service",
@@ -1513,7 +1649,7 @@ const messages: Record<Locale, MessageCatalog> = {
       agentGrantAccess: "Allow access",
       agentAccessGranted: "Access allowed",
       agentHostAccessRequired: "Allow Chrome access to test or use this custom service.",
-      behaviorHeading: "4. Preference",
+      behaviorHeading: "5. Preference",
       maxTagsPerRepoLabel: "Max Auto Tags per repo",
       maxTagsPerRepoHint:
         "When you run Auto Tags, each repo can receive at most this many topic tags.",
@@ -1530,6 +1666,8 @@ const messages: Record<Locale, MessageCatalog> = {
       tokenPublicRepos:
         "Account · Starring (read/write, for sync and unstar)",
       tokenGists: "Account · Gists (read/write, for cross-device tag sync)",
+      tokenWatchingOptional:
+        "Optional for Watch · Watching (read, to list watched repositories)",
       tokenGistNote:
         "Note: GitHub Gist scope is account-wide (no per-gist isolation for fine-grained tokens). We create one dedicated secret gist for sync.",
       authenticatedAs: (username) => `Authenticated as @${username}.`,
@@ -1540,8 +1678,24 @@ const messages: Record<Locale, MessageCatalog> = {
       clearCachedAuth: "Clear cached auth",
       saveVerify: "Save & verify",
       verifying: "Verifying…",
-      tokenVerified: (username) => `Token verified. Logged in as ${username}. Sync and Gist access checked; unstar also needs Starring read/write.`,
+      tokenVerified: (username) => `Token verified. Logged in as ${username}. Sync, Gist, and Watch access checked; unstar also needs Starring read/write.`,
+      tokenVerifiedWatchForbidden: (username) => `Token saved for ${username}. Sync and Gist access checked, but Watch needs Account · Watching (read). Add that permission, then Save & verify again.`,
+      tokenVerifiedWatchUnverified: (username) => `Token saved for ${username}. Sync and Gist access checked, but Watch access could not be verified. Try Save & verify again; if this persists, confirm Account · Watching (read).`,
       tokenRemoved: "Token removed.",
+      watchTokenHeading: "2. Watch Inbox Token",
+      watchTokenIntroPrefix: "Create a classic PAT with only the notifications scope at",
+      watchTokenLinkLabel: "GitHub token settings",
+      watchTokenIntroSuffix: "This token is used only for the optional Watch Inbox.",
+      watchTokenAccountHint:
+        "It must belong to the same GitHub account as the main token. The extension verifies both identity and Inbox access before saving it.",
+      watchTokenLabel: "Classic Notifications token",
+      watchTokenMainRequired: "Connect a usable main GitHub token first.",
+      watchTokenConnect: "Connect Inbox",
+      watchTokenReplace: "Replace token",
+      watchTokenDisconnect: "Disconnect Inbox",
+      watchTokenVerifying: "Verifying…",
+      watchTokenConnected: (username) => `Watch Inbox connected as @${username}.`,
+      watchTokenDisconnected: "Watch Inbox disconnected and cached threads removed.",
       tokenStepsTitle: "How to create the token (fine-grained PAT)",
       tokenStep1:
         "Open GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens → Generate new token.",
@@ -1550,16 +1704,16 @@ const messages: Record<Locale, MessageCatalog> = {
       tokenStep3:
         'Repository access → select "All public repositories" (the extension reads your starred public repos).',
       tokenStep4:
-        'Account permissions → enable "Starring (read and write)" and "Gists (read and write)". Leave everything else off.',
+        'Account permissions → enable "Starring (read and write)" and "Gists (read and write)". Optionally enable "Watching (read)" for Watch.',
       tokenStep5:
         "Generate → copy the token (starts with github_pat_…) → paste it above → Save & verify.",
       shotNewToken: 'Screenshot: the "Generate new token" form',
       shotRepoAccess:
         "Screenshot: repository access set to all public repositories",
       shotPermissions:
-        "Screenshot: account permissions — Starring (read/write) + Gists (read and write)",
+        "Screenshot: account permissions — Starring + Gists, with optional Watching (read)",
       languageLabel: "Language",
-      gistHeading: "3. Gist sync",
+      gistHeading: "4. Gist sync",
       gistBoundPrefix: "Bound to gist",
       gistBoundSuffix:
         "Tags sync to and from this gist. If the same repo is edited in two places, the newer change wins.",
@@ -1627,6 +1781,20 @@ const messages: Record<Locale, MessageCatalog> = {
         `GitHub created the probe Gist but cleanup failed (${status}). Nothing was saved; retry.`,
       tokenGistCleanupNetwork:
         "GitHub created the probe Gist but cleanup could not be confirmed. Nothing was saved; retry.",
+      watchTokenEmpty: "Paste a classic GitHub token first.",
+      watchTokenMainAccountRequired: "Connect the main GitHub account before configuring Watch Inbox.",
+      watchTokenRejected: "GitHub rejected this classic token. Check that you copied the complete value.",
+      watchTokenAccountMismatch: "This classic token belongs to a different GitHub account.",
+      watchTokenAccountChanged: "The main GitHub account changed during verification. Retry with the matching account.",
+      watchTokenProfileStatus: (status) =>
+        `GitHub responded with ${status} while checking the classic token account. Nothing was saved.`,
+      watchTokenProfileBadShape: "GitHub returned an unexpected account response for the classic token.",
+      watchTokenProfileNetwork: "Could not reach GitHub while checking the classic token account.",
+      watchTokenNotificationsForbidden: "This classic token cannot read Notifications. Create one with the notifications scope.",
+      watchTokenNotificationsStatus: (status) =>
+        `GitHub responded with ${status} while checking Notifications access. Nothing was saved.`,
+      watchTokenNotificationsNetwork: "Could not reach GitHub while checking Notifications access.",
+      watchTokenNotificationsBadShape: "GitHub returned an unexpected Notifications response. Nothing was saved.",
       ghTokenRejected: "GitHub rejected the saved token. Re-add it in Options.",
       ghRateLimit: "GitHub rate limit reached. Wait a minute and retry.",
       ghForbidden:
@@ -1766,6 +1934,60 @@ const messages: Record<Locale, MessageCatalog> = {
       backfillSyncLater: "稍后再说",
       backfillSyncRunning: "正在同步数据…",
       backfillSyncFailed: (error) => `同步失败: ${error}`,
+    },
+    watch: {
+      starsSurface: "Stars",
+      watchSurface: "Watch",
+      watchSurfaceUnread: (count) => `Watch，${count} 个未读 threads`,
+      title: "已 Watch 的 Stars 收件箱",
+      filterLabel: "Inbox thread 筛选",
+      searchPlaceholder: "搜索仓库和 threads",
+      clearSearch: "清除 Watch 搜索",
+      reasonFilter: "通知原因",
+      reasonFilterSelected: (count) => `通知原因，已选 ${count} 项`,
+      reasonFilterClear: "清除原因筛选",
+      reasonPresets: "原因预设",
+      reasonPresetAll: "全部",
+      reasonPresetDirect: "直接相关",
+      reasonPresetSecurity: "安全",
+      reasonPresetParticipation: "参与过",
+      reasonPresetWatching: "Watching",
+      reasonPresetOther: "其他",
+      reasonThreadCount: (count) => `${count} 个 threads`,
+      unread: "未读",
+      all: "全部",
+      refresh: "刷新 Watch 收件箱",
+      refreshing: "刷新中…",
+      openOptions: "打开选项页",
+      configureMainToken: "请为主 GitHub token 添加 Watching: read 权限，以读取已 Watch 的仓库。",
+      configureNotificationsToken: "请另行连接仅含 notifications scope 的 classic token，以读取 Inbox threads。",
+      scopeNeverLoaded: "刷新后可从 GitHub 加载已 Watch 的仓库。",
+      inboxNeverLoaded: "刷新后可加载最新的有界 Inbox 快照。",
+      queryFailed: "无法加载 Watch 快照。",
+      refreshFailed: "最近一次 Watch 刷新失败，仍可查看之前的快照。",
+      retry: "重试",
+      scopePermissionDenied: "主 token 无法读取 Watching。请在选项页添加可选的 Watching: read 权限后重新连接。",
+      inboxPermissionDenied: "Notifications token 无法读取 GitHub Inbox。请在选项页重新连接有 notifications 权限的 classic token。",
+      scopeUnavailable: "已 Watch 的仓库范围尚未可用，因此无法匹配 Inbox threads。",
+      noWatchedRepositories: "当前已 Star 的仓库中，没有在 GitHub 上处于 Watch 状态的仓库。",
+      noUnreadThreads: "最近一次 Watch 快照中没有未读 thread。",
+      noThreads: "这次快照中没有 Inbox thread 匹配已 Watch 且已 Star 的仓库。",
+      noMatchingThreads: "没有 thread 匹配当前 Watch 搜索和通知原因筛选。",
+      staleSnapshot: "最近一次刷新失败，当前仍显示上一次成功快照。",
+      scopeFailed: "无法刷新已 Watch 的仓库范围。",
+      inboxFailed: "无法刷新 Inbox threads。",
+      truncated: "这里只显示最新的有界窗口，GitHub 上仍有更早的 threads。",
+      cooldownUntil: (time) => `GitHub 要求客户端等到 ${time} 后再刷新。`,
+      watchedRepositoryCount: (count) => `${count} 个已 Watch 且已 Star 的仓库`,
+      threadCount: (count) => `${count} 个 threads`,
+      snapshotAt: (time) => `快照检查于 ${time}`,
+      manageOnGitHub: "在 GitHub 管理 Watch 设置",
+      watchedOnGitHub: "已在 GitHub Watch",
+      repositoryUnreadCount: (count) => `${count} 个未读`,
+      openOnGitHub: "在 GitHub 打开",
+      unreadSnapshot: "未读状态来自这次快照",
+      expandRepository: (repository) => `展开 ${repository}`,
+      collapseRepository: (repository) => `收起 ${repository}`,
     },
     toolbar: {
       searchPlaceholder: "搜索 名称 / 描述 / topics / notes   (按 / 聚焦)",
@@ -2381,7 +2603,7 @@ const messages: Record<Locale, MessageCatalog> = {
     options: {
       title: "Better GitHub Stars Manager — 选项",
       starRepoButton: "点个Star~",
-      agentHeading: "2. Cubby",
+      agentHeading: "3. Cubby",
       agentIntro:
         "连接 AI 服务后，Cubby 会直接向该服务发送请求，并在扩展内显示结果。",
       agentServiceLabel: "AI 服务",
@@ -2444,7 +2666,7 @@ const messages: Record<Locale, MessageCatalog> = {
       agentGrantAccess: "允许访问",
       agentAccessGranted: "已允许访问",
       agentHostAccessRequired: "测试或使用此自定义服务前，请先允许 Chrome 访问。",
-      behaviorHeading: "4. 偏好",
+      behaviorHeading: "5. 偏好",
       maxTagsPerRepoLabel: "每个仓库最多自动标签数",
       maxTagsPerRepoHint:
         "点击 Auto Tags 时，单个仓库最多自动添加这么多个主题标签。",
@@ -2461,6 +2683,8 @@ const messages: Record<Locale, MessageCatalog> = {
       tokenPublicRepos:
         "Account · Starring（读写，用于同步和 unstar）",
       tokenGists: "Account · Gists（读写，用于跨设备标签同步）",
+      tokenWatchingOptional:
+        "Watch 可选权限 · Watching（只读，用于列出已 Watch 的仓库）",
       tokenGistNote:
         "注意：GitHub Gist 权限是账号级的（细粒度 token 不能按 gist 隔离）。我们会为同步创建一个专用 secret gist。",
       authenticatedAs: (username) => `已认证为 @${username}。`,
@@ -2471,8 +2695,24 @@ const messages: Record<Locale, MessageCatalog> = {
       clearCachedAuth: "清除缓存认证",
       saveVerify: "保存并验证",
       verifying: "验证中…",
-      tokenVerified: (username) => `Token 验证成功，当前登录为 ${username}。已检查同步和 Gist 权限；取消 Star 还需要 Starring read/write。`,
+      tokenVerified: (username) => `Token 验证成功，当前登录为 ${username}。已检查同步、Gist 和 Watch 访问权限；取消 Star 还需要 Starring read/write。`,
+      tokenVerifiedWatchForbidden: (username) => `已保存 ${username} 的 token，并检查同步和 Gist 权限，但 Watch 还需要 Account · Watching（只读）权限。添加后请再次保存并验证。`,
+      tokenVerifiedWatchUnverified: (username) => `已保存 ${username} 的 token，并检查同步和 Gist 权限，但暂时无法验证 Watch 访问权限。请再次保存并验证；若问题持续，请确认已添加 Account · Watching（只读）权限。`,
       tokenRemoved: "Token 已移除。",
+      watchTokenHeading: "2. Watch Inbox Token",
+      watchTokenIntroPrefix: "在这里创建仅含 notifications scope 的 classic PAT：",
+      watchTokenLinkLabel: "GitHub token 设置",
+      watchTokenIntroSuffix: "该 token 只用于可选的 Watch Inbox。",
+      watchTokenAccountHint:
+        "它必须与主 token 属于同一 GitHub 账号。扩展会在保存前验证账号身份和 Inbox 访问权限。",
+      watchTokenLabel: "Classic Notifications token",
+      watchTokenMainRequired: "请先连接可用的主 GitHub token。",
+      watchTokenConnect: "连接 Inbox",
+      watchTokenReplace: "替换 token",
+      watchTokenDisconnect: "断开 Inbox",
+      watchTokenVerifying: "验证中…",
+      watchTokenConnected: (username) => `Watch Inbox 已连接为 @${username}。`,
+      watchTokenDisconnected: "已断开 Watch Inbox，并移除缓存的 threads。",
       tokenStepsTitle: "如何创建 token(fine-grained PAT)",
       tokenStep1:
         "打开 GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens → Generate new token。",
@@ -2480,15 +2720,15 @@ const messages: Record<Locale, MessageCatalog> = {
       tokenStep3:
         "Repository access → 选「All public repositories」(扩展只读你 star 的公开仓库)。",
       tokenStep4:
-        "Account permissions → 开启「Starring (read and write)」和「Gists (read and write)」,其余全部关闭。",
+        "Account permissions → 开启「Starring (read and write)」和「Gists (read and write)」；使用 Watch 时可选开启「Watching (read)」。",
       tokenStep5:
         "Generate → 复制 token(以 github_pat_ 开头)→ 粘贴到上面 → 保存并验证。",
       shotNewToken: "截图:「Generate new token」表单",
       shotRepoAccess: "截图:仓库访问设为所有公开仓库",
       shotPermissions:
-        "截图:账号权限 —— Starring (read/write) + Gists (read and write)",
+        "截图:账号权限 —— Starring + Gists，以及可选的 Watching (read)",
       languageLabel: "语言",
-      gistHeading: "3. Gist 同步",
+      gistHeading: "4. Gist 同步",
       gistBoundPrefix: "已绑定 gist",
       gistBoundSuffix:
         "标签会与该 gist 双向同步；如果同一仓库在两处被改动，较新的改动会生效。",
@@ -2551,6 +2791,20 @@ const messages: Record<Locale, MessageCatalog> = {
         `GitHub 已创建探针 Gist,但清理失败(${status})。未保存 token,请重试。`,
       tokenGistCleanupNetwork:
         "GitHub 已创建探针 Gist,但无法确认清理是否完成。未保存 token,请重试。",
+      watchTokenEmpty: "请先粘贴 classic GitHub token。",
+      watchTokenMainAccountRequired: "请先连接主 GitHub 账户，再配置 Watch 收件箱。",
+      watchTokenRejected: "GitHub 拒绝了这个 classic token，请确认已完整复制。",
+      watchTokenAccountMismatch: "这个 classic token 属于另一个 GitHub 账户。",
+      watchTokenAccountChanged: "验证期间主 GitHub 账户发生变化，请使用匹配账户重试。",
+      watchTokenProfileStatus: (status) =>
+        `GitHub 在检查 classic token 账户时返回 ${status}，未保存 token。`,
+      watchTokenProfileBadShape: "GitHub 为 classic token 返回了非预期的账户信息。",
+      watchTokenProfileNetwork: "检查 classic token 账户时无法连接 GitHub。",
+      watchTokenNotificationsForbidden: "这个 classic token 无法读取 Notifications，请创建包含 notifications scope 的 token。",
+      watchTokenNotificationsStatus: (status) =>
+        `GitHub 在检查 Notifications 权限时返回 ${status}，未保存 token。`,
+      watchTokenNotificationsNetwork: "检查 Notifications 权限时无法连接 GitHub。",
+      watchTokenNotificationsBadShape: "GitHub 返回了非预期的 Notifications 响应，未保存 token。",
       ghTokenRejected: "GitHub 拒绝了已保存的 token,请在选项页重新添加。",
       ghRateLimit: "已达到 GitHub 速率限制,请稍候重试。",
       ghForbidden:

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -7,7 +7,11 @@ import {
   AlertTriangle,
   ExternalLink,
 } from "lucide-react";
-import { authStore, CONFIG_STORAGE_KEY } from "@/auth/auth-store";
+import {
+  authStore,
+  CONFIG_STORAGE_KEY,
+  GITHUB_CREDENTIALS_STORAGE_KEY,
+} from "@/auth/auth-store";
 import {
   BackgroundCallError,
   bgCall,
@@ -17,6 +21,7 @@ import {
   type SyncStatus,
 } from "@/utils/messaging";
 import {
+  TOKEN_WATCHING_FORBIDDEN,
   translateError,
 } from "@/api/errors";
 import { Button } from "@/ui/shadcn/button";
@@ -73,7 +78,7 @@ const DEFAULT_CUSTOM_AGENT_PROTOCOL: AgentCustomProviderProtocol = "chat-complet
 const MIN_AGENT_CONTEXT_WINDOW = 4_096;
 const MAX_AGENT_CONTEXT_WINDOW = 2_000_000;
 
-type OptionsMessage = { kind: "ok" | "err"; text: string };
+type OptionsMessage = { kind: "ok" | "warn" | "err"; text: string };
 type AgentConnectionResult = {
   providerLabel: string;
   model: string;
@@ -93,14 +98,15 @@ function StatusNotice({
   return (
     <div
       data-testid={testId}
-      role={message.kind === "ok" ? "status" : "alert"}
-      aria-live={message.kind === "ok" ? "polite" : "assertive"}
+      role={message.kind === "err" ? "alert" : "status"}
+      aria-live={message.kind === "err" ? "assertive" : "polite"}
       className={cn(
         "gsm-status-note",
         className,
         {
           "text-success": message.kind === "ok",
-          "text-destructive": message.kind !== "ok",
+          "text-warning": message.kind === "warn",
+          "text-destructive": message.kind === "err",
         },
       )}
     >
@@ -112,6 +118,7 @@ function StatusNotice({
 export function Options() {
   const [username, setUsername] = useState<string | null>(null);
   const [hasUsableToken, setHasUsableToken] = useState(false);
+  const [hasWatchNotificationsToken, setHasWatchNotificationsToken] = useState(false);
   const [gistId, setGistId] = useState<string | null>(null);
   const [theme, setTheme] = useState<"dark" | "light">("dark");
   const [agentProvider, setAgentProvider] = useState<AgentProviderId>("openai");
@@ -135,22 +142,30 @@ export function Options() {
   const persistedMinTopicRepoCountRef = useRef(String(DEFAULT_MIN_TOPIC_REPO_COUNT));
   const [starsPanelDefaultEnabled, setStarsPanelDefaultEnabled] = useState(true);
   const [tokenBusy, setTokenBusy] = useState(false);
+  const [watchTokenBusy, setWatchTokenBusy] = useState(false);
   const [agentSaveBusy, setAgentSaveBusy] = useState(false);
   const [agentTestBusy, setAgentTestBusy] = useState(false);
   const [syncStatus, setSyncStatus] = useState<SyncStatus | null>(null);
   const [msg, setMsg] = useState<OptionsMessage | null>(null);
+  const [watchMsg, setWatchMsg] = useState<OptionsMessage | null>(null);
   const [agentMsg, setAgentMsg] = useState<OptionsMessage | null>(null);
   const { locale, setLocale, m } = useI18n();
   const tokenInput = useImeBufferedInput("");
+  const watchTokenInput = useImeBufferedInput("");
+  const refreshGeneration = useRef(0);
 
   const refresh = async () => {
-    const [c, hasToken, status] = await Promise.all([
+    const generation = ++refreshGeneration.current;
+    const [c, hasToken, hasWatchToken, status] = await Promise.all([
       authStore.getConfig(),
       authStore.hasToken(),
+      authStore.hasWatchNotificationsToken(),
       bgCall<SyncStatus>("getStatus").catch(() => null),
     ]);
+    if (generation !== refreshGeneration.current) return;
     setUsername(c.username);
     setHasUsableToken(hasToken);
+    setHasWatchNotificationsToken(hasWatchToken);
     setGistId(c.gistId);
     setTheme(c.theme);
     setAgentProvider(c.agentProvider.provider);
@@ -194,8 +209,15 @@ export function Options() {
     setTokenBusy(true);
     setMsg(null);
     try {
-      const { username: u } = await authStore.setToken(tokenInput.value);
-      setMsg({ kind: "ok", text: m.options.tokenVerified(u) });
+      const { username: u, watching } = await authStore.setToken(tokenInput.value);
+      setMsg(watching.available
+        ? { kind: "ok", text: m.options.tokenVerified(u) }
+        : {
+            kind: "warn",
+            text: watching.errorCode === TOKEN_WATCHING_FORBIDDEN
+              ? m.options.tokenVerifiedWatchForbidden(u)
+              : m.options.tokenVerifiedWatchUnverified(u),
+          });
       tokenInput.commit("");
       await refresh();
     } catch (e) {
@@ -209,6 +231,41 @@ export function Options() {
     await authStore.clearToken();
     await refresh();
     setMsg({ kind: "ok", text: m.options.tokenRemoved });
+  };
+
+  const saveWatchNotificationsToken = async () => {
+    setWatchTokenBusy(true);
+    setWatchMsg(null);
+    try {
+      const { username: connectedUsername } = await authStore.setWatchNotificationsToken(
+        watchTokenInput.value,
+      );
+      watchTokenInput.commit("");
+      await refresh();
+      setWatchMsg({
+        kind: "ok",
+        text: m.options.watchTokenConnected(connectedUsername),
+      });
+    } catch (error) {
+      setWatchMsg({ kind: "err", text: translateError(error, m) });
+    } finally {
+      setWatchTokenBusy(false);
+    }
+  };
+
+  const disconnectWatchNotificationsToken = async () => {
+    setWatchTokenBusy(true);
+    setWatchMsg(null);
+    try {
+      await bgCall("disconnectWatchInbox");
+      watchTokenInput.commit("");
+      await refresh();
+      setWatchMsg({ kind: "ok", text: m.options.watchTokenDisconnected });
+    } catch (error) {
+      setWatchMsg({ kind: "err", text: translateError(error, m) });
+    } finally {
+      setWatchTokenBusy(false);
+    }
   };
 
   const requestAgentConnectionTest = (apiKey?: string) => bgCall<AgentConnectionResult>(
@@ -484,7 +541,12 @@ export function Options() {
       changes: Record<string, chrome.storage.StorageChange>,
       areaName: string,
     ) => {
-      if (areaName !== "local" || !changes[CONFIG_STORAGE_KEY]) return;
+      if (areaName !== "local") return;
+      if (changes[GITHUB_CREDENTIALS_STORAGE_KEY]) {
+        void refresh();
+        return;
+      }
+      if (!changes[CONFIG_STORAGE_KEY]) return;
       const oldCfg = changes[CONFIG_STORAGE_KEY].oldValue as Record<string, unknown> | undefined;
       const newCfg = changes[CONFIG_STORAGE_KEY].newValue as Record<string, unknown> | undefined;
       const visibleConfigUnchanged =
@@ -493,6 +555,12 @@ export function Options() {
         oldCfg?.theme === newCfg?.theme &&
         oldCfg?.locale === newCfg?.locale &&
         oldCfg?.tokenEncrypted === newCfg?.tokenEncrypted &&
+        JSON.stringify(oldCfg?.tokenCryptoMeta ?? null) ===
+          JSON.stringify(newCfg?.tokenCryptoMeta ?? null) &&
+        oldCfg?.watchNotificationsTokenEncrypted ===
+          newCfg?.watchNotificationsTokenEncrypted &&
+        JSON.stringify(oldCfg?.watchNotificationsTokenCryptoMeta ?? null) ===
+          JSON.stringify(newCfg?.watchNotificationsTokenCryptoMeta ?? null) &&
         JSON.stringify(oldCfg?.agentProvider ?? null) ===
           JSON.stringify(newCfg?.agentProvider ?? null) &&
         oldCfg?.maxTagsPerRepo === newCfg?.maxTagsPerRepo &&
@@ -620,6 +688,7 @@ export function Options() {
         <ul className="gsm-body-note mt-2">
           <li>{m.options.tokenPublicRepos}</li>
           <li>{m.options.tokenGists}</li>
+          <li>{m.options.tokenWatchingOptional}</li>
         </ul>
         <p className="mt-1 text-xs text-warning">{m.options.tokenGistNote}</p>
 
@@ -671,6 +740,92 @@ export function Options() {
             )}
           </Button>
         </div>
+        {msg && (
+          <StatusNotice
+            message={msg}
+            className="mt-3"
+            testId="main-token-status"
+          />
+        )}
+      </section>
+
+      <section className="mt-6">
+        <h2 className="text-base font-medium">{m.options.watchTokenHeading}</h2>
+        <p className="gsm-body-note mt-1">
+          {m.options.watchTokenIntroPrefix}{" "}
+          <a
+            className="text-primary hover:underline"
+            href="https://github.com/settings/tokens/new?scopes=notifications&description=GitHub%20Stars%20Manager%20Watch%20Inbox"
+            target="_blank"
+            rel="noreferrer"
+          >
+            {m.options.watchTokenLinkLabel}
+          </a>
+          . {m.options.watchTokenIntroSuffix}
+        </p>
+        <p className="gsm-body-note mt-2">{m.options.watchTokenAccountHint}</p>
+
+        {hasWatchNotificationsToken && username && (
+          <div className="gsm-status-note my-3 flex flex-wrap items-center gap-1.5 text-success">
+            <Check className="size-4 shrink-0" />
+            <span>{m.options.watchTokenConnected(username)}</span>
+            <Button
+              data-testid="watch-token-disconnect"
+              variant="ghost"
+              size="sm"
+              className="ml-2"
+              disabled={watchTokenBusy}
+              onClick={() => void disconnectWatchNotificationsToken()}
+            >
+              {m.options.watchTokenDisconnect}
+            </Button>
+          </div>
+        )}
+
+        <label
+          htmlFor="watch-notifications-token"
+          className="mt-3 block text-sm font-medium text-foreground"
+        >
+          {m.options.watchTokenLabel}
+        </label>
+        <Input
+          id="watch-notifications-token"
+          name="watch-notifications-token"
+          type="password"
+          autoComplete="new-password"
+          spellCheck={false}
+          {...watchTokenInput.inputProps}
+          placeholder="ghp_..."
+          disabled={!hasUsableToken || !username || watchTokenBusy}
+          className="mt-1 font-mono"
+        />
+        {!hasUsableToken && (
+          <p className="mt-1 text-xs text-warning">{m.options.watchTokenMainRequired}</p>
+        )}
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <Button
+            data-testid="watch-token-connect"
+            disabled={
+              watchTokenBusy ||
+              !hasUsableToken ||
+              !username ||
+              !watchTokenInput.value.trim()
+            }
+            onClick={() => void saveWatchNotificationsToken()}
+          >
+            {watchTokenBusy ? (
+              <>
+                <Spinner data-icon="inline-start" />
+                {m.options.watchTokenVerifying}
+              </>
+            ) : hasWatchNotificationsToken ? (
+              m.options.watchTokenReplace
+            ) : (
+              m.options.watchTokenConnect
+            )}
+          </Button>
+        </div>
+        {watchMsg && <StatusNotice message={watchMsg} testId="watch-token-status" />}
       </section>
 
       <section className="mt-6">
@@ -967,7 +1122,7 @@ export function Options() {
 
       <Separator className="my-6" />
 
-      {/* 2. Gist */}
+      {/* 4. Gist */}
       <section>
         <h2 className="text-base font-medium">{m.options.gistHeading}</h2>
         <p className="gsm-status-note mt-1 text-muted-foreground">
@@ -1009,7 +1164,7 @@ export function Options() {
         </div>
       </section>
 
-      {/* 3. Preference */}
+      {/* 5. Preference */}
       <section className="mt-6">
         <h2 className="text-base font-medium">{m.options.behaviorHeading}</h2>
         <div className="mt-3 grid gap-4 rounded-lg border border-border bg-muted/20 p-4">
@@ -1058,8 +1213,6 @@ export function Options() {
           </div>
         </div>
       </section>
-
-      {msg && <StatusNotice message={msg} className="mt-4" />}
     </div>
   );
 }

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -10,6 +10,11 @@ import type {
   TagDirtyOutboxRecord,
   TagMeta,
 } from '@/types';
+import type {
+  GitHubNotificationThread,
+  GitHubWatchRepository,
+  GitHubWatchStateRecord,
+} from '@/watch/watch-model';
 import { normalizeStoredTag, type LegacyTagRow } from './tag-shape';
 
 /**
@@ -27,6 +32,9 @@ export class StarsDB extends Dexie {
   organizeApplies!: Table<OrganizeApplyRecord, string>;
   organizeApplyRows!: Table<OrganizeApplyRowRecord, string>;
   tagDirtyOutbox!: Table<TagDirtyOutboxRecord, string>;
+  watchRepositories!: Table<GitHubWatchRepository, string>;
+  watchNotificationThreads!: Table<GitHubNotificationThread, string>;
+  watchState!: Table<GitHubWatchStateRecord, 'singleton'>;
 
   constructor() {
     super('better-github-stars-manager');
@@ -56,8 +64,8 @@ export class StarsDB extends Dexie {
       const rows = await table.toArray() as LegacyTagRow[];
       await table.bulkPut(rows.map((row) => normalizeStoredTag(row)));
     });
-    // v4 adds isolated durable artifacts for whole-library tag organization and
-    // Gist dirtiness. The non-indexed analysis split worklist lives on organizeJobs.
+    // v4 adds isolated durable artifacts for whole-library tag organization,
+    // Gist dirtiness, and the account-bound Watch snapshots.
     this.version(4).stores({
       stars: 'full_name, language, starred_at, pushed_at, created_at, tombstone',
       tags: 'full_name, mtime',
@@ -68,6 +76,9 @@ export class StarsDB extends Dexie {
       organizeApplies: 'applyId, jobId, status',
       organizeApplyRows: 'id, [applyId+position], [applyId+state], applyId, state, leaseExpiresAt',
       tagDirtyOutbox: 'id, kind, updatedAt',
+      watchRepositories: 'full_name',
+      watchNotificationThreads: 'id, repositoryFullName, updatedAt, [repositoryFullName+updatedAt]',
+      watchState: 'id',
     });
   }
 }

--- a/src/storage/watch-store.ts
+++ b/src/storage/watch-store.ts
@@ -1,0 +1,465 @@
+import { db } from '@/storage/db';
+import {
+  canonicalRepositoryFullName,
+  projectWatchInbox,
+  type GitHubNotificationThread,
+  type GitHubWatchRepository,
+  type GitHubWatchStateRecord,
+  type WatchInboxProjection,
+  type WatchInboxRefreshSnapshot,
+  type WatchScopeRefreshSnapshot,
+} from '@/watch/watch-model';
+
+const WATCH_STATE_ID = 'singleton' as const;
+
+export interface WatchInboxQueryResult extends WatchInboxProjection {
+  state: GitHubWatchStateRecord | null;
+}
+
+/**
+ * Remove rows that are no longer attributable to the configured GitHub
+ * account. This is intentionally idempotent so a later service-worker wake
+ * can finish cleanup after a storage listener was interrupted.
+ */
+export async function reconcileWatchAccount(
+  accountLogin: string | null | undefined,
+): Promise<boolean> {
+  const normalizedLogin = accountLogin?.trim()
+    ? normalizeAccountLogin(accountLogin)
+    : null;
+  return db.transaction(
+    'rw',
+    db.watchRepositories,
+    db.watchNotificationThreads,
+    db.watchState,
+    async () => {
+      const state = await db.watchState.get(WATCH_STATE_ID);
+      const rowsPresent = state !== undefined ||
+        await db.watchRepositories.count() > 0 ||
+        await db.watchNotificationThreads.count() > 0;
+      if (normalizedLogin && state?.accountLogin === normalizedLogin) return false;
+      if (!rowsPresent) return false;
+      await Promise.all([
+        db.watchRepositories.clear(),
+        db.watchNotificationThreads.clear(),
+        db.watchState.clear(),
+      ]);
+      return true;
+    },
+  );
+}
+
+/**
+ * Remove cached Watch rows that no longer belong to the current live-star
+ * library. Running this on reads also repairs a service-worker interruption
+ * between a star tombstone commit and the normal post-sync reconciliation.
+ */
+export async function reconcileWatchLiveStars(
+  accountLogin: string | null | undefined,
+): Promise<boolean> {
+  if (!accountLogin?.trim()) return false;
+  const normalizedLogin = normalizeAccountLogin(accountLogin);
+  return db.transaction(
+    'rw',
+    db.stars,
+    db.watchRepositories,
+    db.watchNotificationThreads,
+    db.watchState,
+    async () => {
+      const state = await db.watchState.get(WATCH_STATE_ID);
+      if (state?.accountLogin !== normalizedLogin) return false;
+
+      const [stars, repositories, threads] = await Promise.all([
+        db.stars.toArray(),
+        db.watchRepositories.toArray(),
+        db.watchNotificationThreads.toArray(),
+      ]);
+      const liveNames = new Set(stars.flatMap((star) => {
+        if (star.tombstone) return [];
+        const fullName = canonicalRepositoryFullName(star.full_name);
+        return fullName ? [fullName] : [];
+      }));
+      const retainedScope = new Set(repositories.flatMap((repository) => {
+        const fullName = canonicalRepositoryFullName(repository.full_name);
+        return fullName && liveNames.has(fullName) ? [fullName] : [];
+      }));
+      const removedRepositoryNames = repositories
+        .filter((repository) => !retainedScope.has(repository.full_name))
+        .map((repository) => repository.full_name);
+      const removedThreadIds = threads
+        .filter((thread) => !retainedScope.has(thread.repositoryFullName))
+        .map((thread) => thread.id);
+      const repositoryCount = retainedScope.size;
+      const matchedCount = threads.length - removedThreadIds.length;
+      const stateChanged = state.scope.repositoryCount !== repositoryCount ||
+        state.inbox.matchedCount !== matchedCount;
+      if (!removedRepositoryNames.length && !removedThreadIds.length && !stateChanged) {
+        return false;
+      }
+
+      if (removedRepositoryNames.length) {
+        await db.watchRepositories.bulkDelete(removedRepositoryNames);
+      }
+      if (removedThreadIds.length) {
+        await db.watchNotificationThreads.bulkDelete(removedThreadIds);
+      }
+      await db.watchState.put({
+        ...state,
+        scope: { ...state.scope, repositoryCount },
+        inbox: { ...state.inbox, matchedCount },
+      });
+      return true;
+    },
+  );
+}
+
+function normalizeAccountLogin(login: string): string {
+  const normalized = login.trim().toLowerCase();
+  if (!normalized) throw new TypeError('Watch account login is required.');
+  return normalized;
+}
+
+function emptyScope(): WatchScopeRefreshSnapshot {
+  return {
+    lastAttemptAt: null,
+    lastSuccessfulAt: null,
+    errorCode: null,
+    repositoryCount: 0,
+  };
+}
+
+function emptyInbox(): WatchInboxRefreshSnapshot {
+  return {
+    lastAttemptAt: null,
+    lastSuccessfulAt: null,
+    errorCode: null,
+    lastModified: null,
+    nextAllowedAt: null,
+    candidateCount: 0,
+    matchedCount: 0,
+    truncated: false,
+  };
+}
+
+function emptyState(accountLogin: string): GitHubWatchStateRecord {
+  return {
+    id: WATCH_STATE_ID,
+    accountLogin,
+    scope: emptyScope(),
+    inbox: emptyInbox(),
+  };
+}
+
+async function replaceAccountIfNeeded(accountLogin: string): Promise<GitHubWatchStateRecord> {
+  const normalizedLogin = normalizeAccountLogin(accountLogin);
+  const current = await db.watchState.get(WATCH_STATE_ID);
+  if (current?.accountLogin === normalizedLogin) return current;
+
+  // Tables without their account-bound state are orphaned and must never be
+  // adopted by the next account that writes a refresh result.
+  await Promise.all([
+    db.watchRepositories.clear(),
+    db.watchNotificationThreads.clear(),
+  ]);
+  return emptyState(normalizedLogin);
+}
+
+function normalizeRepositories(
+  repositories: readonly GitHubWatchRepository[],
+): GitHubWatchRepository[] {
+  const names = new Set<string>();
+  for (const repository of repositories) {
+    const fullName = canonicalRepositoryFullName(repository.full_name);
+    if (!fullName) throw new TypeError('Watch snapshot contains an invalid repository.');
+    names.add(fullName);
+  }
+  return [...names].sort().map((full_name) => ({ full_name }));
+}
+
+function normalizeThreads(
+  threads: readonly GitHubNotificationThread[],
+): GitHubNotificationThread[] {
+  const byId = new Map<string, GitHubNotificationThread>();
+  for (const thread of threads) {
+    if (!thread.id.trim()) throw new TypeError('Watch snapshot contains an invalid thread id.');
+    const repositoryFullName = canonicalRepositoryFullName(thread.repositoryFullName);
+    if (!repositoryFullName) throw new TypeError('Watch snapshot contains an invalid thread repository.');
+    byId.set(thread.id, { ...thread, repositoryFullName });
+  }
+  return [...byId.values()];
+}
+
+export async function getWatchState(
+  accountLogin: string | null | undefined,
+): Promise<GitHubWatchStateRecord | null> {
+  if (!accountLogin?.trim()) return null;
+  const normalizedLogin = normalizeAccountLogin(accountLogin);
+  const state = await db.watchState.get(WATCH_STATE_ID);
+  return state?.accountLogin === normalizedLogin ? state : null;
+}
+
+export async function getWatchRepositories(
+  accountLogin: string | null | undefined,
+): Promise<GitHubWatchRepository[]> {
+  if (!accountLogin?.trim()) return [];
+  const normalizedLogin = normalizeAccountLogin(accountLogin);
+  return db.transaction('r', db.watchRepositories, db.watchState, async () => {
+    const state = await db.watchState.get(WATCH_STATE_ID);
+    if (state?.accountLogin !== normalizedLogin) return [];
+    return db.watchRepositories.orderBy('full_name').toArray();
+  });
+}
+
+export async function queryStoredWatchInbox(input: {
+  accountLogin: string | null | undefined;
+  unreadOnly?: boolean;
+}): Promise<WatchInboxQueryResult> {
+  if (!input.accountLogin?.trim()) {
+    return { ...projectWatchInbox([], { unreadOnly: input.unreadOnly }), state: null };
+  }
+  const normalizedLogin = normalizeAccountLogin(input.accountLogin);
+  return db.transaction(
+    'r',
+    db.watchRepositories,
+    db.watchNotificationThreads,
+    db.watchState,
+    async () => {
+      const state = await db.watchState.get(WATCH_STATE_ID);
+      if (state?.accountLogin !== normalizedLogin) {
+        return { ...projectWatchInbox([], { unreadOnly: input.unreadOnly }), state: null };
+      }
+      const [repositories, threads] = await Promise.all([
+        db.watchRepositories.toArray(),
+        db.watchNotificationThreads.toArray(),
+      ]);
+      const scope = new Set(repositories.map((repository) => repository.full_name));
+      return {
+        ...projectWatchInbox(
+          threads.filter((thread) => scope.has(thread.repositoryFullName)),
+          { unreadOnly: input.unreadOnly },
+        ),
+        state,
+      };
+    },
+  );
+}
+
+export async function replaceWatchScope(input: {
+  accountLogin: string;
+  repositories: readonly GitHubWatchRepository[];
+  attemptedAt: string;
+  successfulAt?: string;
+}): Promise<GitHubWatchStateRecord> {
+  const repositories = normalizeRepositories(input.repositories);
+  return db.transaction(
+    'rw',
+    db.watchRepositories,
+    db.watchNotificationThreads,
+    db.watchState,
+    async () => {
+      const current = await replaceAccountIfNeeded(input.accountLogin);
+      const previousScope = new Set(await db.watchRepositories.toCollection().primaryKeys());
+      const nextScope = new Set(repositories.map((repository) => repository.full_name));
+      const scopeChanged = previousScope.size !== nextScope.size ||
+        [...nextScope].some((fullName) => !previousScope.has(fullName));
+      await db.watchRepositories.clear();
+      if (repositories.length) await db.watchRepositories.bulkPut(repositories);
+      const staleThreadIds = await db.watchNotificationThreads
+        .filter((thread) => !nextScope.has(thread.repositoryFullName))
+        .primaryKeys();
+      if (staleThreadIds.length) await db.watchNotificationThreads.bulkDelete(staleThreadIds);
+      const matchedCount = await db.watchNotificationThreads.count();
+      const next: GitHubWatchStateRecord = {
+        ...current,
+        scope: {
+          lastAttemptAt: input.attemptedAt,
+          lastSuccessfulAt: input.successfulAt ?? input.attemptedAt,
+          errorCode: null,
+          repositoryCount: repositories.length,
+        },
+        inbox: {
+          ...current.inbox,
+          matchedCount,
+          ...(scopeChanged ? {
+            errorCode: current.inbox.errorCode ?? (
+              current.inbox.lastSuccessfulAt ? 'scope_changed' : null
+            ),
+            lastModified: null,
+            nextAllowedAt: null,
+          } : {}),
+        },
+      };
+      await db.watchState.put(next);
+      return next;
+    },
+  );
+}
+
+export async function recordWatchScopeFailure(input: {
+  accountLogin: string;
+  attemptedAt: string;
+  errorCode: string;
+}): Promise<GitHubWatchStateRecord> {
+  return db.transaction(
+    'rw',
+    db.watchRepositories,
+    db.watchNotificationThreads,
+    db.watchState,
+    async () => {
+      const current = await replaceAccountIfNeeded(input.accountLogin);
+      const next: GitHubWatchStateRecord = {
+        ...current,
+        scope: {
+          ...current.scope,
+          lastAttemptAt: input.attemptedAt,
+          errorCode: input.errorCode,
+        },
+      };
+      await db.watchState.put(next);
+      return next;
+    },
+  );
+}
+
+export async function replaceWatchInbox(input: {
+  accountLogin: string;
+  threads: readonly GitHubNotificationThread[];
+  attemptedAt: string;
+  successfulAt?: string;
+  lastModified: string | null;
+  nextAllowedAt: string | null;
+  candidateCount: number;
+  truncated: boolean;
+}): Promise<GitHubWatchStateRecord> {
+  const normalizedThreads = normalizeThreads(input.threads);
+  return db.transaction(
+    'rw',
+    db.watchRepositories,
+    db.watchNotificationThreads,
+    db.watchState,
+    async () => {
+      const current = await replaceAccountIfNeeded(input.accountLogin);
+      const scope = new Set(await db.watchRepositories.toCollection().primaryKeys());
+      const threads = normalizedThreads.filter((thread) => scope.has(thread.repositoryFullName));
+      await db.watchNotificationThreads.clear();
+      if (threads.length) await db.watchNotificationThreads.bulkPut(threads);
+      const next: GitHubWatchStateRecord = {
+        ...current,
+        inbox: {
+          lastAttemptAt: input.attemptedAt,
+          lastSuccessfulAt: input.successfulAt ?? input.attemptedAt,
+          errorCode: null,
+          lastModified: input.lastModified,
+          nextAllowedAt: input.nextAllowedAt,
+          candidateCount: input.candidateCount,
+          matchedCount: threads.length,
+          truncated: input.truncated,
+        },
+      };
+      await db.watchState.put(next);
+      return next;
+    },
+  );
+}
+
+export async function revalidateWatchInbox(input: {
+  accountLogin: string;
+  attemptedAt: string;
+  successfulAt?: string;
+  nextAllowedAt: string | null;
+  lastModified?: string | null;
+}): Promise<GitHubWatchStateRecord> {
+  return db.transaction(
+    'rw',
+    db.watchRepositories,
+    db.watchNotificationThreads,
+    db.watchState,
+    async () => {
+      const current = await replaceAccountIfNeeded(input.accountLogin);
+      const next: GitHubWatchStateRecord = {
+        ...current,
+        inbox: {
+          ...current.inbox,
+          lastAttemptAt: input.attemptedAt,
+          lastSuccessfulAt: input.successfulAt ?? input.attemptedAt,
+          errorCode: null,
+          lastModified: input.lastModified === undefined
+            ? current.inbox.lastModified
+            : input.lastModified,
+          nextAllowedAt: input.nextAllowedAt,
+        },
+      };
+      await db.watchState.put(next);
+      return next;
+    },
+  );
+}
+
+export async function recordWatchInboxFailure(input: {
+  accountLogin: string;
+  attemptedAt: string;
+  errorCode: string;
+}): Promise<GitHubWatchStateRecord> {
+  return db.transaction(
+    'rw',
+    db.watchRepositories,
+    db.watchNotificationThreads,
+    db.watchState,
+    async () => {
+      const current = await replaceAccountIfNeeded(input.accountLogin);
+      const next: GitHubWatchStateRecord = {
+        ...current,
+        inbox: {
+          ...current.inbox,
+          lastAttemptAt: input.attemptedAt,
+          errorCode: input.errorCode,
+        },
+      };
+      await db.watchState.put(next);
+      return next;
+    },
+  );
+}
+
+export async function disconnectWatchInbox(
+  accountLogin: string | null | undefined,
+): Promise<void> {
+  const normalizedLogin = accountLogin?.trim()
+    ? normalizeAccountLogin(accountLogin)
+    : null;
+  await db.transaction(
+    'rw',
+    db.watchRepositories,
+    db.watchNotificationThreads,
+    db.watchState,
+    async () => {
+      const state = await db.watchState.get(WATCH_STATE_ID);
+      if (!normalizedLogin || state?.accountLogin !== normalizedLogin) {
+        await Promise.all([
+          db.watchRepositories.clear(),
+          db.watchNotificationThreads.clear(),
+          db.watchState.clear(),
+        ]);
+        return;
+      }
+      await db.watchNotificationThreads.clear();
+      await db.watchState.put({ ...state, inbox: emptyInbox() });
+    },
+  );
+}
+
+export async function clearWatchData(): Promise<void> {
+  await db.transaction(
+    'rw',
+    db.watchRepositories,
+    db.watchNotificationThreads,
+    db.watchState,
+    async () => {
+      await Promise.all([
+        db.watchRepositories.clear(),
+        db.watchNotificationThreads.clear(),
+        db.watchState.clear(),
+      ]);
+    },
+  );
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -315,6 +315,8 @@ export interface AgentProviderConfig {
 export interface Config {
   tokenEncrypted: string | null;
   tokenCryptoMeta: CryptoMeta | null;
+  watchNotificationsTokenEncrypted: string | null;
+  watchNotificationsTokenCryptoMeta: CryptoMeta | null;
   agentProvider: AgentProviderConfig;
   /** Explicit Agent data-sharing acknowledgement for one disclosure/provider/origin tuple. */
   agentDataDisclosureAcceptance: AgentDataDisclosureAcceptance | null;

--- a/src/ui/ManagerPanel.tsx
+++ b/src/ui/ManagerPanel.tsx
@@ -9,10 +9,12 @@ import { ActiveFilterChips } from '@/ui/components/ActiveFilterChips';
 import { FloatingLocaleToggle } from '@/ui/components/FloatingLocaleToggle';
 import { RepoDetailPanel } from '@/ui/components/RepoDetailPanel';
 import { StarsTable } from '@/ui/components/StarsTable';
+import { WatchInbox } from '@/ui/components/WatchInbox';
 import { LayoutColumnMenu, LayoutDragGhost, LayoutEditChrome } from '@/ui/components/LayoutEditChrome';
 import { useColumnLayoutEditor } from '@/ui/hooks/use-column-layout-editor';
 import { useManagerSyncActions } from '@/ui/hooks/use-manager-sync-actions';
 import { useAutoTagAgentPrompt } from '@/ui/hooks/use-auto-tag-agent-prompt';
+import { useWatchInbox } from '@/ui/hooks/use-watch-inbox';
 import { pruneFavoriteOverrides, type FavoriteOverrideState } from '@/ui/favorite-state';
 import { Button } from '@/ui/shadcn/button';
 import { Spinner } from '@/ui/shadcn/spinner';
@@ -24,7 +26,7 @@ import { bgCall, type SyncStatus } from '@/utils/messaging';
 import { hidePanel } from '@/content/stars-page/panel-toggle';
 import { cn } from '@/lib/utils';
 import { useI18n, type MessageCatalog } from '@/i18n';
-import type { BackfillState } from '@/types';
+import type { BackfillState, Star, Tag } from '@/types';
 import { COLUMN_DEFS } from '@/ui/column-layout';
 import { layoutViewportFromMeasurements, type LayoutViewportState } from '@/ui/layout-resize-surface';
 import type { LayoutResizeLiveAdapter } from '@/ui/layout-resize-tool';
@@ -41,6 +43,9 @@ export { layoutViewportFromMeasurements };
 type UnstarFeedback =
   | { kind: 'done'; fullName: string }
   | { kind: 'failed'; fullName: string; error: string };
+
+type ManagerSurface = 'stars' | 'watch';
+type WatchRepositoryDetail = { star: Star | null; tag: Tag | null };
 
 const REPO_MARKER = '__GSM_REPO__';
 const TOKEN_SETTINGS_LABEL = 'github.com/settings/tokens';
@@ -103,6 +108,7 @@ function helperInfoKey(info: string | null, unstarFeedback: UnstarFeedback | nul
 
 export function ManagerPanel() {
   const { rows, total, grandTotal, loading, phase, languages, tagTree, tagsByFullName, refresh: refreshStars } = useStars();
+  const watchInbox = useWatchInbox();
   const f = useFilterStore();
   const {
     status,
@@ -120,7 +126,9 @@ export function ManagerPanel() {
     deferBackfill,
     isOnboardingCardStage,
   } = useManagerSyncActions({ refreshStars });
+  const [surface, setSurface] = useState<ManagerSurface>('stars');
   const [selected, setSelected] = useState<string | null>(null);
+  const [watchDetail, setWatchDetail] = useState<WatchRepositoryDetail | null>(null);
   const [agentPanelOpen, setAgentPanelOpen] = useState(false);
   const [agentHostMounted, setAgentHostMounted] = useState(false);
   const [agentPresentation, setAgentPresentation] = useState<AgentHostPresentation>({
@@ -135,6 +143,7 @@ export function ManagerPanel() {
   const listRef = useRef<HTMLDivElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const layoutResizeLiveAdapterRef = useRef<LayoutResizeLiveAdapter | null>(null);
+  const watchDetailGeneration = useRef(0);
   const { theme, themeClass, toggle: toggleTheme } = useTheme();
   const { m } = useI18n();
   const {
@@ -188,6 +197,11 @@ export function ManagerPanel() {
   const visibleRows = rows;
   const visibleTotal = total;
   const visibleGrandTotal = grandTotal;
+  const starsSurface = surface === 'stars';
+
+  useEffect(() => () => {
+    watchDetailGeneration.current++;
+  }, []);
 
   useEffect(() => {
     if (info) setUnstarFeedback(null);
@@ -239,17 +253,46 @@ export function ManagerPanel() {
   };
 
   const selectedIdx = useMemo(
-    () => (selected ? visibleRows.findIndex((r) => r.full_name === selected) : -1),
-    [selected, visibleRows],
+    () => (starsSurface && selected ? visibleRows.findIndex((r) => r.full_name === selected) : -1),
+    [selected, starsSurface, visibleRows],
   );
-  const selectedStar = selectedIdx >= 0 ? visibleRows[selectedIdx] : null;
-  const selectedTag = selectedStar ? tagsByFullName.get(selectedStar.full_name) : undefined;
+  const selectedStar = starsSurface
+    ? selectedIdx >= 0 ? visibleRows[selectedIdx] : null
+    : selected ? watchDetail?.star ?? null : null;
+  const selectedTag = starsSurface
+    ? selectedStar ? tagsByFullName.get(selectedStar.full_name) : undefined
+    : watchDetail?.tag ?? undefined;
   useEffect(() => {
     setFavoriteOverrides((current) => pruneFavoriteOverrides(current, tagsByFullName, visibleRows));
   }, [visibleRows, tagsByFullName]);
 
   const handleSelect = (full_name: string) => {
     setSelected((cur) => (cur === full_name ? null : full_name));
+  };
+
+  const handleWatchRepositorySelect = async (fullName: string) => {
+    const requestGeneration = ++watchDetailGeneration.current;
+    setSelected(fullName);
+    setWatchDetail(null);
+    try {
+      const detail = await bgCall<WatchRepositoryDetail>('getWatchRepositoryDetail', { fullName });
+      if (watchDetailGeneration.current !== requestGeneration) return;
+      if (!detail.star) {
+        setSelected(null);
+        return;
+      }
+      setSelected(detail.star.full_name);
+      setWatchDetail(detail);
+    } catch {
+      if (watchDetailGeneration.current === requestGeneration) setSelected(null);
+    }
+  };
+
+  const handleDetailDataChanged = () => {
+    refreshStars();
+    if (!starsSurface && selectedStar) {
+      void handleWatchRepositorySelect(selectedStar.full_name);
+    }
   };
 
   const openAgentPanel = () => {
@@ -266,7 +309,19 @@ export function ManagerPanel() {
     onRunAutoTags: () => { void handleAutoAssignTags(); },
   });
 
-  const agentCandidate = useMemo(() => selected
+  const handleSurfaceChange = (next: ManagerSurface) => {
+    if (next === surface || editingLayout) return;
+    watchDetailGeneration.current++;
+    setSelected(null);
+    setWatchDetail(null);
+    setOpenUnstarFullName(null);
+    setUnstarFeedback(null);
+    setAgentPanelOpen(false);
+    autoTagAgentPrompt.dismiss();
+    setSurface(next);
+  };
+
+  const agentCandidate = useMemo(() => starsSurface && selected
     ? {
         kind: 'selected_repository' as const,
         selectedRepositoryIdHint: selected,
@@ -297,6 +352,7 @@ export function ManagerPanel() {
     f.tagMode,
     f.tags,
     selected,
+    starsSurface,
   ]);
 
   const handleToggleFavorite = async (full_name: string, favorite: boolean) => {
@@ -430,10 +486,13 @@ export function ManagerPanel() {
           onStartLayoutEdit={editingLayout ? cancelLayoutEdit : beginCustomLayoutEdit}
           onPreviewCustomChange={previewCustomLayout}
           layoutEditChrome={layoutEditChrome}
+          surface={surface}
+          onSurfaceChange={handleSurfaceChange}
+          watchUnreadCount={watchInbox.result?.unreadCount ?? 0}
         />
-        {layoutColumnMenu}
+        {starsSurface && layoutColumnMenu}
 
-        {statusLoaded && status && !status.hasToken && status.onboardingStage === 'done' && (
+        {starsSurface && statusLoaded && status && !status.hasToken && status.onboardingStage === 'done' && (
           <div className="flex items-center gap-2 bg-warning/10 px-3 py-2 text-xs text-warning">
             <AlertTriangle className="size-4 shrink-0" />
             <span>{m.manager.noTokenBanner}</span>
@@ -447,7 +506,7 @@ export function ManagerPanel() {
           </div>
         )}
 
-        <div
+        {starsSurface && <div
           className={cn('gsm-active-filter-row', { open: hasActiveFilter })}
           aria-hidden={!hasActiveFilter}
           {...getLockedRegionProps(!hasActiveFilter)}
@@ -455,9 +514,9 @@ export function ManagerPanel() {
           <div>
             <ActiveFilterChips f={f} count={visibleTotal} interactionLocked={interactionLocked} />
           </div>
-        </div>
+        </div>}
 
-        {(info || unstarFeedback) && (
+        {starsSurface && (info || unstarFeedback) && (
           <div className="gsm-helper-text border-b border-border bg-card px-3 py-1">
             <span
               key={helperInfoKey(info, unstarFeedback)}
@@ -469,7 +528,7 @@ export function ManagerPanel() {
         )}
 
         <div className="flex min-h-0 flex-1">
-          <FilterSidebar
+          {starsSurface && <FilterSidebar
             f={f}
             languages={languages}
             tagTree={tagTree}
@@ -479,10 +538,27 @@ export function ManagerPanel() {
               if (message) setUnstarFeedback(null);
             }}
             onTagMutationSuccess={refreshStars}
-          />
+          />}
 
-          <div ref={listRef} data-coach-target="repo" className="no-scrollbar flex-1 overflow-auto">
-            {!statusLoaded || !status ? (
+          <div
+            ref={listRef}
+            data-coach-target={starsSurface ? 'repo' : undefined}
+            className="no-scrollbar flex-1 overflow-auto"
+          >
+            {!starsSurface ? (
+              <WatchInbox
+                result={watchInbox.result}
+                loading={watchInbox.loading}
+                refreshing={watchInbox.refreshing}
+                error={watchInbox.error}
+                unreadOnly={watchInbox.unreadOnly}
+                onUnreadOnlyChange={watchInbox.setUnreadOnly}
+                onRefresh={() => { void watchInbox.refresh(); }}
+                onRetryQuery={() => { void watchInbox.reload(); }}
+                onOpenOptions={() => bgCall('openOptions').catch(() => {})}
+                onSelectRepository={(fullName) => { void handleWatchRepositorySelect(fullName); }}
+              />
+            ) : !statusLoaded || !status ? (
               <div className="p-10 text-center text-sm text-muted-foreground">
                 {m.common.loading}
               </div>
@@ -557,12 +633,16 @@ export function ManagerPanel() {
                 tag={selectedTag}
                 selectedTags={f.tags}
                 onToggleTag={f.toggleTag}
-                onDataChanged={refreshStars}
-                onClose={() => setSelected(null)}
-                onPrev={() => selectedIdx > 0 && setSelected(visibleRows[selectedIdx - 1].full_name)}
-                onNext={() => selectedIdx >= 0 && selectedIdx < visibleRows.length - 1 && setSelected(visibleRows[selectedIdx + 1].full_name)}
-                hasPrev={selectedIdx > 0}
-                hasNext={selectedIdx >= 0 && selectedIdx < visibleRows.length - 1}
+                onDataChanged={handleDetailDataChanged}
+                onClose={() => {
+                  watchDetailGeneration.current++;
+                  setSelected(null);
+                  setWatchDetail(null);
+                }}
+                onPrev={() => starsSurface && selectedIdx > 0 && setSelected(visibleRows[selectedIdx - 1].full_name)}
+                onNext={() => starsSurface && selectedIdx >= 0 && selectedIdx < visibleRows.length - 1 && setSelected(visibleRows[selectedIdx + 1].full_name)}
+                hasPrev={starsSurface && selectedIdx > 0}
+                hasNext={starsSurface && selectedIdx >= 0 && selectedIdx < visibleRows.length - 1}
                 interactionLocked={interactionLocked}
               />
             )}
@@ -573,7 +653,7 @@ export function ManagerPanel() {
 
         <LayoutDragGhost ghost={dragGhost} />
 
-        {agentHostMounted && (
+        {starsSurface && agentHostMounted && (
           <Suspense fallback={null}>
             <LazyAgentHost
               open={agentPanelOpen}
@@ -588,14 +668,14 @@ export function ManagerPanel() {
           </Suspense>
         )}
 
-        <AutoTagAgentPrompt
+        {starsSurface && <AutoTagAgentPrompt
           open={autoTagAgentPrompt.open}
           onChooseAgent={autoTagAgentPrompt.chooseAgent}
           onChooseAutoTags={autoTagAgentPrompt.chooseAutoTags}
           onDismiss={autoTagAgentPrompt.dismiss}
-        />
+        />}
 
-        {statusLoaded && status?.onboardingStage === 'coach' && coachStep !== null && (
+        {starsSurface && statusLoaded && status?.onboardingStage === 'coach' && coachStep !== null && (
           <CoachOverlay
             step={coachStep}
             total={COACH_TARGETS.length}

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -193,6 +193,9 @@ export function Toolbar({
   onStartLayoutEdit,
   onPreviewCustomChange,
   layoutEditChrome,
+  surface = 'stars',
+  onSurfaceChange,
+  watchUnreadCount = 0,
 }: {
   f: FilterState;
   status: SyncStatus | null;
@@ -225,11 +228,15 @@ export function Toolbar({
   onStartLayoutEdit: () => void;
   onPreviewCustomChange: (previewing: boolean) => void;
   layoutEditChrome?: ReactNode;
+  surface?: 'stars' | 'watch';
+  onSurfaceChange?: (surface: 'stars' | 'watch') => void;
+  watchUnreadCount?: number;
 }) {
   const { m } = useI18n();
   const [account, setAccount] = useState<Account | null>(null);
   const [syncMenuOpen, setSyncMenuOpen] = useState(false);
   const [gistMenuOpen, setGistMenuOpen] = useState(false);
+  const starsSurface = surface === 'stars';
   const syncing = !!status?.inFlight && status.progress.phase !== 'idle';
   const phase = syncing ? status!.progress : null;
   const actionBusy = busy || syncing || pendingAction !== null;
@@ -315,6 +322,13 @@ export function Toolbar({
     }
   }, [layoutEditing]);
 
+  useEffect(() => {
+    if (starsSurface) return;
+    setSyncMenuOpen(false);
+    setGistMenuOpen(false);
+    customPreviewIntent.clear();
+  }, [customPreviewIntent.clear, starsSurface]);
+
   const seenTooltips = status?.seenTooltips ?? 0;
 
   const runSync = (type: string, label: string) => {
@@ -354,6 +368,45 @@ export function Toolbar({
           <TooltipContent>{m.toolbar.starRepoTitle}</TooltipContent>
         </Tooltip>
 
+        {onSurfaceChange && <div
+          className="inline-flex h-8 items-center rounded-md border border-border bg-muted p-0.5 text-xs"
+          role="group"
+          aria-label={m.watch.title}
+        >
+          <button
+            type="button"
+            aria-pressed={starsSurface}
+            disabled={layoutEditing}
+            onClick={() => onSurfaceChange('stars')}
+            className={cn('h-7 rounded px-2.5 font-medium text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring', {
+              'bg-background text-foreground shadow-sm': starsSurface,
+            })}
+          >
+            {m.watch.starsSurface}
+          </button>
+          <button
+            type="button"
+            aria-pressed={!starsSurface}
+            aria-label={watchUnreadCount > 0
+              ? m.watch.watchSurfaceUnread(watchUnreadCount)
+              : m.watch.watchSurface}
+            disabled={layoutEditing}
+            onClick={() => onSurfaceChange('watch')}
+            className={cn('inline-flex h-7 items-center gap-1.5 rounded px-2.5 font-medium text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring', {
+              'bg-background text-foreground shadow-sm': !starsSurface,
+            })}
+          >
+            {m.watch.watchSurface}
+            {watchUnreadCount > 0 && (
+              <span className="min-w-4 rounded-full bg-primary px-1 text-[10px] leading-4 text-primary-foreground tabular-nums">
+                {watchUnreadCount > 99 ? '99+' : watchUnreadCount}
+              </span>
+            )}
+          </button>
+        </div>}
+
+        {starsSurface && (
+          <>
         <div className="relative min-w-[220px] flex-1">
           <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
           <Input
@@ -507,11 +560,13 @@ export function Toolbar({
           />
           {m.toolbar.autoAssignButton}
         </TButton>
+          </>
+        )}
 
         <span className="flex-1" />
 
         {/* Optional AI workbench entry — post-spacer, independent of Auto Tags. */}
-        {onOpenAgent && (
+        {starsSurface && onOpenAgent && (
           <TButton
             variant="outline"
             size="sm"
@@ -533,6 +588,7 @@ export function Toolbar({
         )}
 
         {/* Gist hover bar: Push / Pull / Open. */}
+        {starsSurface && (
         <ToolHoverBar
           open={gistMenuOpen}
           onOpenChange={setGistMenuOpen}
@@ -614,6 +670,7 @@ export function Toolbar({
             )}
           </div>
         </ToolHoverBar>
+        )}
 
         <Tooltip>
           <TooltipTrigger asChild>
@@ -687,7 +744,7 @@ export function Toolbar({
 
       <div className="flex flex-col gap-1 border-t border-border/50 px-3 py-1 text-xs text-muted-foreground">
         <div className="flex flex-wrap items-center gap-4">
-          <span
+          {starsSurface && <span
             className="tabular-nums"
             style={{
               opacity: listPhase === 'fading-out' ? 0 : 1,
@@ -702,8 +759,8 @@ export function Toolbar({
             ) : (
               m.toolbar.shownTotal(total, grandTotal)
             )}
-          </span>
-          {syncing && phase && (
+          </span>}
+          {starsSurface && syncing && phase && (
             <span className="inline-flex items-center gap-2 text-primary">
               <Spinner className="size-3" />
               {m.common.phase(phase.phase)}: {phase.message}
@@ -717,7 +774,7 @@ export function Toolbar({
             </span>
           )}
           <span className="flex-1" />
-          <div className="relative ml-auto inline-flex shrink-0 items-center gap-2">
+          {starsSurface && <div className="relative ml-auto inline-flex shrink-0 items-center gap-2">
             <span className="text-[11px]">{m.toolbar.viewLabel}</span>
             <div className="inline-flex items-center gap-0.5 rounded-lg border border-border bg-muted p-0.5 text-[11px]">
               <div className={cn('inline-flex items-center gap-0.5', { 'pointer-events-none opacity-[0.35]': layoutControlsDisabled })}>
@@ -784,16 +841,20 @@ export function Toolbar({
                 {m.toolbar.previewCustomLayout}
               </span>
             )}
-          </div>
+          </div>}
         </div>
-        {syncing && progressValue != null && (
+        {starsSurface && syncing && progressValue != null && (
           <div className="flex items-center gap-2">
             <Progress value={progressValue} className="h-2 flex-1" />
             <span className="gsm-progress-count">{progressCount}</span>
           </div>
         )}
       </div>
-      {layoutEditChrome}
+      {starsSurface && (
+        <>
+          {layoutEditChrome}
+        </>
+      )}
     </div>
   );
 }

--- a/src/ui/components/WatchInbox.tsx
+++ b/src/ui/components/WatchInbox.tsx
@@ -1,0 +1,750 @@
+import {
+  AlertTriangle,
+  Bell,
+  BookOpen,
+  ChevronDown,
+  CircleDot,
+  Clock3,
+  Eye,
+  GitCommitHorizontal,
+  GitPullRequest,
+  Inbox,
+  ListFilter,
+  MessageCircle,
+  RefreshCw,
+  Search,
+  Settings2,
+  ShieldAlert,
+  Tag,
+  X,
+  type LucideIcon,
+} from 'lucide-react';
+import {
+  useId,
+  useMemo,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
+import { useI18n } from '@/i18n';
+import { cn } from '@/lib/utils';
+import { useImeBufferedInput } from '@/ui/hooks/use-ime-input';
+import { Button } from '@/ui/shadcn/button';
+import { Checkbox } from '@/ui/shadcn/checkbox';
+import { Input } from '@/ui/shadcn/input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/ui/shadcn/popover';
+import { Spinner } from '@/ui/shadcn/spinner';
+import {
+  countWatchReasons,
+  filterWatchInboxProjection,
+  formatWatchRelativeTime,
+  watchReasonPresetValues,
+  type WatchReasonCount,
+  type WatchReasonPreset,
+} from '@/ui/watch-inbox-presentation';
+import {
+  notificationSubjectTypeLabel,
+  type GitHubNotificationThread,
+} from '@/watch/watch-model';
+import type { WatchInboxQueryResponse } from '@/watch/watch-contract';
+
+interface WatchInboxProps {
+  result: WatchInboxQueryResponse | null;
+  loading: boolean;
+  refreshing: boolean;
+  error: 'query' | 'refresh' | null;
+  unreadOnly: boolean;
+  onUnreadOnlyChange: (unreadOnly: boolean) => void;
+  onRefresh: () => void;
+  onRetryQuery: () => void;
+  onOpenOptions: () => void;
+  onSelectRepository?: (fullName: string) => void;
+}
+
+const REASON_PRESETS: readonly WatchReasonPreset[] = [
+  'direct',
+  'security',
+  'participation',
+  'watching',
+  'other',
+];
+
+function normalizedReason(reason: string): string {
+  return reason.trim().toLowerCase();
+}
+
+function sameReasonSelection(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false;
+  const rightSet = new Set(right.map(normalizedReason));
+  return left.every((reason) => rightSet.has(normalizedReason(reason)));
+}
+
+function handleThreadListKeyDown(event: ReactKeyboardEvent<HTMLDivElement>) {
+  if (event.altKey || event.ctrlKey || event.metaKey) return;
+  if (!['ArrowUp', 'ArrowDown', 'Home', 'End'].includes(event.key)) return;
+  const target = event.target instanceof Element
+    ? event.target.closest<HTMLAnchorElement>('a[data-watch-thread]')
+    : null;
+  if (!target || !event.currentTarget.contains(target)) return;
+
+  // Collapsed groups do not render anchors, so this list is also the visible
+  // navigation order and remains scoped to this Watch surface.
+  const links = Array.from(
+    event.currentTarget.querySelectorAll<HTMLAnchorElement>('a[data-watch-thread]'),
+  );
+  const currentIndex = links.indexOf(target);
+  if (currentIndex < 0 || links.length === 0) return;
+
+  const nextIndex = event.key === 'Home'
+    ? 0
+    : event.key === 'End'
+      ? links.length - 1
+      : event.key === 'ArrowUp'
+        ? Math.max(0, currentIndex - 1)
+        : Math.min(links.length - 1, currentIndex + 1);
+  event.preventDefault();
+  links[nextIndex]?.focus();
+}
+
+function ReasonFilterPopover({
+  reasonCounts,
+  selectedReasons,
+  onSelectedReasonsChange,
+}: {
+  reasonCounts: readonly WatchReasonCount[];
+  selectedReasons: readonly string[];
+  onSelectedReasonsChange: (reasons: string[]) => void;
+}) {
+  const { m } = useI18n();
+  const selectedKeys = useMemo(
+    () => new Set(selectedReasons.map(normalizedReason)),
+    [selectedReasons],
+  );
+  const reasonRows = useMemo(() => {
+    const rows = new Map(
+      reasonCounts.map((item) => [normalizedReason(item.reason), item] as const),
+    );
+    for (const reason of selectedReasons) {
+      const key = normalizedReason(reason);
+      if (key && !rows.has(key)) rows.set(key, { reason, count: 0 });
+    }
+    return Array.from(rows.values()).sort((left, right) => (
+      left.reason.localeCompare(right.reason)
+    ));
+  }, [reasonCounts, selectedReasons]);
+  const availableReasons = reasonCounts.map((item) => item.reason);
+  const presetLabels: Record<WatchReasonPreset, string> = {
+    direct: m.watch.reasonPresetDirect,
+    security: m.watch.reasonPresetSecurity,
+    participation: m.watch.reasonPresetParticipation,
+    watching: m.watch.reasonPresetWatching,
+    other: m.watch.reasonPresetOther,
+  };
+  const triggerLabel = selectedReasons.length > 0
+    ? m.watch.reasonFilterSelected(selectedReasons.length)
+    : m.watch.reasonFilter;
+
+  const toggleReason = (reason: string) => {
+    const key = normalizedReason(reason);
+    onSelectedReasonsChange(
+      selectedKeys.has(key)
+        ? selectedReasons.filter((item) => normalizedReason(item) !== key)
+        : [...selectedReasons, reason],
+    );
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className={cn('h-8 shrink-0 px-2 text-muted-foreground', {
+            'border-foreground/30 bg-muted text-foreground': selectedReasons.length > 0,
+          })}
+          aria-label={triggerLabel}
+          title={triggerLabel}
+          disabled={reasonRows.length === 0}
+        >
+          <ListFilter className="size-3.5" aria-hidden="true" />
+          <span className="hidden sm:inline">{m.watch.reasonFilter}</span>
+          {selectedReasons.length > 0 && (
+            <span className="min-w-4 rounded-sm bg-primary px-1 font-mono text-[10px] leading-4 text-primary-foreground">
+              {selectedReasons.length}
+            </span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        collisionPadding={8}
+        className="w-72 p-2"
+        role="dialog"
+        aria-label={m.watch.reasonFilter}
+      >
+        <div className="px-1 pb-1.5 text-[11px] font-medium text-muted-foreground">
+          {m.watch.reasonPresets}
+        </div>
+        <div className="flex flex-wrap gap-1" role="group" aria-label={m.watch.reasonPresets}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className={cn('h-7 px-2 text-[11px]', {
+              'bg-muted text-foreground': selectedReasons.length === 0,
+            })}
+            aria-pressed={selectedReasons.length === 0}
+            onClick={() => onSelectedReasonsChange([])}
+          >
+            {m.watch.reasonPresetAll}
+          </Button>
+          {REASON_PRESETS.map((preset) => {
+            const values = watchReasonPresetValues(preset, availableReasons);
+            const active = values.length > 0 && sameReasonSelection(selectedReasons, values);
+            return (
+              <Button
+                key={preset}
+                type="button"
+                variant="ghost"
+                size="sm"
+                className={cn('h-7 px-2 text-[11px]', {
+                  'bg-muted text-foreground': active,
+                })}
+                disabled={values.length === 0}
+                aria-pressed={active}
+                onClick={() => onSelectedReasonsChange(values)}
+              >
+                {presetLabels[preset]}
+              </Button>
+            );
+          })}
+        </div>
+        <div className="my-2 h-px bg-border" />
+        <div className="max-h-64 overflow-y-auto pr-1">
+          {reasonRows.map(({ reason, count }) => {
+            const checked = selectedKeys.has(normalizedReason(reason));
+            return (
+              <label
+                key={normalizedReason(reason)}
+                className={cn('flex min-h-8 cursor-pointer items-center gap-2 rounded-sm px-1.5 py-1 text-xs hover:bg-muted/50', {
+                  'bg-muted/35 text-foreground': checked,
+                  'text-muted-foreground': !checked,
+                })}
+              >
+                <Checkbox
+                  checked={checked}
+                  onCheckedChange={() => toggleReason(reason)}
+                />
+                <code className="min-w-0 flex-1 truncate text-[11px]" title={reason}>
+                  {reason}
+                </code>
+                <span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
+                  {m.watch.reasonThreadCount(count)}
+                </span>
+              </label>
+            );
+          })}
+        </div>
+        {selectedReasons.length > 0 && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="mt-1 h-7 w-full justify-start px-1.5 text-[11px] text-muted-foreground"
+            onClick={() => onSelectedReasonsChange([])}
+          >
+            <X className="size-3.5" aria-hidden="true" />
+            {m.watch.reasonFilterClear}
+          </Button>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function formatTime(value: string | null, locale: string): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return null;
+  return new Intl.DateTimeFormat(locale, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function EmptyState({
+  icon,
+  text,
+  action,
+}: {
+  icon: React.ReactNode;
+  text: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="grid min-h-64 place-items-center px-6 py-12 text-center">
+      <div className="max-w-md">
+        <div className="mx-auto mb-3 grid size-10 place-items-center rounded-md bg-muted text-muted-foreground">
+          {icon}
+        </div>
+        <p className="text-sm leading-6 text-muted-foreground">{text}</p>
+        {action && <div className="mt-4">{action}</div>}
+      </div>
+    </div>
+  );
+}
+
+function ThreadRow({
+  thread,
+  locale,
+}: {
+  thread: GitHubNotificationThread;
+  locale: string;
+}) {
+  const { m } = useI18n();
+  const target = thread.subjectHtmlUrl ?? thread.repositoryHtmlUrl;
+  const updated = formatWatchRelativeTime(thread.updatedAt);
+  const updatedTitle = formatTime(thread.updatedAt, locale);
+  const subjectType = notificationSubjectTypeLabel(thread.subjectType);
+  const SubjectIcon = notificationSubjectIcon(thread.subjectType, thread.reason);
+  const metadataId = useId();
+  return (
+    <a
+      href={target}
+      target="_blank"
+      rel="noreferrer"
+      data-watch-thread
+      aria-label={`${m.watch.openOnGitHub}: ${thread.subjectTitle}`}
+      aria-describedby={metadataId}
+      className="group relative grid min-h-10 grid-cols-[18px_16px_minmax(0,1fr)_auto] items-center gap-x-2 px-4 py-1.5 text-foreground outline-none transition-colors hover:bg-muted/35 focus-visible:bg-muted/50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:grid-cols-[18px_16px_minmax(0,1fr)_minmax(0,auto)_auto]"
+    >
+      <span className="relative z-10 grid size-[18px] place-items-center bg-background" aria-hidden="true">
+        <span
+          className={cn('size-2 rounded-full', {
+            'bg-foreground': thread.unread,
+            'border border-muted-foreground/45 bg-background': !thread.unread,
+          })}
+          title={thread.unread ? m.watch.unreadSnapshot : undefined}
+        />
+      </span>
+      <SubjectIcon
+        className={cn('size-4 shrink-0', {
+          'text-foreground': thread.unread,
+          'text-muted-foreground': !thread.unread,
+        })}
+        aria-hidden="true"
+      />
+      <span
+        className={cn('min-w-0 truncate text-[13px] leading-5 group-hover:underline', {
+          'font-semibold text-foreground': thread.unread,
+          'font-medium text-foreground/80': !thread.unread,
+        })}
+        title={thread.subjectTitle}
+      >
+        {thread.subjectTitle}
+      </span>
+      <span id={metadataId} className="sr-only">
+        {thread.unread ? `${m.watch.unreadSnapshot}. ` : ''}
+        {subjectType}. {thread.reason}. {updatedTitle ?? ''}
+      </span>
+      <code
+        className="hidden max-w-44 truncate rounded-sm bg-muted px-1.5 py-0.5 text-[10px] leading-4 text-muted-foreground sm:block"
+        title={thread.reason}
+      >
+        {thread.reason}
+      </code>
+      {updated && (
+        <time
+          dateTime={thread.updatedAt}
+          title={updatedTitle ?? undefined}
+          className="min-w-[4ch] text-right font-mono text-[10px] tabular-nums text-muted-foreground"
+        >
+          {updated}
+        </time>
+      )}
+    </a>
+  );
+}
+
+/** GitHub subject types are open-ended; Bell keeps future values renderable. */
+function notificationSubjectIcon(type: string, reason: string): LucideIcon {
+  if (reason.trim().toLowerCase() === 'security_alert') return ShieldAlert;
+  switch (type.trim().toLowerCase().replace(/[\s_-]+/gu, '')) {
+    case 'issue':
+      return CircleDot;
+    case 'pullrequest':
+      return GitPullRequest;
+    case 'discussion':
+      return MessageCircle;
+    case 'commit':
+      return GitCommitHorizontal;
+    case 'release':
+      return Tag;
+    default:
+      return Bell;
+  }
+}
+
+function WatchGroup({
+  group,
+  locale,
+  defaultOpen,
+  revealMatches,
+  onSelectRepository,
+}: {
+  group: WatchInboxQueryResponse['groups'][number];
+  locale: string;
+  defaultOpen: boolean;
+  revealMatches: boolean;
+  onSelectRepository?: (fullName: string) => void;
+}) {
+  const { m } = useI18n();
+  const [open, setOpen] = useState(defaultOpen);
+  const expanded = revealMatches || open;
+  const unreadCount = group.threads.reduce(
+    (count, thread) => count + Number(thread.unread),
+    0,
+  );
+  return (
+    <section
+      className="relative bg-background"
+      style={{ contentVisibility: 'auto', containIntrinsicSize: '44px 320px' }}
+    >
+      {expanded && group.threads.length > 0 && (
+        <span
+          className="pointer-events-none absolute bottom-5 left-6 top-5 w-px bg-border"
+          aria-hidden="true"
+        />
+      )}
+      <div className="relative grid min-h-11 grid-cols-[18px_16px_minmax(0,1fr)_auto] items-center gap-x-2 px-4 py-1.5 hover:bg-muted/25">
+        <button
+          type="button"
+          className="relative z-10 grid size-[18px] place-items-center rounded-sm bg-background text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:hover:bg-background"
+          aria-expanded={expanded}
+          aria-label={expanded
+            ? m.watch.collapseRepository(group.repositoryFullName)
+            : m.watch.expandRepository(group.repositoryFullName)}
+          disabled={revealMatches}
+          onClick={() => setOpen((current) => !current)}
+        >
+          <ChevronDown
+            className={cn('size-3.5 transition-transform', { '-rotate-90': !expanded })}
+          />
+        </button>
+        <BookOpen className="size-3.5 text-muted-foreground" aria-hidden="true" />
+        <div className="flex min-w-0 items-center gap-2">
+          {onSelectRepository ? (
+            <button
+              type="button"
+              className="min-w-0 truncate rounded-sm text-left text-[13px] font-semibold text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              onClick={() => onSelectRepository(group.repositoryFullName)}
+            >
+              {group.repositoryFullName}
+            </button>
+          ) : (
+            <a
+              href={group.repositoryHtmlUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="min-w-0 truncate rounded-sm text-[13px] font-semibold text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {group.repositoryFullName}
+            </a>
+          )}
+          <span className="hidden shrink-0 items-center gap-1 text-[10px] text-muted-foreground md:inline-flex">
+            <Eye className="size-3" aria-hidden="true" />
+            {m.watch.watchedOnGitHub}
+          </span>
+        </div>
+        <span className="shrink-0 rounded-full border border-border px-2 py-0.5 font-mono text-[10px] tabular-nums text-muted-foreground">
+          {m.watch.repositoryUnreadCount(unreadCount)}
+        </span>
+      </div>
+      {expanded && (
+        <div>
+          {group.threads.map((thread) => (
+            <ThreadRow key={thread.id} thread={thread} locale={locale} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function WatchInbox({
+  result,
+  loading,
+  refreshing,
+  error,
+  unreadOnly,
+  onUnreadOnlyChange,
+  onRefresh,
+  onRetryQuery,
+  onOpenOptions,
+  onSelectRepository,
+}: WatchInboxProps) {
+  const { m, locale } = useI18n();
+  const [query, setQuery] = useState('');
+  const [selectedReasons, setSelectedReasons] = useState<string[]>([]);
+  const searchInput = useImeBufferedInput(query, setQuery);
+  const status = result?.status;
+  const state = status?.state;
+  const cooldownUntil = formatTime(state?.inbox.nextAllowedAt ?? null, locale);
+  const checkedAt = formatTime(state?.inbox.lastSuccessfulAt ?? null, locale);
+  const reasonCounts = useMemo(
+    () => countWatchReasons(result?.threads ?? []),
+    [result?.threads],
+  );
+  const visibleProjection = useMemo(
+    () => result
+      ? filterWatchInboxProjection(result, { query, reasons: selectedReasons })
+      : null,
+    [query, result, selectedReasons],
+  );
+  const groups = visibleProjection?.groups ?? [];
+  const hasPresentationFilters = query.trim().length > 0 || selectedReasons.length > 0;
+  const refreshDisabled = refreshing || status?.inboxStatus === 'cooldown';
+
+  if (loading) {
+    return <EmptyState icon={<Spinner className="size-5" />} text={m.common.loading} />;
+  }
+
+  if (!result || !status) {
+    return (
+      <EmptyState
+        icon={<AlertTriangle className="size-5" />}
+        text={m.watch.queryFailed}
+        action={<Button onClick={onRetryQuery}>{m.watch.retry}</Button>}
+      />
+    );
+  }
+
+  if (!status.hasMainToken) {
+    return (
+      <EmptyState
+        icon={<Settings2 className="size-5" />}
+        text={m.watch.configureMainToken}
+        action={<Button onClick={onOpenOptions}>{m.watch.openOptions}</Button>}
+      />
+    );
+  }
+
+  const scopeNeverLoaded = !state?.scope.lastSuccessfulAt;
+  const inboxNeverLoaded = !state?.inbox.lastSuccessfulAt;
+
+  return (
+    <section className="min-h-full bg-background" aria-label={m.watch.title}>
+      <header className="sticky top-0 z-20 border-b border-border bg-background/95 px-4 py-3 backdrop-blur">
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="min-w-0 flex-1">
+            <h2 className="text-sm font-semibold leading-5 text-foreground sm:truncate">
+              {m.watch.title}
+            </h2>
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+              <span>{m.watch.watchedRepositoryCount(state?.scope.repositoryCount ?? 0)}</span>
+              <span>{m.watch.threadCount(visibleProjection?.totalCount ?? 0)}</span>
+              {checkedAt && <span>{m.watch.snapshotAt(checkedAt)}</span>}
+            </div>
+          </div>
+          <div
+            className="inline-flex h-8 items-center rounded-md border border-border bg-muted p-0.5 text-xs"
+            role="group"
+            aria-label={m.watch.filterLabel}
+          >
+            <button
+              type="button"
+              aria-pressed={unreadOnly}
+              onClick={() => onUnreadOnlyChange(true)}
+              className={cn('h-7 rounded px-2.5 font-medium text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring', {
+                'bg-background text-foreground shadow-sm': unreadOnly,
+              })}
+            >
+              {m.watch.unread}
+            </button>
+            <button
+              type="button"
+              aria-pressed={!unreadOnly}
+              onClick={() => onUnreadOnlyChange(false)}
+              className={cn('h-7 rounded px-2.5 font-medium text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring', {
+                'bg-background text-foreground shadow-sm': !unreadOnly,
+              })}
+            >
+              {m.watch.all}
+            </button>
+          </div>
+          <Button
+            variant="outline"
+            size="icon"
+            className="size-8"
+            disabled={refreshDisabled}
+            onClick={onRefresh}
+            aria-label={refreshing ? m.watch.refreshing : m.watch.refresh}
+            title={refreshing ? m.watch.refreshing : m.watch.refresh}
+          >
+            {refreshing ? <Spinner className="size-4" /> : <RefreshCw className="size-4" />}
+          </Button>
+          <Button asChild variant="ghost" size="icon" className="size-8">
+            <a
+              href="https://github.com/watching"
+              target="_blank"
+              rel="noreferrer"
+              aria-label={m.watch.manageOnGitHub}
+              title={m.watch.manageOnGitHub}
+            >
+              <Settings2 className="size-4" />
+            </a>
+          </Button>
+        </div>
+        <div className="mt-3 flex min-w-0 items-center gap-2">
+          <div className="relative min-w-0 flex-1 sm:max-w-md">
+            <Search
+              className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <Input
+              {...searchInput.inputProps}
+              type="search"
+              aria-label={m.watch.searchPlaceholder}
+              placeholder={m.watch.searchPlaceholder}
+              className="h-8 pl-8 pr-8 text-xs"
+            />
+            {searchInput.value.length > 0 && (
+              <button
+                type="button"
+                aria-label={m.watch.clearSearch}
+                title={m.watch.clearSearch}
+                onClick={() => searchInput.commit('')}
+                className="absolute right-1.5 top-1/2 grid size-6 -translate-y-1/2 place-items-center rounded-sm text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <X className="size-3.5" aria-hidden="true" />
+              </button>
+            )}
+          </div>
+          <ReasonFilterPopover
+            reasonCounts={reasonCounts}
+            selectedReasons={selectedReasons}
+            onSelectedReasonsChange={setSelectedReasons}
+          />
+        </div>
+      </header>
+
+      {(error === 'refresh' || status.scopeStatus === 'stale' || status.inboxStatus === 'stale') && (
+        <div role="status" className="flex items-start gap-2 border-b border-warning/30 bg-warning/10 px-4 py-2 text-xs text-warning">
+          <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+          <span className="break-words">
+            {status.scopeStatus === 'stale' || status.inboxStatus === 'stale'
+              ? m.watch.staleSnapshot
+              : m.watch.refreshFailed}
+          </span>
+        </div>
+      )}
+      {error === 'query' && (
+        <div role="status" className="flex items-center gap-2 border-b border-warning/30 bg-warning/10 px-4 py-2 text-xs text-warning">
+          <AlertTriangle className="size-4 shrink-0" />
+          <span>{m.watch.queryFailed}</span>
+          <Button variant="ghost" size="sm" className="ml-auto" onClick={onRetryQuery}>
+            {m.watch.retry}
+          </Button>
+        </div>
+      )}
+      {status.scopeStatus === 'error' && (
+        <div role="alert" className="flex items-center gap-2 border-b border-destructive/30 bg-destructive/10 px-4 py-2 text-xs text-destructive">
+          <AlertTriangle className="size-4 shrink-0" />
+          <span>{m.watch.scopeFailed}</span>
+        </div>
+      )}
+      {status.inboxStatus === 'error' && (
+        <div role="alert" className="flex items-center gap-2 border-b border-destructive/30 bg-destructive/10 px-4 py-2 text-xs text-destructive">
+          <AlertTriangle className="size-4 shrink-0" />
+          <span>{m.watch.inboxFailed}</span>
+        </div>
+      )}
+      {state?.inbox.truncated && (
+        <div role="status" className="flex items-center gap-2 border-b border-border bg-muted/40 px-4 py-2 text-xs text-muted-foreground">
+          <Inbox className="size-4 shrink-0" />
+          <span>{m.watch.truncated}</span>
+        </div>
+      )}
+      {status.inboxStatus === 'cooldown' && cooldownUntil && (
+        <div role="status" className="flex items-center gap-2 border-b border-border bg-muted/40 px-4 py-2 text-xs text-muted-foreground">
+          <Clock3 className="size-4 shrink-0" />
+          <span>{m.watch.cooldownUntil(cooldownUntil)}</span>
+        </div>
+      )}
+
+      {status.scopeStatus === 'error' ? (
+        <EmptyState
+          icon={<AlertTriangle className="size-5" />}
+          text={state?.scope.errorCode === 'permission_denied'
+            ? m.watch.scopePermissionDenied
+            : m.watch.scopeFailed}
+          action={state?.scope.errorCode === 'permission_denied'
+            ? <Button onClick={onOpenOptions}>{m.watch.openOptions}</Button>
+            : <Button onClick={onRefresh} disabled={refreshDisabled}>{m.watch.retry}</Button>}
+        />
+      ) : scopeNeverLoaded ? (
+        <EmptyState
+          icon={<RefreshCw className="size-5" />}
+          text={m.watch.scopeNeverLoaded}
+          action={<Button onClick={onRefresh} disabled={refreshDisabled}>{m.watch.refresh}</Button>}
+        />
+      ) : state.scope.repositoryCount === 0 ? (
+        <EmptyState icon={<Inbox className="size-5" />} text={m.watch.noWatchedRepositories} />
+      ) : !status.hasNotificationsToken ? (
+        <EmptyState
+          icon={<Settings2 className="size-5" />}
+          text={m.watch.configureNotificationsToken}
+          action={<Button onClick={onOpenOptions}>{m.watch.openOptions}</Button>}
+        />
+      ) : status.inboxStatus === 'scope_unavailable' ? (
+        <EmptyState
+          icon={<AlertTriangle className="size-5" />}
+          text={m.watch.scopeUnavailable}
+          action={<Button onClick={onRefresh} disabled={refreshDisabled}>{m.watch.retry}</Button>}
+        />
+      ) : status.inboxStatus === 'error' ? (
+        <EmptyState
+          icon={<AlertTriangle className="size-5" />}
+          text={state.inbox.errorCode === 'permission_denied'
+            ? m.watch.inboxPermissionDenied
+            : m.watch.inboxFailed}
+          action={state.inbox.errorCode === 'permission_denied'
+            ? <Button onClick={onOpenOptions}>{m.watch.openOptions}</Button>
+            : <Button onClick={onRefresh} disabled={refreshDisabled}>{m.watch.retry}</Button>}
+        />
+      ) : inboxNeverLoaded ? (
+        <EmptyState
+          icon={<RefreshCw className="size-5" />}
+          text={m.watch.inboxNeverLoaded}
+          action={<Button onClick={onRefresh} disabled={refreshDisabled}>{m.watch.refresh}</Button>}
+        />
+      ) : groups.length === 0 ? (
+        <EmptyState
+          icon={<Inbox className="size-5" />}
+          text={result.threads.length > 0 && hasPresentationFilters
+            ? m.watch.noMatchingThreads
+            : unreadOnly ? m.watch.noUnreadThreads : m.watch.noThreads}
+        />
+      ) : (
+        <div
+          className="divide-y divide-border/60"
+          data-watch-thread-list
+          onKeyDown={handleThreadListKeyDown}
+        >
+          {groups.map((group, index) => (
+            <WatchGroup
+              key={group.repositoryFullName}
+              group={group}
+              locale={locale}
+              defaultOpen={index < 8}
+              revealMatches={hasPresentationFilters}
+              onSelectRepository={onSelectRepository}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/ui/hooks/use-manager-sync-actions.ts
+++ b/src/ui/hooks/use-manager-sync-actions.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { GITHUB_CREDENTIALS_STORAGE_KEY } from '@/auth/auth-store';
 import type { BackfillId } from '@/types';
 import { useI18n } from '@/i18n';
 import { isOnboardingCardStage, resolveOnboardingStageAfterSync, shouldTrackOnboardingSync } from '@/onboarding/state';
@@ -166,6 +167,23 @@ export function useManagerSyncActions({ refreshStars }: { refreshStars: () => vo
         .finally(() => setPendingAction((cur) => (cur === syncType ? null : cur)));
     })().finally(() => setStatusLoaded(true));
     return () => off();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const onChanged = chrome.storage?.onChanged;
+    if (!onChanged) return;
+    const listener = (
+      changes: Record<string, chrome.storage.StorageChange>,
+      areaName: string,
+    ) => {
+      if (areaName !== 'local' || !changes[GITHUB_CREDENTIALS_STORAGE_KEY]) return;
+      void refreshStatus();
+    };
+    onChanged.addListener(listener);
+    return () => onChanged.removeListener(listener);
+    // Credential changes refresh presentation only; initial-sync selection is
+    // intentionally owned by the mount effect above.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/ui/hooks/use-watch-inbox.ts
+++ b/src/ui/hooks/use-watch-inbox.ts
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { GITHUB_CREDENTIALS_STORAGE_KEY } from '@/auth/auth-store';
+import { bgCall } from '@/utils/messaging';
+import type {
+  WatchInboxQueryResponse,
+  WatchRefreshResult,
+} from '@/watch/watch-contract';
+
+export function useWatchInbox() {
+  const [unreadOnly, setUnreadOnly] = useState(true);
+  const [result, setResult] = useState<WatchInboxQueryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<'query' | 'refresh' | null>(null);
+  const generation = useRef(0);
+  const unreadOnlyRef = useRef(unreadOnly);
+  const refreshingRef = useRef(false);
+  const mountedRef = useRef(true);
+  const cooldownProbeRef = useRef<{ deadline: string | null; attempts: number }>({
+    deadline: null,
+    attempts: 0,
+  });
+  const [cooldownProbeTick, setCooldownProbeTick] = useState(0);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      generation.current++;
+    };
+  }, []);
+
+  const load = useCallback(async (silent = false, mode = unreadOnlyRef.current) => {
+    if (!mountedRef.current) return;
+    const requestGeneration = ++generation.current;
+    if (!silent) {
+      setLoading(true);
+      setResult(null);
+    }
+    try {
+      const next = await bgCall<WatchInboxQueryResponse>('queryWatchInbox', { unreadOnly: mode });
+      if (!mountedRef.current || generation.current !== requestGeneration) return;
+      setResult(next);
+      setError(null);
+    } catch {
+      if (!mountedRef.current || generation.current !== requestGeneration) return;
+      setError('query');
+    } finally {
+      if (mountedRef.current && generation.current === requestGeneration) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    unreadOnlyRef.current = unreadOnly;
+    void load(false, unreadOnly);
+  }, [load, unreadOnly]);
+
+  useEffect(() => {
+    const onMessage = chrome.runtime?.onMessage;
+    if (!onMessage) return;
+    const listener = (message: { type?: string }) => {
+      if (message.type === 'watchChanged') void load(true);
+    };
+    onMessage.addListener(listener);
+    return () => onMessage.removeListener(listener);
+  }, [load]);
+
+  useEffect(() => {
+    const onChanged = chrome.storage?.onChanged;
+    if (!onChanged) return;
+    const listener = (
+      changes: Record<string, chrome.storage.StorageChange>,
+      areaName: string,
+    ) => {
+      if (areaName !== 'local' || !changes[GITHUB_CREDENTIALS_STORAGE_KEY]) return;
+      void load(true);
+    };
+    onChanged.addListener(listener);
+    return () => onChanged.removeListener(listener);
+  }, [load]);
+
+  const cooldownUntil = result?.status.inboxStatus === 'cooldown'
+    ? result.status.state?.inbox.nextAllowedAt ?? null
+    : null;
+  useEffect(() => {
+    if (!cooldownUntil) {
+      cooldownProbeRef.current = { deadline: null, attempts: 0 };
+      return;
+    }
+    const allowedAt = Date.parse(cooldownUntil);
+    if (!Number.isFinite(allowedAt)) return;
+    if (cooldownProbeRef.current.deadline !== cooldownUntil) {
+      cooldownProbeRef.current = { deadline: cooldownUntil, attempts: 0 };
+    }
+    const remaining = allowedAt - Date.now();
+    // A timer can fire a little early. Retry once against the remaining
+    // deadline, but never turn an unchanged cooldown into a tight local loop.
+    if (remaining <= 0 && cooldownProbeRef.current.attempts > 0) return;
+    // This only re-derives status from local state; network refresh remains user initiated.
+    const timer = setTimeout(() => {
+      cooldownProbeRef.current.attempts += 1;
+      setCooldownProbeTick((current) => current + 1);
+      void load(true);
+    }, Math.max(0, remaining) + 25);
+    return () => clearTimeout(timer);
+  }, [cooldownProbeTick, cooldownUntil, load]);
+
+  const refresh = useCallback(async () => {
+    if (!mountedRef.current || refreshingRef.current) return;
+    refreshingRef.current = true;
+    setRefreshing(true);
+    setError(null);
+    try {
+      await bgCall<WatchRefreshResult>('refreshWatchInbox');
+      await load(true);
+    } catch {
+      await load(true);
+      if (mountedRef.current) setError('refresh');
+    } finally {
+      refreshingRef.current = false;
+      if (mountedRef.current) setRefreshing(false);
+    }
+  }, [load]);
+
+  const changeUnreadOnly = useCallback((next: boolean) => {
+    unreadOnlyRef.current = next;
+    setUnreadOnly(next);
+  }, []);
+
+  return {
+    unreadOnly,
+    setUnreadOnly: changeUnreadOnly,
+    result,
+    loading,
+    refreshing: refreshing || result?.status.refreshing === true,
+    error,
+    refresh,
+    reload: load,
+  };
+}

--- a/src/ui/watch-inbox-presentation.ts
+++ b/src/ui/watch-inbox-presentation.ts
@@ -1,0 +1,105 @@
+import {
+  projectWatchInbox,
+  type GitHubNotificationThread,
+  type WatchInboxProjection,
+} from '@/watch/watch-model';
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const MONTH_MS = 30 * DAY_MS;
+const YEAR_MS = 365 * DAY_MS;
+
+/** Compact, locale-neutral age used for Watch's machine-data column. */
+export function formatWatchRelativeTime(
+  value: string | null,
+  now: number = Date.now(),
+): string | null {
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp) || !Number.isFinite(now)) return null;
+
+  const elapsed = Math.max(0, now - timestamp);
+  if (elapsed < MINUTE_MS) return '<1m';
+  if (elapsed < HOUR_MS) return `${Math.floor(elapsed / MINUTE_MS)}m`;
+  if (elapsed < DAY_MS) return `${Math.floor(elapsed / HOUR_MS)}h`;
+  if (elapsed < MONTH_MS) return `${Math.floor(elapsed / DAY_MS)}d`;
+  if (elapsed < YEAR_MS) return `${Math.floor(elapsed / MONTH_MS)}mo`;
+  return `${Math.floor(elapsed / YEAR_MS)}y`;
+}
+
+export type WatchReasonPreset =
+  | 'direct'
+  | 'security'
+  | 'participation'
+  | 'watching'
+  | 'other';
+
+export const WATCH_REASON_PRESETS: Record<Exclude<WatchReasonPreset, 'other'>, readonly string[]> = {
+  direct: [
+    'approval_requested',
+    'assign',
+    'invitation',
+    'member_feature_requested',
+    'mention',
+    'review_requested',
+    'team_mention',
+  ],
+  security: ['security_advisory_credit', 'security_alert'],
+  participation: ['author', 'ci_activity', 'comment', 'manual', 'state_change'],
+  watching: ['subscribed'],
+};
+
+const CATEGORIZED_REASONS = new Set(Object.values(WATCH_REASON_PRESETS).flat());
+
+export interface WatchReasonCount {
+  reason: string;
+  count: number;
+}
+
+export function countWatchReasons(
+  threads: Iterable<GitHubNotificationThread>,
+): WatchReasonCount[] {
+  const counts = new Map<string, WatchReasonCount>();
+  for (const thread of threads) {
+    const key = thread.reason.toLowerCase();
+    const current = counts.get(key);
+    if (current) current.count++;
+    else counts.set(key, { reason: thread.reason, count: 1 });
+  }
+  return Array.from(counts.values()).sort((left, right) => (
+    left.reason.localeCompare(right.reason)
+  ));
+}
+
+export function watchReasonPresetValues(
+  preset: WatchReasonPreset,
+  availableReasons: Iterable<string>,
+): string[] {
+  const available = Array.from(availableReasons);
+  const allowed = preset === 'other'
+    ? null
+    : new Set(WATCH_REASON_PRESETS[preset]);
+  return available.filter((reason) => (
+    allowed ? allowed.has(reason.toLowerCase()) : !CATEGORIZED_REASONS.has(reason.toLowerCase())
+  ));
+}
+
+export function filterWatchInboxProjection(
+  projection: WatchInboxProjection,
+  input: { query?: string; reasons?: Iterable<string> } = {},
+): WatchInboxProjection {
+  const query = input.query?.trim().toLowerCase() ?? '';
+  const reasons = new Set(
+    Array.from(input.reasons ?? [], (reason) => reason.trim().toLowerCase()).filter(Boolean),
+  );
+  const threads = projection.threads.filter((thread) => {
+    if (reasons.size > 0 && !reasons.has(thread.reason.toLowerCase())) return false;
+    if (!query) return true;
+    return [
+      thread.repositoryFullName,
+      thread.subjectTitle,
+    ].some((value) => value.toLowerCase().includes(query));
+  });
+  return projectWatchInbox(threads);
+}

--- a/src/watch/watch-contract.ts
+++ b/src/watch/watch-contract.ts
@@ -1,0 +1,41 @@
+import type {
+  GitHubWatchStateRecord,
+  WatchInboxProjection,
+} from '@/watch/watch-model';
+
+export type WatchScopeStatus =
+  | 'not_configured'
+  | 'never_loaded'
+  | 'fresh'
+  | 'stale'
+  | 'error';
+
+export type WatchInboxStatus =
+  | 'not_configured'
+  | 'scope_unavailable'
+  | 'never_loaded'
+  | 'fresh'
+  | 'stale'
+  | 'error'
+  | 'cooldown';
+
+export interface WatchStatus {
+  accountLogin: string | null;
+  hasMainToken: boolean;
+  hasNotificationsToken: boolean;
+  refreshing: boolean;
+  scopeStatus: WatchScopeStatus;
+  inboxStatus: WatchInboxStatus;
+  state: GitHubWatchStateRecord | null;
+}
+
+export interface WatchInboxQueryResponse extends WatchInboxProjection {
+  status: WatchStatus;
+}
+
+export interface WatchRefreshResult {
+  status: WatchStatus;
+  scopePublished: boolean;
+  inboxPublished: boolean;
+  notModified: boolean;
+}

--- a/src/watch/watch-model.ts
+++ b/src/watch/watch-model.ts
@@ -209,24 +209,6 @@ export function repositoryHtmlUrl(fullName: unknown): string {
   return `${WEB_ORIGIN}/${normalizeRepositoryFullName(fullName)}`;
 }
 
-function safeRepositoryHtmlUrl(value: unknown, fullName: string): string {
-  if (typeof value !== 'string' || value.trim() === '') return repositoryHtmlUrl(fullName);
-  try {
-    const parsed = new URL(value);
-    if (parsed.origin !== WEB_ORIGIN || parsed.username || parsed.password || parsed.port) {
-      return repositoryHtmlUrl(fullName);
-    }
-    const path = parsed.pathname.replace(/\/$/, '').split('/').filter(Boolean);
-    if (path.length !== 2 || normalizeRepositoryFullName(path.join('/')) !== fullName) {
-      return repositoryHtmlUrl(fullName);
-    }
-    if (parsed.search || parsed.hash) return repositoryHtmlUrl(fullName);
-    return repositoryHtmlUrl(fullName);
-  } catch {
-    return repositoryHtmlUrl(fullName);
-  }
-}
-
 function apiPathSegments(value: string): string[] | null {
   try {
     const parsed = new URL(value);
@@ -376,8 +358,8 @@ export function normalizeNotificationThread(
     }
     subjectApiUrl = typeof subject.url === 'string' ? subject.url : null;
   }
-  const rawRepositoryUrl = repository.html_url;
-  const repositoryUrl = safeRepositoryHtmlUrl(rawRepositoryUrl, repositoryFullName);
+  // Rebuild from the validated repository name instead of trusting a remote URL.
+  const repositoryUrl = repositoryHtmlUrl(repositoryFullName);
   const subjectType = subject.type.trim();
   return {
     id: input.id.trim(),
@@ -439,7 +421,7 @@ export function dedupeNotificationThreads(
 
 export function filterNotificationThreads(
   threads: Iterable<GitHubNotificationThread>,
-  unreadOnly = true,
+  unreadOnly = false,
 ): GitHubNotificationThread[] {
   const selected = unreadOnly ? Array.from(threads).filter((thread) => thread.unread) : Array.from(threads);
   return sortNotificationThreads(selected);

--- a/src/watch/watch-model.ts
+++ b/src/watch/watch-model.ts
@@ -1,0 +1,543 @@
+/**
+ * Pure domain contracts and normalization helpers for the GitHub Watch
+ * surface.  API adapters use these helpers before a row is allowed to reach
+ * storage or the UI.  The model deliberately keeps GitHub's reason/type
+ * strings open-ended so a new server value is not silently discarded.
+ */
+
+export type WatchErrorCode =
+  | 'authentication_required'
+  | 'permission_denied'
+  | 'rate_limited'
+  | 'request_aborted'
+  | 'deadline_exceeded'
+  | 'network_error'
+  | 'github_unavailable'
+  | 'invalid_content_type'
+  | 'invalid_response'
+  | 'invalid_pagination'
+  | 'not_modified'
+  | 'page_limit_exceeded'
+  | 'invalid_repository'
+  | 'invalid_thread';
+
+/** Stable, non-payload-bearing error surfaced by either Watch API source. */
+export class GitHubWatchError extends Error {
+  readonly code: WatchErrorCode;
+  readonly status?: number;
+  readonly page?: number;
+
+  constructor(
+    code: WatchErrorCode,
+    message: string = code,
+    details: { status?: number; page?: number } = {},
+  ) {
+    super(message);
+    this.name = 'GitHubWatchError';
+    this.code = code;
+    this.status = details.status;
+    this.page = details.page;
+  }
+}
+
+/** A native watched repository, reduced to the identity needed by Watch. */
+export interface GitHubWatchRepository {
+  full_name: string;
+}
+
+/** Normalized GitHub Inbox thread. */
+export interface GitHubNotificationThread {
+  id: string;
+  repositoryFullName: string;
+  repositoryHtmlUrl: string;
+  reason: string;
+  subjectType: string;
+  subjectTitle: string;
+  subjectApiUrl: string | null;
+  subjectHtmlUrl: string | null;
+  unread: boolean;
+  updatedAt: string;
+  lastReadAt: string | null;
+  fetchedAt: string;
+}
+
+export interface WatchNotificationGroup {
+  repositoryFullName: string;
+  repositoryHtmlUrl: string;
+  latestUpdatedAt: string;
+  threads: GitHubNotificationThread[];
+}
+
+export interface WatchInboxProjection {
+  threads: GitHubNotificationThread[];
+  groups: WatchNotificationGroup[];
+  unreadCount: number;
+  totalCount: number;
+}
+
+export interface WatchRefreshSnapshot {
+  lastAttemptAt: string | null;
+  lastSuccessfulAt: string | null;
+  errorCode: string | null;
+}
+
+export interface WatchScopeRefreshSnapshot extends WatchRefreshSnapshot {
+  repositoryCount: number;
+}
+
+export interface WatchInboxRefreshSnapshot extends WatchRefreshSnapshot {
+  lastModified: string | null;
+  nextAllowedAt: string | null;
+  candidateCount: number;
+  matchedCount: number;
+  truncated: boolean;
+}
+
+export interface GitHubWatchStateRecord {
+  id: 'singleton';
+  accountLogin: string;
+  scope: WatchScopeRefreshSnapshot;
+  inbox: WatchInboxRefreshSnapshot;
+}
+
+export interface WatchScopeSnapshot {
+  repositories: GitHubWatchRepository[];
+  pageCount: number;
+  fetchedAt: string;
+}
+
+export interface WatchNotificationSnapshot {
+  threads: GitHubNotificationThread[];
+  /** Number of valid candidate threads received before scope intersection. */
+  candidateCount: number;
+  /** Number of threads remaining after optional watched-scope intersection. */
+  matchedCount: number;
+  pageCount: number;
+  truncated: boolean;
+  notModified: boolean;
+  before: string;
+  fetchedAt: string;
+  lastModified: string | null;
+  pollIntervalSeconds: number;
+}
+
+export interface NormalizeNotificationOptions {
+  fetchedAt?: string | Date | number;
+}
+
+const API_ORIGIN = 'https://api.github.com';
+const WEB_ORIGIN = 'https://github.com';
+
+// GitHub user/org names are at most 39 characters and repository names are at
+// most 100. Repository names may start with punctuation (`github/.github` is a
+// real example), so owner and repository grammar cannot share one expression.
+const OWNER_NAME = /^[A-Za-z0-9][A-Za-z0-9_.-]*$/;
+const REPOSITORY_NAME = /^[A-Za-z0-9_.-]+$/;
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function normalizedTimestamp(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim() === '' || !Number.isFinite(Date.parse(value))) {
+    throw new GitHubWatchError('invalid_thread', `invalid ${field}`);
+  }
+  // Keep the server's representation.  Date parsing is only validation; exact
+  // strings are useful when diagnosing GitHub's snapshot boundary.
+  return value;
+}
+
+function normalizedFetchedAt(value: string | Date | number | undefined): string {
+  if (value === undefined) return new Date().toISOString();
+  const date = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(date.getTime())) {
+    throw new GitHubWatchError('invalid_thread', 'invalid fetchedAt');
+  }
+  return date.toISOString();
+}
+
+/** Return a lower-case canonical `owner/repository` identity, or throw. */
+export function normalizeRepositoryFullName(value: unknown): string {
+  if (typeof value !== 'string') {
+    throw new GitHubWatchError('invalid_repository', 'repository full_name must be a string');
+  }
+  const input = value.trim();
+  const parts = input.split('/');
+  if (
+    parts.length !== 2 ||
+    parts[0]!.length === 0 ||
+    parts[0]!.length > 39 ||
+    parts[1]!.length === 0 ||
+    parts[1]!.length > 100 ||
+    !OWNER_NAME.test(parts[0]!) ||
+    !REPOSITORY_NAME.test(parts[1]!) ||
+    parts[1] === '.' ||
+    parts[1] === '..'
+  ) {
+    throw new GitHubWatchError('invalid_repository', 'invalid repository full_name');
+  }
+  return `${parts[0]!.toLowerCase()}/${parts[1]!.toLowerCase()}`;
+}
+
+/** Non-throwing repository identity guard useful at UI/query boundaries. */
+export function canonicalRepositoryFullName(value: unknown): string | null {
+  try {
+    return normalizeRepositoryFullName(value);
+  } catch {
+    return null;
+  }
+}
+
+export const normalizeRepositoryName = normalizeRepositoryFullName;
+export const canonicalRepositoryName = canonicalRepositoryFullName;
+
+/** Normalize a scope row and discard all unneeded remote fields. */
+export function normalizeWatchRepository(value: unknown): GitHubWatchRepository {
+  const input = record(value);
+  const fullName = normalizeRepositoryFullName(input?.full_name);
+  return { full_name: fullName };
+}
+
+/** Construct the only repository-page URL the Watch UI is allowed to open. */
+export function repositoryHtmlUrl(fullName: unknown): string {
+  return `${WEB_ORIGIN}/${normalizeRepositoryFullName(fullName)}`;
+}
+
+function safeRepositoryHtmlUrl(value: unknown, fullName: string): string {
+  if (typeof value !== 'string' || value.trim() === '') return repositoryHtmlUrl(fullName);
+  try {
+    const parsed = new URL(value);
+    if (parsed.origin !== WEB_ORIGIN || parsed.username || parsed.password || parsed.port) {
+      return repositoryHtmlUrl(fullName);
+    }
+    const path = parsed.pathname.replace(/\/$/, '').split('/').filter(Boolean);
+    if (path.length !== 2 || normalizeRepositoryFullName(path.join('/')) !== fullName) {
+      return repositoryHtmlUrl(fullName);
+    }
+    if (parsed.search || parsed.hash) return repositoryHtmlUrl(fullName);
+    return repositoryHtmlUrl(fullName);
+  } catch {
+    return repositoryHtmlUrl(fullName);
+  }
+}
+
+function apiPathSegments(value: string): string[] | null {
+  try {
+    const parsed = new URL(value);
+    if (parsed.origin !== API_ORIGIN || parsed.username || parsed.password || parsed.port) return null;
+    if (parsed.search || parsed.hash) return null;
+    const rawSegments = parsed.pathname.split('/');
+    if (
+      rawSegments[0] !== '' ||
+      rawSegments.slice(1).some((segment) => segment === '' || segment === '.' || segment === '..')
+    ) {
+      return null;
+    }
+    const segments: string[] = [];
+    for (const segment of rawSegments.slice(1)) {
+      let decoded: string;
+      try {
+        decoded = decodeURIComponent(segment);
+      } catch {
+        return null;
+      }
+      // Encoded separators must not become a different repository/path.
+      if (decoded.includes('/') || decoded.includes('\\') || decoded === '.' || decoded === '..') return null;
+      segments.push(decoded);
+    }
+    return segments;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Map a notification API subject URL to a browser URL only when the route,
+ * repository, subject type, and identifier all agree.  Unknown or hostile
+ * values return null so callers can fall back to the repository page.
+ */
+export function safeSubjectHtmlUrl(input: {
+  repositoryFullName: string;
+  subjectType: string;
+  subjectApiUrl: string | null | undefined;
+}): string | null;
+export function safeSubjectHtmlUrl(
+  repositoryFullName: string,
+  subjectType: string,
+  subjectApiUrl: string | null | undefined,
+): string | null;
+export function safeSubjectHtmlUrl(
+  first: {
+    repositoryFullName: string;
+    subjectType: string;
+    subjectApiUrl: string | null | undefined;
+  } | string,
+  second?: string,
+  third?: string | null,
+): string | null {
+  const repositoryFullName = typeof first === 'string' ? first : first.repositoryFullName;
+  const subjectType = typeof first === 'string' ? second ?? '' : first.subjectType;
+  const subjectApiUrl = typeof first === 'string' ? third : first.subjectApiUrl;
+  let canonicalRepository: string;
+  try {
+    canonicalRepository = normalizeRepositoryFullName(repositoryFullName);
+  } catch {
+    return null;
+  }
+  if (typeof subjectApiUrl !== 'string' || subjectApiUrl.trim() === '' || typeof subjectType !== 'string') {
+    return null;
+  }
+  const parts = apiPathSegments(subjectApiUrl);
+  if (!parts || parts.length !== 5 || parts[0] !== 'repos') return null;
+  let routeRepository: string;
+  try {
+    routeRepository = normalizeRepositoryFullName(`${parts[1]}/${parts[2]}`);
+  } catch {
+    return null;
+  }
+  if (routeRepository !== canonicalRepository) return null;
+
+  const route = parts[3]!.toLowerCase();
+  const identifier = parts[4]!;
+  const type = subjectType.trim().toLowerCase();
+  if (type === 'issue') {
+    if (route !== 'issues' || !/^[1-9]\d*$/.test(identifier)) return null;
+    return `${WEB_ORIGIN}/${canonicalRepository}/issues/${identifier}`;
+  }
+  if (type === 'pullrequest' || type === 'pull_request' || type === 'pull request') {
+    if ((route !== 'issues' && route !== 'pulls') || !/^[1-9]\d*$/.test(identifier)) return null;
+    return `${WEB_ORIGIN}/${canonicalRepository}/pull/${identifier}`;
+  }
+  if (type === 'discussion') {
+    if (route !== 'discussions' || !/^[1-9]\d*$/.test(identifier)) return null;
+    return `${WEB_ORIGIN}/${canonicalRepository}/discussions/${identifier}`;
+  }
+  if (type === 'commit') {
+    if (route !== 'commits' || !/^[0-9a-fA-F]{7,64}$/.test(identifier)) return null;
+    return `${WEB_ORIGIN}/${canonicalRepository}/commit/${identifier}`;
+  }
+  return null;
+}
+
+/** Positional alias used by API-source callers. */
+export function deriveSubjectHtmlUrl(
+  repositoryFullName: string,
+  subjectType: string,
+  subjectApiUrl: string | null | undefined,
+): string | null {
+  return safeSubjectHtmlUrl(repositoryFullName, subjectType, subjectApiUrl);
+}
+
+export const mapSubjectHtmlUrl = deriveSubjectHtmlUrl;
+
+export interface NotificationPayloadValidationOptions extends NormalizeNotificationOptions {}
+
+/** Normalize one raw `/notifications` row. */
+export function normalizeNotificationThread(
+  value: unknown,
+  options: NotificationPayloadValidationOptions = {},
+): GitHubNotificationThread {
+  const input = record(value);
+  if (!input || !nonEmptyString(input.id)) {
+    throw new GitHubWatchError('invalid_thread', 'notification id is required');
+  }
+  const repository = record(input.repository);
+  const subject = record(input.subject);
+  if (!repository || !subject) {
+    throw new GitHubWatchError('invalid_thread', 'notification repository and subject are required');
+  }
+  let repositoryFullName: string;
+  try {
+    repositoryFullName = normalizeRepositoryFullName(repository.full_name);
+  } catch {
+    throw new GitHubWatchError('invalid_thread', 'invalid notification repository');
+  }
+  if (!nonEmptyString(subject.title) || !nonEmptyString(input.reason) || !nonEmptyString(subject.type)) {
+    throw new GitHubWatchError('invalid_thread', 'notification title, reason, and type are required');
+  }
+  if (typeof input.unread !== 'boolean') {
+    throw new GitHubWatchError('invalid_thread', 'notification unread must be boolean');
+  }
+  const updatedAt = normalizedTimestamp(input.updated_at, 'updated_at');
+  let lastReadAt: string | null = null;
+  if (input.last_read_at !== undefined && input.last_read_at !== null) {
+    lastReadAt = normalizedTimestamp(input.last_read_at, 'last_read_at');
+  }
+  let subjectApiUrl: string | null = null;
+  if (input.subject && Object.prototype.hasOwnProperty.call(subject, 'url')) {
+    if (subject.url !== null && subject.url !== undefined && typeof subject.url !== 'string') {
+      throw new GitHubWatchError('invalid_thread', 'notification subject url must be string or null');
+    }
+    subjectApiUrl = typeof subject.url === 'string' ? subject.url : null;
+  }
+  const rawRepositoryUrl = repository.html_url;
+  const repositoryUrl = safeRepositoryHtmlUrl(rawRepositoryUrl, repositoryFullName);
+  const subjectType = subject.type.trim();
+  return {
+    id: input.id.trim(),
+    repositoryFullName,
+    repositoryHtmlUrl: repositoryUrl,
+    reason: input.reason.trim(),
+    subjectType,
+    subjectTitle: subject.title.trim(),
+    subjectApiUrl,
+    subjectHtmlUrl: safeSubjectHtmlUrl({
+      repositoryFullName,
+      subjectType,
+      subjectApiUrl,
+    }),
+    unread: input.unread,
+    updatedAt,
+    lastReadAt,
+    fetchedAt: normalizedFetchedAt(options.fetchedAt),
+  };
+}
+
+export const normalizeGitHubNotification = normalizeNotificationThread;
+
+function timestampValue(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/** Stable newest-first ordering; IDs provide a deterministic tie breaker. */
+export function sortNotificationThreads(
+  threads: Iterable<GitHubNotificationThread>,
+): GitHubNotificationThread[] {
+  return Array.from(threads).sort((left, right) => {
+    const time = timestampValue(right.updatedAt) - timestampValue(left.updatedAt);
+    if (time !== 0) return time;
+    return left.id.localeCompare(right.id);
+  });
+}
+
+/** Deduplicate by thread id, retaining the newest deterministic representation. */
+export function dedupeNotificationThreads(
+  threads: Iterable<GitHubNotificationThread>,
+): GitHubNotificationThread[] {
+  const byId = new Map<string, GitHubNotificationThread>();
+  for (const thread of threads) {
+    const current = byId.get(thread.id);
+    if (!current) {
+      byId.set(thread.id, thread);
+      continue;
+    }
+    const currentTime = timestampValue(current.updatedAt);
+    const nextTime = timestampValue(thread.updatedAt);
+    if (nextTime > currentTime || (nextTime === currentTime && JSON.stringify(thread) < JSON.stringify(current))) {
+      byId.set(thread.id, thread);
+    }
+  }
+  return sortNotificationThreads(byId.values());
+}
+
+export function filterNotificationThreads(
+  threads: Iterable<GitHubNotificationThread>,
+  unreadOnly = true,
+): GitHubNotificationThread[] {
+  const selected = unreadOnly ? Array.from(threads).filter((thread) => thread.unread) : Array.from(threads);
+  return sortNotificationThreads(selected);
+}
+
+export const filterWatchNotifications = filterNotificationThreads;
+
+/** Group threads by canonical repository, newest group first. */
+export function groupNotificationThreads(
+  threads: Iterable<GitHubNotificationThread>,
+  options: { unreadOnly?: boolean } = {},
+): WatchNotificationGroup[] {
+  const selected = filterNotificationThreads(threads, options.unreadOnly ?? false);
+  const groups = new Map<string, WatchNotificationGroup>();
+  for (const thread of selected) {
+    const group = groups.get(thread.repositoryFullName);
+    if (group) {
+      group.threads.push(thread);
+      if (timestampValue(thread.updatedAt) > timestampValue(group.latestUpdatedAt)) {
+        group.latestUpdatedAt = thread.updatedAt;
+      }
+    } else {
+      groups.set(thread.repositoryFullName, {
+        repositoryFullName: thread.repositoryFullName,
+        repositoryHtmlUrl: thread.repositoryHtmlUrl,
+        latestUpdatedAt: thread.updatedAt,
+        threads: [thread],
+      });
+    }
+  }
+  return Array.from(groups.values()).sort((left, right) => {
+    const time = timestampValue(right.latestUpdatedAt) - timestampValue(left.latestUpdatedAt);
+    if (time !== 0) return time;
+    return left.repositoryFullName.localeCompare(right.repositoryFullName);
+  });
+}
+
+export const groupWatchNotifications = groupNotificationThreads;
+
+export function projectWatchInbox(
+  threads: Iterable<GitHubNotificationThread>,
+  options: { unreadOnly?: boolean } = {},
+): WatchInboxProjection {
+  const selected = filterNotificationThreads(threads, options.unreadOnly ?? false);
+  return {
+    threads: selected,
+    groups: groupNotificationThreads(selected),
+    unreadCount: selected.reduce((count, thread) => count + Number(thread.unread), 0),
+    totalCount: selected.length,
+  };
+}
+
+export const queryWatchInbox = projectWatchInbox;
+
+/**
+ * GitHub's `reason` explains why a notification reached the authenticated
+ * user's Inbox; it is not a locally inferred tag or proof of current state.
+ * Keep unknown values persisted for forward compatibility.
+ * @see https://docs.github.com/en/rest/activity/notifications#about-notification-reasons
+ */
+export const KNOWN_NOTIFICATION_REASONS = [
+  'approval_requested',
+  'assign',
+  'author',
+  'comment',
+  'ci_activity',
+  'invitation',
+  'manual',
+  'member_feature_requested',
+  'mention',
+  'review_requested',
+  'security_advisory_credit',
+  'security_alert',
+  'state_change',
+  'subscribed',
+  'team_mention',
+] as const;
+
+export const KNOWN_NOTIFICATION_SUBJECT_TYPES = [
+  'Issue',
+  'PullRequest',
+  'Discussion',
+  'Commit',
+  'Release',
+] as const;
+
+export function notificationReasonLabel(reason: string): string {
+  const value = reason.trim();
+  if (!value) return 'Unknown';
+  return value
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+export function notificationSubjectTypeLabel(type: string): string {
+  const value = type.trim();
+  if (!value) return 'Unknown';
+  if (value.toLowerCase() === 'pullrequest' || value.toLowerCase() === 'pull_request') return 'Pull Request';
+  return value.replace(/[_-]+/g, ' ');
+}

--- a/tests/helpers/chrome-mock.ts
+++ b/tests/helpers/chrome-mock.ts
@@ -16,8 +16,9 @@ export function createChromeMock() {
     api: {
       storage: {
         local: {
-          async get(key: string) {
-            return { [key]: state[key] };
+          async get(key: string | string[]) {
+            const keys = Array.isArray(key) ? key : [key];
+            return Object.fromEntries(keys.map((item) => [item, state[item]]));
           },
           async set(next: Record<string, unknown>) {
             if (rejectNextSet) {

--- a/tests/regressions/auth/github-credential-context-regression.test.ts
+++ b/tests/regressions/auth/github-credential-context-regression.test.ts
@@ -32,6 +32,43 @@ function lockManager() {
   };
 }
 
+function delayedFirstLockResult() {
+  let tail: Promise<void> = Promise.resolve();
+  let requestCount = 0;
+  let markFirstOperationFinished!: () => void;
+  let releaseFirstResult!: () => void;
+  const firstOperationFinished = new Promise<void>((resolve) => {
+    markFirstOperationFinished = resolve;
+  });
+  const firstResultGate = new Promise<void>((resolve) => {
+    releaseFirstResult = resolve;
+  });
+  return {
+    manager: {
+      request<T>(_name: string, callback: () => Promise<T>): Promise<T> {
+        const operation = tail.then(callback, callback);
+        tail = operation.then(() => undefined, () => undefined);
+        requestCount++;
+        if (requestCount !== 1) return operation;
+        return operation.then(
+          async (value) => {
+            markFirstOperationFinished();
+            await firstResultGate;
+            return value;
+          },
+          async (error: unknown) => {
+            markFirstOperationFinished();
+            await firstResultGate;
+            throw error;
+          },
+        );
+      },
+    },
+    firstOperationFinished,
+    releaseFirstResult,
+  };
+}
+
 async function loadAuthStores() {
   vi.resetModules();
   const first = await import('@/auth/auth-store');
@@ -63,6 +100,26 @@ afterEach(() => {
 });
 
 describe('GitHub credential context isolation', () => {
+  it('publishes plaintext cache changes before releasing the shared credential lock', async () => {
+    const delayedLock = delayedFirstLockResult();
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { locks: delayedLock.manager },
+      configurable: true,
+    });
+    const { first, second } = await loadAuthStores();
+    globalThis.fetch = mainTokenFetch('idah', 'probe-context-cache-order');
+
+    const setToken = first.authStore.setToken('github_pat_context_cache_order');
+    await delayedLock.firstOperationFinished;
+    await second.authStore.clearToken();
+    delayedLock.releaseFirstResult();
+    await setToken;
+
+    const current = await first.authStore.getConfig();
+    assert.equal(current.tokenEncrypted, null);
+    assert.equal(current.onboardingStage, 'needs_token');
+  });
+
   it('keeps the authoritative credential record after a stale settings write', async () => {
     const { first, second } = await loadAuthStores();
     globalThis.fetch = mainTokenFetch('idah', 'probe-context-main');

--- a/tests/regressions/auth/github-credential-context-regression.test.ts
+++ b/tests/regressions/auth/github-credential-context-regression.test.ts
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it, vi } from 'vitest';
+import { createChromeMock, response } from '../../helpers/chrome-mock';
+
+let chromeMock: ReturnType<typeof createChromeMock>;
+let originalFetch: typeof fetch;
+let originalNavigator: unknown;
+
+function mainTokenFetch(login: string, probeId: string): typeof fetch {
+  return (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+    if (url.endsWith('/user') && method === 'GET') {
+      return response(200, { login, avatar_url: null, name: login }, { 'x-oauth-scopes': '' });
+    }
+    if (url.includes('/user/starred') && method === 'GET') return response(200, []);
+    if (url.endsWith('/gists') && method === 'POST') return response(201, { id: probeId });
+    if (url.endsWith(`/gists/${probeId}`) && method === 'DELETE') return response(204);
+    if (url.includes('/user/subscriptions') && method === 'GET') return response(200, []);
+    throw new Error(`unexpected credential fetch: ${method} ${url}`);
+  }) as typeof fetch;
+}
+
+function lockManager() {
+  let tail: Promise<void> = Promise.resolve();
+  return {
+    request<T>(_name: string, callback: () => Promise<T>): Promise<T> {
+      const result = tail.then(callback, callback);
+      tail = result.then(() => undefined, () => undefined);
+      return result;
+    },
+  };
+}
+
+async function loadAuthStores() {
+  vi.resetModules();
+  const first = await import('@/auth/auth-store');
+  vi.resetModules();
+  const second = await import('@/auth/auth-store');
+  return { first, second };
+}
+
+beforeEach(() => {
+  chromeMock = createChromeMock();
+  Object.defineProperty(globalThis, 'chrome', {
+    value: chromeMock.api,
+    configurable: true,
+  });
+  originalFetch = globalThis.fetch;
+  originalNavigator = globalThis.navigator;
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { locks: lockManager() },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  Object.defineProperty(globalThis, 'navigator', {
+    value: originalNavigator,
+    configurable: true,
+  });
+});
+
+describe('GitHub credential context isolation', () => {
+  it('keeps the authoritative credential record after a stale settings write', async () => {
+    const { first, second } = await loadAuthStores();
+    globalThis.fetch = mainTokenFetch('idah', 'probe-context-main');
+    await first.authStore.setToken('github_pat_context_main');
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/user')) return response(200, { login: 'idah' });
+      if (url.includes('/notifications?all=true&per_page=1')) return response(200, []);
+      throw new Error(`unexpected Notifications fetch: ${url}`);
+    }) as typeof fetch;
+    await first.authStore.setWatchNotificationsToken('ghp_context_watch');
+
+    const stale = await chromeMock.api.storage.local.get('gsm_config');
+    await second.authStore.clearToken();
+    await chromeMock.api.storage.local.set({
+      gsm_config: {
+        ...(stale.gsm_config as Record<string, unknown>),
+        theme: 'light',
+      },
+    });
+
+    const current = await first.authStore.getConfig();
+    assert.equal(current.username, null);
+    assert.equal(current.tokenEncrypted, null);
+    assert.equal(current.watchNotificationsTokenEncrypted, null);
+    assert.equal(await first.authStore.getToken(), null);
+    assert.equal(await first.authStore.getWatchNotificationsToken(), null);
+    assert.equal(await second.authStore.getToken(), null);
+    assert.equal(await second.authStore.getWatchNotificationsToken(), null);
+  });
+
+  it('does not publish a decrypted token when the credential record changes mid-read', async () => {
+    const { first, second } = await loadAuthStores();
+    globalThis.fetch = mainTokenFetch('idah', 'probe-context-late-read');
+    await first.authStore.setToken('github_pat_late_read');
+
+    const originalDecrypt = crypto.subtle.decrypt.bind(crypto.subtle);
+    let releaseDecrypt!: () => void;
+    let decryptStarted!: () => void;
+    const decryptGate = new Promise<void>((resolve) => { releaseDecrypt = resolve; });
+    const decryptReady = new Promise<void>((resolve) => { decryptStarted = resolve; });
+    let delayed = true;
+    crypto.subtle.decrypt = (async (...args: Parameters<SubtleCrypto['decrypt']>) => {
+      if (delayed) {
+        delayed = false;
+        decryptStarted();
+        await decryptGate;
+      }
+      return originalDecrypt(...args);
+    }) as SubtleCrypto['decrypt'];
+
+    try {
+      const pending = second.authStore.getToken();
+      await decryptReady;
+      const stored = await chromeMock.api.storage.local.get('gsm_github_credentials_v1');
+      await chromeMock.api.storage.local.set({
+        gsm_github_credentials_v1: {
+          ...(stored.gsm_github_credentials_v1 as Record<string, unknown>),
+          tokenEncrypted: null,
+          tokenCryptoMeta: null,
+          watchNotificationsTokenEncrypted: null,
+          watchNotificationsTokenCryptoMeta: null,
+          username: null,
+          avatarUrl: null,
+          displayName: null,
+        },
+      });
+      releaseDecrypt();
+      assert.equal(await pending, null);
+      assert.equal(await second.authStore.getToken(), null);
+    } finally {
+      crypto.subtle.decrypt = originalDecrypt as SubtleCrypto['decrypt'];
+    }
+  });
+});

--- a/tests/regressions/auth/token-probe-and-status-regression.test.ts
+++ b/tests/regressions/auth/token-probe-and-status-regression.test.ts
@@ -6,6 +6,7 @@ import {
   TOKEN_GIST_CLEANUP_STATUS,
   TOKEN_PROFILE_STATUS,
   TOKEN_STARS_STATUS,
+  TOKEN_WATCHING_FORBIDDEN,
   translateError,
 } from '../../../src/api/errors';
 import { probeTokenCapabilities } from '../../../src/auth/token-probe';
@@ -48,7 +49,9 @@ function fakeMessages() {
 const chromeMock = createChromeMock();
 (globalThis as { chrome?: unknown }).chrome = chromeMock.api;
 const originalFetch = globalThis.fetch;
-const { authStore } = await import('../../../src/auth/auth-store');
+const { authStore, GITHUB_CREDENTIALS_STORAGE_KEY } = await import(
+  '../../../src/auth/auth-store'
+);
 
 async function storeReadableToken(token: string, probeId: string) {
   globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
@@ -201,6 +204,33 @@ describe('Status/token regressions', () => {
     assert.equal(cfg.tokenEncrypted, null);
     assert.equal(cfg.username, null);
     assert.equal(await authStore.getToken(), null);
+  });
+
+  it('persists a valid main token while reporting optional Watching permission failure', async () => {
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? 'GET';
+      if (url.endsWith('/user') && method === 'GET') {
+        return response(200, { login: 'idah', avatar_url: null, name: 'Idah' }, { 'x-oauth-scopes': '' });
+      }
+      if (url.includes('/user/starred') && method === 'GET') return response(200, []);
+      if (url.endsWith('/gists') && method === 'POST') return response(201, { id: 'watching-optional' });
+      if (url.endsWith('/gists/watching-optional') && method === 'DELETE') return response(204);
+      if (url.includes('/user/subscriptions') && method === 'GET') return response(403);
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+
+    await authStore.clearToken();
+    const result = await authStore.setToken('github_pat_without_watching');
+
+    assert.deepEqual(result.watching, {
+      available: false,
+      errorCode: TOKEN_WATCHING_FORBIDDEN,
+    });
+    const cfg = await authStore.getConfig();
+    assert.ok(cfg.tokenEncrypted);
+    assert.equal(cfg.username, 'idah');
+    assert.equal(await authStore.getToken(), 'github_pat_without_watching');
   });
 
   it('authStore.update keeps the previous cached config when storage write fails', async () => {
@@ -432,9 +462,10 @@ describe('Status/token regressions', () => {
       assert.ok(persisted.tokenEncrypted);
       const changedCipher = `${persisted.tokenEncrypted[0] === 'A' ? 'B' : 'A'}${persisted.tokenEncrypted.slice(1)}`;
       assert.notEqual(persisted.tokenEncrypted, changedCipher);
+      const stored = await chromeMock.api.storage.local.get(GITHUB_CREDENTIALS_STORAGE_KEY);
       await chromeMock.api.storage.local.set({
-        gsm_config: {
-          ...persisted,
+        [GITHUB_CREDENTIALS_STORAGE_KEY]: {
+          ...(stored[GITHUB_CREDENTIALS_STORAGE_KEY] as object),
           tokenEncrypted: changedCipher,
         },
       });

--- a/tests/regressions/auth/watch-notifications-token-regression.test.ts
+++ b/tests/regressions/auth/watch-notifications-token-regression.test.ts
@@ -1,0 +1,282 @@
+import assert from 'node:assert/strict';
+import { afterAll, afterEach, beforeEach, describe, it } from 'vitest';
+import { createChromeMock, response } from '../../helpers/chrome-mock';
+import {
+  WATCH_TOKEN_ACCOUNT_CHANGED,
+  WATCH_TOKEN_ACCOUNT_MISMATCH,
+  WATCH_TOKEN_EMPTY,
+  WATCH_TOKEN_NOTIFICATIONS_FORBIDDEN,
+} from '@/api/errors';
+
+const chromeMock = createChromeMock();
+Object.defineProperty(globalThis, 'chrome', { value: chromeMock.api, configurable: true });
+const originalFetch = globalThis.fetch;
+const {
+  authStore,
+  CONFIG_STORAGE_KEY,
+  GITHUB_CREDENTIALS_STORAGE_KEY,
+} = await import('@/auth/auth-store');
+
+function mainTokenFetch(login: string, probeId: string): typeof fetch {
+  return (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+    if (url.endsWith('/user') && method === 'GET') {
+      return response(200, { login, avatar_url: null, name: login }, { 'x-oauth-scopes': '' });
+    }
+    if (url.includes('/user/starred') && method === 'GET') return response(200, []);
+    if (url.endsWith('/gists') && method === 'POST') return response(201, { id: probeId });
+    if (url.endsWith(`/gists/${probeId}`) && method === 'DELETE') return response(204);
+    if (url.includes('/user/subscriptions') && method === 'GET') return response(200, []);
+    throw new Error(`unexpected main-token fetch: ${method} ${url}`);
+  }) as typeof fetch;
+}
+
+function watchTokenFetch(input: {
+  login: string;
+  notificationsStatus?: number;
+  onRequest?: (url: string) => void;
+}): typeof fetch {
+  return (async (request: string | URL | Request) => {
+    const url = String(request);
+    input.onRequest?.(url);
+    if (url.endsWith('/user')) return response(200, { login: input.login });
+    if (url.includes('/notifications?all=true&per_page=1')) {
+      const status = input.notificationsStatus ?? 200;
+      return response(status, status === 200 ? [] : { message: 'denied' });
+    }
+    throw new Error(`unexpected Watch-token fetch: ${url}`);
+  }) as typeof fetch;
+}
+
+async function configureMain(login = 'Idah', token = 'github_pat_main'): Promise<void> {
+  globalThis.fetch = mainTokenFetch(login, `probe-${login}-${token}`);
+  await authStore.setToken(token);
+}
+
+async function configureWatch(login = 'idah', token = 'ghp_watch'): Promise<void> {
+  globalThis.fetch = watchTokenFetch({ login });
+  await authStore.setWatchNotificationsToken(token);
+}
+
+beforeEach(async () => {
+  await chromeMock.api.storage.local.clear();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('Watch Notifications token lifecycle', () => {
+  it('binds a classic token to the main account case-insensitively', async () => {
+    await configureMain('Idah');
+    await configureWatch('IDAH', 'ghp_notifications');
+
+    const config = await authStore.getConfig();
+    assert.ok(config.watchNotificationsTokenEncrypted);
+    assert.ok(config.watchNotificationsTokenCryptoMeta);
+    assert.equal(await authStore.hasWatchNotificationsToken(), true);
+    assert.equal(await authStore.getWatchNotificationsToken(), 'ghp_notifications');
+  });
+
+  it('stops before Notifications on account mismatch and preserves the existing token', async () => {
+    await configureMain();
+    await configureWatch('idah', 'ghp_existing');
+    const previous = await authStore.getConfig();
+    const calls: string[] = [];
+    globalThis.fetch = watchTokenFetch({ login: 'another-user', onRequest: (url) => calls.push(url) });
+
+    await assert.rejects(
+      () => authStore.setWatchNotificationsToken('ghp_wrong_account'),
+      (error: unknown) => error instanceof Error && error.message === WATCH_TOKEN_ACCOUNT_MISMATCH,
+    );
+
+    assert.deepEqual(calls, ['https://api.github.com/user']);
+    const current = await authStore.getConfig();
+    assert.equal(current.watchNotificationsTokenEncrypted, previous.watchNotificationsTokenEncrypted);
+    assert.deepEqual(current.watchNotificationsTokenCryptoMeta, previous.watchNotificationsTokenCryptoMeta);
+    assert.equal(await authStore.getWatchNotificationsToken(), 'ghp_existing');
+  });
+
+  it('preserves the existing token on permission or storage failure', async () => {
+    await configureMain();
+    await configureWatch('idah', 'ghp_existing');
+    const previous = await authStore.getConfig();
+
+    globalThis.fetch = watchTokenFetch({ login: 'idah', notificationsStatus: 403 });
+    await assert.rejects(
+      () => authStore.setWatchNotificationsToken('ghp_forbidden'),
+      (error: unknown) => error instanceof Error && error.message === WATCH_TOKEN_NOTIFICATIONS_FORBIDDEN,
+    );
+
+    globalThis.fetch = watchTokenFetch({ login: 'idah' });
+    chromeMock.rejectNextSet(new Error('storage failed'));
+    await assert.rejects(
+      () => authStore.setWatchNotificationsToken('ghp_write_failure'),
+      /storage failed/,
+    );
+
+    const current = await authStore.getConfig();
+    assert.equal(current.watchNotificationsTokenEncrypted, previous.watchNotificationsTokenEncrypted);
+    assert.deepEqual(current.watchNotificationsTokenCryptoMeta, previous.watchNotificationsTokenCryptoMeta);
+    assert.equal(await authStore.getWatchNotificationsToken(), 'ghp_existing');
+  });
+
+  it('rejects whitespace without network or storage work', async () => {
+    let fetchCalls = 0;
+    let setCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls++;
+      throw new Error('must not fetch');
+    }) as typeof fetch;
+    const originalSet = chromeMock.api.storage.local.set;
+    chromeMock.api.storage.local.set = (async (...args: Parameters<typeof originalSet>) => {
+      setCalls++;
+      return originalSet(...args);
+    }) as typeof originalSet;
+    try {
+      await assert.rejects(
+        () => authStore.setWatchNotificationsToken('  \n\t  '),
+        (error: unknown) => error instanceof Error && error.message === WATCH_TOKEN_EMPTY,
+      );
+    } finally {
+      chromeMock.api.storage.local.set = originalSet;
+    }
+    assert.equal(fetchCalls, 0);
+    assert.equal(setCalls, 0);
+  });
+
+  it('keeps the token for a same-account main PAT replacement and clears it on account change or logout', async () => {
+    await configureMain('Idah', 'github_pat_first');
+    await configureWatch('idah', 'ghp_existing');
+
+    globalThis.fetch = mainTokenFetch('IDAH', 'probe-same-account');
+    await authStore.setToken('github_pat_second');
+    assert.equal(await authStore.getWatchNotificationsToken(), 'ghp_existing');
+
+    globalThis.fetch = mainTokenFetch('another-user', 'probe-new-account');
+    await authStore.setToken('github_pat_other');
+    assert.equal(await authStore.getWatchNotificationsToken(), null);
+    assert.equal((await authStore.getConfig()).watchNotificationsTokenEncrypted, null);
+
+    await configureWatch('another-user', 'ghp_other');
+    await authStore.clearToken();
+    assert.equal(await authStore.getWatchNotificationsToken(), null);
+    assert.equal((await authStore.getConfig()).watchNotificationsTokenCryptoMeta, null);
+  });
+
+  it('does not let a stale settings write resurrect credentials after logout', async () => {
+    await configureMain();
+    await configureWatch('idah', 'ghp_existing');
+    const before = await chromeMock.api.storage.local.get(CONFIG_STORAGE_KEY);
+    const staleConfig = before[CONFIG_STORAGE_KEY] as Record<string, unknown>;
+
+    await authStore.clearToken();
+    await chromeMock.api.storage.local.set({
+      [CONFIG_STORAGE_KEY]: {
+        ...staleConfig,
+        theme: staleConfig.theme === 'dark' ? 'light' : 'dark',
+      },
+    });
+
+    const current = await authStore.getConfig();
+    assert.equal(current.username, null);
+    assert.equal(current.tokenEncrypted, null);
+    assert.equal(current.watchNotificationsTokenEncrypted, null);
+    assert.equal(await authStore.getToken(), null);
+    assert.equal(await authStore.getWatchNotificationsToken(), null);
+  });
+
+  it('normalizes an orphaned classic credential away without a bound main account', async () => {
+    await configureMain();
+    await configureWatch('idah', 'ghp_existing');
+
+    const stored = await chromeMock.api.storage.local.get(GITHUB_CREDENTIALS_STORAGE_KEY);
+    await chromeMock.api.storage.local.set({
+      [GITHUB_CREDENTIALS_STORAGE_KEY]: {
+        ...(stored[GITHUB_CREDENTIALS_STORAGE_KEY] as object),
+        tokenEncrypted: null,
+        tokenCryptoMeta: null,
+        username: null,
+      },
+    });
+
+    const normalized = await authStore.getConfig();
+    assert.equal(normalized.watchNotificationsTokenEncrypted, null);
+    assert.equal(normalized.watchNotificationsTokenCryptoMeta, null);
+    assert.equal(await authStore.getWatchNotificationsToken(), null);
+  });
+
+  it('serializes concurrent main and Notifications credential replacements', async () => {
+    await configureMain('idah', 'github_pat_existing');
+    let releaseMainProfile!: () => void;
+    const mainProfileGate = new Promise<void>((resolve) => {
+      releaseMainProfile = resolve;
+    });
+    const mainFetch = mainTokenFetch('idah', 'probe-concurrent-main');
+    const notificationsFetch = watchTokenFetch({ login: 'idah' });
+    globalThis.fetch = (async (request: string | URL | Request, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string> | undefined;
+      const authorization = headers?.Authorization ?? '';
+      const url = String(request);
+      if (authorization === 'Bearer github_pat_replacement') {
+        if (url.endsWith('/user')) await mainProfileGate;
+        return mainFetch(request, init);
+      }
+      if (authorization === 'Bearer ghp_concurrent') {
+        return notificationsFetch(request, init);
+      }
+      throw new Error(`unexpected concurrent credential fetch: ${authorization} ${url}`);
+    }) as typeof fetch;
+
+    const mainReplacement = authStore.setToken('github_pat_replacement');
+    await Promise.resolve();
+    const notificationsReplacement = authStore.setWatchNotificationsToken('ghp_concurrent');
+    await Promise.resolve();
+
+    releaseMainProfile();
+    await Promise.all([mainReplacement, notificationsReplacement]);
+
+    assert.equal(await authStore.getToken(), 'github_pat_replacement');
+    assert.equal(await authStore.getWatchNotificationsToken(), 'ghp_concurrent');
+    assert.equal((await authStore.getConfig()).username, 'idah');
+  });
+
+  it('cannot publish a probed token after the main credential changes', async () => {
+    await configureMain();
+    let resolveNotifications!: (response: Response) => void;
+    const pendingNotifications = new Promise<Response>((resolve) => {
+      resolveNotifications = resolve;
+    });
+    let markNotificationsStarted!: () => void;
+    const notificationsStarted = new Promise<void>((resolve) => {
+      markNotificationsStarted = resolve;
+    });
+    globalThis.fetch = (async (request: string | URL | Request) => {
+      const url = String(request);
+      if (url.endsWith('/user')) return response(200, { login: 'idah' });
+      if (url.includes('/notifications?all=true&per_page=1')) {
+        markNotificationsStarted();
+        return pendingNotifications;
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const pending = authStore.setWatchNotificationsToken('ghp_racing');
+    const rejected = assert.rejects(
+      () => pending,
+      (error: unknown) => error instanceof Error && error.message === WATCH_TOKEN_ACCOUNT_CHANGED,
+    );
+    await notificationsStarted;
+    globalThis.fetch = mainTokenFetch('another-user', 'probe-racing-account');
+    await authStore.setToken('github_pat_another_account');
+    resolveNotifications(response(200, []));
+
+    await rejected;
+    assert.equal((await authStore.getConfig()).watchNotificationsTokenEncrypted, null);
+  });
+});

--- a/tests/regressions/storage/dexie-tag-upgrade-regression.test.ts
+++ b/tests/regressions/storage/dexie-tag-upgrade-regression.test.ts
@@ -76,10 +76,16 @@ describe('Dexie tag schema upgrades', () => {
             'tagDirtyOutbox',
             'tagMeta',
             'tags',
+            'watchNotificationThreads',
+            'watchRepositories',
+            'watchState',
           ].sort(),
         );
         assert.equal(await current.organizeJobs.count(), 0);
         assert.equal(await current.tagDirtyOutbox.count(), 0);
+        assert.equal(await current.watchRepositories.count(), 0);
+        assert.equal(await current.watchNotificationThreads.count(), 0);
+        assert.equal(await current.watchState.count(), 0);
       } finally {
         await current.close();
         await Dexie.delete(DB_NAME);

--- a/tests/regressions/storage/watch-store-regression.test.ts
+++ b/tests/regressions/storage/watch-store-regression.test.ts
@@ -1,0 +1,611 @@
+import 'fake-indexeddb/auto';
+import assert from 'node:assert/strict';
+import { afterAll, beforeEach, describe, it, vi } from 'vitest';
+import { db } from '@/storage/db';
+import { createChromeMock } from '../../helpers/chrome-mock';
+import {
+  clearWatchData,
+  disconnectWatchInbox,
+  getWatchRepositories,
+  getWatchState,
+  queryStoredWatchInbox,
+  reconcileWatchAccount,
+  reconcileWatchLiveStars,
+  recordWatchInboxFailure,
+  recordWatchScopeFailure,
+  replaceWatchInbox,
+  replaceWatchScope,
+  revalidateWatchInbox,
+} from '@/storage/watch-store';
+import type { GitHubNotificationThread } from '@/watch/watch-model';
+
+const chromeMock = createChromeMock();
+Object.defineProperty(globalThis, 'chrome', { value: chromeMock.api, configurable: true });
+
+const { CONFIG_STORAGE_KEY } = await import('@/auth/auth-store');
+const {
+  markDirtyForLocalWrites,
+  resetDirtyForDev,
+  snapshotDirty,
+} = await import('@/storage/idb-tag-store');
+
+const ACCOUNT = 'Idah';
+const FIRST = '2026-08-05T01:00:00.000Z';
+const SECOND = '2026-08-05T02:00:00.000Z';
+
+function thread(id: string, repositoryFullName = 'owner/repo'): GitHubNotificationThread {
+  return {
+    id,
+    repositoryFullName,
+    repositoryHtmlUrl: `https://github.com/${repositoryFullName}`,
+    reason: 'subscribed',
+    subjectType: 'Issue',
+    subjectTitle: `Thread ${id}`,
+    subjectApiUrl: `https://api.github.com/repos/${repositoryFullName}/issues/1`,
+    subjectHtmlUrl: `https://github.com/${repositoryFullName}/issues/1`,
+    unread: true,
+    updatedAt: FIRST,
+    lastReadAt: null,
+    fetchedAt: FIRST,
+  };
+}
+
+function star(fullName: string, tombstone = false) {
+  return {
+    full_name: fullName,
+    html_url: `https://github.com/${fullName}`,
+    description: '',
+    language: null,
+    stargazers_count: 0,
+    topics: [],
+    pushed_at: null,
+    created_at: null,
+    fork: false,
+    archived: false,
+    starred_at: FIRST,
+    tombstone,
+    synced_at: FIRST,
+  };
+}
+
+async function snapshotNonWatchData() {
+  const [
+    stars,
+    tags,
+    tagMeta,
+    organizeJobs,
+    organizeItems,
+    organizeTaxonomies,
+    organizeApplies,
+    organizeApplyRows,
+    tagDirtyOutbox,
+    storedConfig,
+  ] = await Promise.all([
+    db.stars.toArray(),
+    db.tags.toArray(),
+    db.tagMeta.toArray(),
+    db.organizeJobs.toArray(),
+    db.organizeItems.toArray(),
+    db.organizeTaxonomies.toArray(),
+    db.organizeApplies.toArray(),
+    db.organizeApplyRows.toArray(),
+    db.tagDirtyOutbox.toArray(),
+    chromeMock.api.storage.local.get(CONFIG_STORAGE_KEY),
+  ]);
+  return {
+    stars,
+    tags,
+    tagMeta,
+    organizeJobs,
+    organizeItems,
+    organizeTaxonomies,
+    organizeApplies,
+    organizeApplyRows,
+    tagDirtyOutbox,
+    config: storedConfig[CONFIG_STORAGE_KEY],
+    dirty: snapshotDirty(),
+  };
+}
+
+describe('Watch snapshot storage', () => {
+  beforeEach(async () => {
+    await db.delete();
+    await db.open();
+    await chromeMock.api.storage.local.clear();
+    resetDirtyForDev();
+  });
+
+  afterAll(async () => {
+    resetDirtyForDev();
+    await db.close();
+  });
+
+  it('atomically replaces a successful scope and preserves it after failure', async () => {
+    await replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'Owner/One' }, { full_name: 'owner/two' }],
+      attemptedAt: FIRST,
+    });
+    await replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/two' }],
+      attemptedAt: SECOND,
+    });
+
+    assert.deepEqual(await getWatchRepositories('idah'), [{ full_name: 'owner/two' }]);
+
+    await recordWatchScopeFailure({
+      accountLogin: ACCOUNT,
+      attemptedAt: '2026-08-05T03:00:00.000Z',
+      errorCode: 'network_error',
+    });
+
+    assert.deepEqual(await getWatchRepositories('IDAH'), [{ full_name: 'owner/two' }]);
+    const state = await getWatchState('idah');
+    assert.equal(state?.scope.lastSuccessfulAt, SECOND);
+    assert.equal(state?.scope.errorCode, 'network_error');
+  });
+
+  it('rolls back scope rows, pruned Inbox rows, and state when the scope checkpoint fails', async () => {
+    await replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/one' }, { full_name: 'owner/two' }],
+      attemptedAt: FIRST,
+    });
+    await replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads: [thread('1', 'owner/one'), thread('2', 'owner/two')],
+      attemptedAt: FIRST,
+      lastModified: 'Wed, 05 Aug 2026 01:00:00 GMT',
+      nextAllowedAt: SECOND,
+      candidateCount: 2,
+      truncated: false,
+    });
+    const before = {
+      repositories: await db.watchRepositories.orderBy('full_name').toArray(),
+      threads: await db.watchNotificationThreads.orderBy('id').toArray(),
+      state: await db.watchState.get('singleton'),
+    };
+    const stateWrite = vi.spyOn(db.watchState, 'put')
+      .mockRejectedValueOnce(new Error('scope state checkpoint failed'));
+
+    try {
+      await assert.rejects(
+        () => replaceWatchScope({
+          accountLogin: ACCOUNT,
+          repositories: [{ full_name: 'owner/two' }, { full_name: 'owner/three' }],
+          attemptedAt: SECOND,
+        }),
+        /scope state checkpoint failed/u,
+      );
+    } finally {
+      stateWrite.mockRestore();
+    }
+
+    assert.deepEqual(
+      {
+        repositories: await db.watchRepositories.orderBy('full_name').toArray(),
+        threads: await db.watchNotificationThreads.orderBy('id').toArray(),
+        state: await db.watchState.get('singleton'),
+      },
+      before,
+    );
+  });
+
+  it('rolls back Inbox rows and state when the Inbox checkpoint fails', async () => {
+    await replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/one' }, { full_name: 'owner/two' }],
+      attemptedAt: FIRST,
+    });
+    await replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads: [thread('1', 'owner/one'), thread('2', 'owner/two')],
+      attemptedAt: FIRST,
+      lastModified: 'Wed, 05 Aug 2026 01:00:00 GMT',
+      nextAllowedAt: SECOND,
+      candidateCount: 2,
+      truncated: false,
+    });
+    const before = {
+      threads: await db.watchNotificationThreads.orderBy('id').toArray(),
+      state: await db.watchState.get('singleton'),
+    };
+    const stateWrite = vi.spyOn(db.watchState, 'put')
+      .mockRejectedValueOnce(new Error('Inbox state checkpoint failed'));
+
+    try {
+      await assert.rejects(
+        () => replaceWatchInbox({
+          accountLogin: ACCOUNT,
+          threads: [thread('replacement', 'owner/two')],
+          attemptedAt: SECOND,
+          lastModified: 'Wed, 05 Aug 2026 02:00:00 GMT',
+          nextAllowedAt: '2026-08-05T03:00:00.000Z',
+          candidateCount: 1,
+          truncated: true,
+        }),
+        /Inbox state checkpoint failed/u,
+      );
+    } finally {
+      stateWrite.mockRestore();
+    }
+
+    assert.deepEqual(
+      {
+        threads: await db.watchNotificationThreads.orderBy('id').toArray(),
+        state: await db.watchState.get('singleton'),
+      },
+      before,
+    );
+  });
+
+  it('removes cached Inbox threads outside a newly successful scope', async () => {
+    await replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/one' }, { full_name: 'owner/two' }],
+      attemptedAt: FIRST,
+    });
+    await replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads: [
+        thread('1', 'owner/one'),
+        thread('2', 'owner/two'),
+        thread('3', 'outside/scope'),
+      ],
+      attemptedAt: FIRST,
+      lastModified: 'Wed, 05 Aug 2026 01:00:00 GMT',
+      nextAllowedAt: SECOND,
+      candidateCount: 3,
+      truncated: false,
+    });
+
+    const initial = await queryStoredWatchInbox({ accountLogin: 'idah', unreadOnly: false });
+    assert.deepEqual(initial.threads.map((row) => row.id), ['1', '2']);
+    assert.equal(initial.state?.inbox.matchedCount, 2);
+
+    await replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/two' }],
+      attemptedAt: SECOND,
+    });
+
+    const result = await queryStoredWatchInbox({ accountLogin: 'idah', unreadOnly: false });
+    assert.deepEqual(result.threads.map((row) => row.id), ['2']);
+    assert.equal(result.state?.inbox.matchedCount, 1);
+    assert.equal(result.state?.inbox.lastModified, null);
+    assert.equal(result.state?.inbox.nextAllowedAt, null);
+    assert.equal(result.state?.inbox.errorCode, 'scope_changed');
+    assert.deepEqual(await db.watchNotificationThreads.toCollection().primaryKeys(), ['2']);
+  });
+
+  it('keeps the last Inbox on failure and 304-style revalidation', async () => {
+    await replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/repo' }],
+      attemptedAt: FIRST,
+    });
+    await replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads: [thread('1')],
+      attemptedAt: FIRST,
+      lastModified: 'Wed, 05 Aug 2026 01:00:00 GMT',
+      nextAllowedAt: SECOND,
+      candidateCount: 2,
+      truncated: true,
+    });
+    await recordWatchInboxFailure({
+      accountLogin: ACCOUNT,
+      attemptedAt: SECOND,
+      errorCode: 'github_unavailable',
+    });
+
+    assert.deepEqual((await queryStoredWatchInbox({ accountLogin: 'idah' })).threads.map((row) => row.id), ['1']);
+
+    await revalidateWatchInbox({
+      accountLogin: ACCOUNT,
+      attemptedAt: '2026-08-05T03:00:00.000Z',
+      nextAllowedAt: '2026-08-05T03:01:00.000Z',
+    });
+
+    const result = await queryStoredWatchInbox({ accountLogin: 'idah' });
+    assert.deepEqual(result.threads.map((row) => row.id), ['1']);
+    assert.equal(result.state?.inbox.errorCode, null);
+    assert.equal(result.state?.inbox.candidateCount, 2);
+    assert.equal(result.state?.inbox.truncated, true);
+  });
+
+  it('isolates account changes and lets disconnect clear only private Inbox data', async () => {
+    await replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/repo' }],
+      attemptedAt: FIRST,
+    });
+    await replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads: [thread('1')],
+      attemptedAt: FIRST,
+      lastModified: null,
+      nextAllowedAt: SECOND,
+      candidateCount: 1,
+      truncated: false,
+    });
+
+    await disconnectWatchInbox('IDAH');
+    assert.deepEqual(await getWatchRepositories('idah'), [{ full_name: 'owner/repo' }]);
+    assert.equal((await queryStoredWatchInbox({ accountLogin: 'idah' })).threads.length, 0);
+
+    await replaceWatchScope({
+      accountLogin: 'another-user',
+      repositories: [{ full_name: 'other/repo' }],
+      attemptedAt: SECOND,
+    });
+    assert.equal(await getWatchState('idah'), null);
+    assert.deepEqual(await getWatchRepositories('another-user'), [{ full_name: 'other/repo' }]);
+  });
+
+  it('never rebinds mismatched or orphaned rows to another account', async () => {
+    await replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'alice/private' }],
+      attemptedAt: FIRST,
+    });
+    await replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads: [thread('private', 'alice/private')],
+      attemptedAt: FIRST,
+      lastModified: null,
+      nextAllowedAt: null,
+      candidateCount: 1,
+      truncated: false,
+    });
+
+    await disconnectWatchInbox('bob');
+    assert.equal(await db.watchRepositories.count(), 0);
+    assert.equal(await db.watchNotificationThreads.count(), 0);
+    assert.equal(await db.watchState.count(), 0);
+
+    await replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'alice/private' }],
+      attemptedAt: FIRST,
+    });
+    await db.watchState.clear();
+    await recordWatchScopeFailure({
+      accountLogin: 'bob',
+      attemptedAt: SECOND,
+      errorCode: 'network_error',
+    });
+    assert.deepEqual(await getWatchRepositories('bob'), []);
+    assert.equal(await db.watchRepositories.count(), 0);
+
+    await db.watchRepositories.put({ full_name: 'alice/private' });
+    await db.watchState.clear();
+    await disconnectWatchInbox(null);
+    assert.equal(await db.watchRepositories.count(), 0);
+  });
+
+  it('clears only Watch data while preserving annotations, Agent stores, and Gist state', async () => {
+    await Promise.all([
+      db.stars.put({
+        full_name: 'owner/repo',
+        html_url: 'https://github.com/owner/repo',
+        description: '',
+        language: null,
+        stargazers_count: 1,
+        topics: [],
+        pushed_at: null,
+        created_at: null,
+        fork: false,
+        archived: false,
+        starred_at: FIRST,
+        tombstone: false,
+        synced_at: FIRST,
+      }),
+      db.tags.put({
+        full_name: 'owner/repo',
+        manualTags: ['preserved'],
+        autoTags: ['agent'],
+        dismissedAutoTags: [],
+        manualTagsMtime: FIRST,
+        autoTagsMtime: FIRST,
+        dismissedAutoTagsMtime: FIRST,
+        notes: 'Keep this annotation.',
+        favorite: true,
+        mtime: FIRST,
+      }),
+      db.tagMeta.put({
+        name: 'preserved',
+        dimension: 'topic',
+        color: '#123456',
+        excluded: false,
+        mtime: FIRST,
+      }),
+      db.organizeJobs.put({
+        jobId: 'job:preserved',
+        activeSlot: 'active',
+        controllerId: 'controller:preserved',
+        sessionId: 'session:preserved',
+        runId: 'run:v1:preserved',
+        generation: 1,
+        proposalId: 'proposal:v1:preserved',
+        frozenScope: {
+          kind: 'all_stars',
+          label: 'All stars',
+          filterSnapshot: {},
+          repositoryIds: ['owner/repo'],
+          capturedAt: 1,
+          fingerprint: 'scope:preserved',
+        },
+        taskInstruction: 'Preserve this Agent job.',
+        budget: { maxBatches: 1 },
+        usage: { batches: 0 },
+        nextFrozenIndex: 1,
+        analysisPendingRanges: [],
+        providerBinding: null,
+        status: 'apply_sealed',
+        preflight: null,
+        revision: 1,
+        itemCount: 1,
+        applyId: 'apply:preserved',
+        pauseRequested: false,
+        createdAt: 1,
+        updatedAt: 2,
+        completedAt: null,
+        cancelledAt: null,
+      }),
+      db.organizeItems.put({
+        id: 'job:preserved:0',
+        jobId: 'job:preserved',
+        position: 0,
+        fullName: 'owner/repo',
+        analysisState: 'actionable',
+        proposedActions: [{
+          kind: 'add_existing_tag',
+          tag: 'preserved',
+          evidence: 'Stored evidence.',
+        }],
+        approvedActions: [{
+          kind: 'add_existing_tag',
+          tag: 'preserved',
+          evidence: 'Stored evidence.',
+        }],
+        proposedAdditions: ['preserved'],
+        sourceFingerprint: 'source:preserved',
+        selected: true,
+        retryCount: 0,
+        failure: null,
+        leaseToken: null,
+        leaseOwner: null,
+        leaseExpiresAt: null,
+        analyzedAt: 2,
+      }),
+      db.organizeTaxonomies.put({
+        jobId: 'job:preserved',
+        fingerprint: 'taxonomy:preserved',
+        snapshot: { entries: ['preserved'] },
+        createdAt: 1,
+      }),
+      db.organizeApplies.put({
+        applyId: 'apply:preserved',
+        jobId: 'job:preserved',
+        sourceRevision: 1,
+        expectedTaxonomyFingerprint: 'taxonomy:preserved',
+        status: 'sealed',
+        rowCount: 1,
+        createdAt: 2,
+        updatedAt: 2,
+        completedAt: null,
+      }),
+      db.organizeApplyRows.put({
+        id: 'apply:preserved:0',
+        applyId: 'apply:preserved',
+        jobId: 'job:preserved',
+        position: 0,
+        fullName: 'owner/repo',
+        approvedActions: [{
+          kind: 'add_existing_tag',
+          tag: 'preserved',
+          evidence: 'Stored evidence.',
+        }],
+        approvedAdditions: ['preserved'],
+        sourceFingerprint: 'source:preserved',
+        taxonomyFingerprint: 'taxonomy:preserved',
+        state: 'pending',
+        outcomeReason: null,
+        attemptCount: 0,
+        leaseToken: null,
+        leaseOwner: null,
+        leaseExpiresAt: null,
+        settledAt: null,
+      }),
+      db.tagDirtyOutbox.put({
+        id: 'tag:owner/repo',
+        kind: 'tag',
+        key: 'owner/repo',
+        version: 'dirty:preserved',
+        updatedAt: FIRST,
+      }),
+      chromeMock.api.storage.local.set({
+        [CONFIG_STORAGE_KEY]: {
+          gistId: 'gist:preserved',
+          gistSyncCursor: SECOND,
+        },
+      }),
+    ]);
+    markDirtyForLocalWrites(['owner/repo'], true);
+    await replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/repo' }],
+      attemptedAt: FIRST,
+    });
+    await replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads: [thread('private')],
+      attemptedAt: FIRST,
+      lastModified: null,
+      nextAllowedAt: SECOND,
+      candidateCount: 1,
+      truncated: false,
+    });
+    const before = await snapshotNonWatchData();
+
+    await clearWatchData();
+
+    assert.deepEqual(await snapshotNonWatchData(), before);
+    assert.equal(await db.watchRepositories.count(), 0);
+    assert.equal(await db.watchNotificationThreads.count(), 0);
+    assert.equal(await db.watchState.count(), 0);
+  });
+
+  it('reconciles only stale account-bound Watch rows and is idempotent after a worker restart', async () => {
+    await replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/repo' }],
+      attemptedAt: FIRST,
+    });
+
+    assert.equal(await reconcileWatchAccount('another-user'), true);
+    assert.equal(await db.watchState.count(), 0);
+    assert.equal(await reconcileWatchAccount('another-user'), false);
+
+    await replaceWatchScope({
+      accountLogin: 'another-user',
+      repositories: [{ full_name: 'other/repo' }],
+      attemptedAt: SECOND,
+    });
+    assert.equal(await reconcileWatchAccount('another-user'), false);
+    assert.deepEqual(await getWatchRepositories('another-user'), [{ full_name: 'other/repo' }]);
+  });
+
+  it('prunes cached scope and private threads when a star becomes a tombstone', async () => {
+    await db.stars.bulkPut([star('owner/repo'), star('owner/other')]);
+    await replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/repo' }, { full_name: 'owner/other' }],
+      attemptedAt: FIRST,
+    });
+    await replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads: [thread('keep', 'owner/repo'), thread('remove', 'owner/other')],
+      attemptedAt: FIRST,
+      lastModified: 'Wed, 05 Aug 2026 01:00:00 GMT',
+      nextAllowedAt: null,
+      candidateCount: 2,
+      truncated: false,
+    });
+    await db.stars.put(star('owner/other', true));
+
+    assert.equal(await reconcileWatchLiveStars(ACCOUNT), true);
+    assert.deepEqual(await getWatchRepositories(ACCOUNT), [{ full_name: 'owner/repo' }]);
+    assert.deepEqual(
+      (await queryStoredWatchInbox({ accountLogin: ACCOUNT, unreadOnly: false })).threads
+        .map((item) => item.id),
+      ['keep'],
+    );
+    const state = await getWatchState(ACCOUNT);
+    assert.equal(state?.scope.repositoryCount, 1);
+    assert.equal(state?.inbox.matchedCount, 1);
+    assert.equal(await reconcileWatchLiveStars(ACCOUNT), false);
+  });
+});

--- a/tests/regressions/sync/full-sync-created-regression.test.ts
+++ b/tests/regressions/sync/full-sync-created-regression.test.ts
@@ -14,8 +14,9 @@ function createChromeMock() {
     api: {
       storage: {
         local: {
-          async get(key: string) {
-            return { [key]: state[key] };
+          async get(key: string | string[]) {
+            const keys = Array.isArray(key) ? key : [key];
+            return Object.fromEntries(keys.map((item) => [item, state[item]]));
           },
           async set(next: Record<string, unknown>) {
             const changes: Record<string, { oldValue: unknown; newValue: unknown }> = {};

--- a/tests/regressions/sync/github-stars-sync-regression.test.ts
+++ b/tests/regressions/sync/github-stars-sync-regression.test.ts
@@ -23,6 +23,8 @@ function configWithCursor(lastSyncStarredAt: string | null): Config {
   return {
     tokenEncrypted: null,
     tokenCryptoMeta: null,
+    watchNotificationsTokenEncrypted: null,
+    watchNotificationsTokenCryptoMeta: null,
     agentProvider: {
       provider: 'openai',
       protocol: null,

--- a/tests/regressions/sync/rescan-regression.test.ts
+++ b/tests/regressions/sync/rescan-regression.test.ts
@@ -15,8 +15,9 @@ function createChromeMock() {
     api: {
       storage: {
         local: {
-          async get(key: string) {
-            return { [key]: state[key] };
+          async get(key: string | string[]) {
+            const keys = Array.isArray(key) ? key : [key];
+            return Object.fromEntries(keys.map((item) => [item, state[item]]));
           },
           async set(next: Record<string, unknown>) {
             const changes: Record<string, { oldValue: unknown; newValue: unknown }> = {};

--- a/tests/runtime/extension-browser-smoke.mjs
+++ b/tests/runtime/extension-browser-smoke.mjs
@@ -11,6 +11,8 @@ const POPUP_PATH = '/src/popup/index.html';
 const INVALID_TOKEN = 'github_pat_invalid_extension_browser_smoke';
 const STARS_URL = 'https://github.com/smoke-user?tab=stars';
 const REPO_URL = 'https://github.com/smoke-user/smoke-repo';
+const WATCH_DESKTOP_SCREENSHOT = '/tmp/github-stars-watch-desktop.png';
+const WATCH_NARROW_SCREENSHOT = '/tmp/github-stars-watch-narrow.png';
 const DOM_POLLING_MS = 100;
 
 if (!existsSync(path.join(DIST, 'manifest.json'))) {
@@ -21,6 +23,7 @@ if (!existsSync(path.join(DIST, 'manifest.json'))) {
 const profile = mkdtempSync(path.join(os.tmpdir(), 'gsm-extension-smoke-'));
 const failures = [];
 const pageIssues = [];
+let backgroundGitHubApiGuard = null;
 
 function step(message) {
   console.log(`\n${message}`);
@@ -38,6 +41,7 @@ let browser;
 try {
   browser = await launchExtensionBrowser({ dist: DIST, userDataDir: profile });
   const extId = await detectExtensionId(browser);
+  await installBackgroundGitHubApiGuard(browser, extId);
   ok(`extension loaded: ${extId}`);
 
   step('1) Popup no-token path opens Options');
@@ -80,7 +84,7 @@ try {
   await seedConfig(extId, {
     username: 'smoke-user',
     tokenEncrypted: 'smoke-ciphertext',
-    tokenCryptoMeta: null,
+    tokenCryptoMeta: { iv: 'smoke-iv', salt: 'smoke-salt' },
     starsPanelDefaultEnabled: true,
   });
   const ownStars = await browser.newPage();
@@ -131,6 +135,73 @@ try {
     return false;
   }, { polling: DOM_POLLING_MS, timeout: 10_000 });
   ok('repo fixture received a shadow-root tag chip');
+
+  await waitForBackgroundIdle(optionsFromPopup);
+  resetBackgroundGitHubApiCalls(browser, extId);
+
+  step('8) Watch renders the bounded stored snapshot without GitHub API calls');
+  const seededWatch = await seedWatchFixture(extId);
+  assert.deepEqual(seededWatch, {
+    databaseVersion: 4,
+    hasMainToken: true,
+    hasNotificationsToken: true,
+    allThreadCount: 3,
+    allGroupCount: 2,
+    outOfScopeVisible: false,
+  });
+  await ownStars.bringToFront();
+  await ownStars.setViewport({ width: 1280, height: 800, deviceScaleFactor: 1 });
+  await openWatchSurface(ownStars, 'Unread issue thread');
+  const unreadSnapshot = await readWatchSnapshot(ownStars);
+  assert.deepEqual(unreadSnapshot, {
+    unreadPressed: true,
+    allPressed: false,
+    unreadTitleVisible: true,
+    readTitleVisible: false,
+    unknownTitleVisible: true,
+    unknownTypeVisible: true,
+    unknownFallbackHref: 'https://github.com/smoke-user/secondary-repo',
+    outOfScopeVisible: false,
+    staleBannerVisible: true,
+    truncatedBannerVisible: true,
+  });
+
+  await clickWatchFilter(ownStars, 'All');
+  const allSnapshot = await readWatchSnapshot(ownStars);
+  assert.equal(allSnapshot.unreadPressed, false);
+  assert.equal(allSnapshot.allPressed, true);
+  assert.equal(allSnapshot.readTitleVisible, true);
+  assert.equal(allSnapshot.outOfScopeVisible, false);
+  ok('Unread/All changed the stored projection and unknown subjects fell back safely');
+
+  step('9) Watch repository headers open local detail and remain coherent responsively');
+  await openWatchRepositoryDetail(ownStars, 'smoke-user/smoke-repo');
+  await assertWatchRepositoryDetail(ownStars, 'smoke-user/smoke-repo');
+  await assertWatchLayout(ownStars, 'desktop');
+  await ownStars.screenshot({ path: WATCH_DESKTOP_SCREENSHOT });
+
+  await closeWatchRepositoryDetail(ownStars);
+  await ownStars.setViewport({ width: 360, height: 740, deviceScaleFactor: 1 });
+  await waitForStableLayout(ownStars);
+  await assertWatchLayout(ownStars, 'narrow');
+  await ownStars.screenshot({ path: WATCH_NARROW_SCREENSHOT });
+  ok(`Watch detail and responsive layout verified (${WATCH_DESKTOP_SCREENSHOT}, ${WATCH_NARROW_SCREENSHOT})`);
+
+  step('10) Removing only the classic token shows Watch setup without ejecting Manager');
+  await markManagerMount(ownStars);
+  const disconnected = await clearWatchNotificationsCredential(extId);
+  assert.deepEqual(disconnected, {
+    mainCredentialPreserved: true,
+    watchCredentialCleared: true,
+    watchChangeDelivered: true,
+  });
+  await openWatchSurface(
+    ownStars,
+    'Connect a separate classic token with the notifications scope',
+  );
+  await assertWatchSetupState(ownStars);
+  await assertNoBackgroundGitHubApiCalls(browser, extId);
+  ok('classic-token removal kept the main Manager mounted and rendered Watch setup');
 
   if (pageIssues.length) {
     failures.push(`unexpected browser diagnostics:\n${pageIssues.join('\n')}`);
@@ -240,6 +311,406 @@ async function seedConfig(extId, patch) {
     await chrome.storage.local.set({ [key]: { ...(current[key] ?? {}), ...nextPatch } });
   }, patch);
   await page.close();
+}
+
+async function seedWatchFixture(extId) {
+  const page = await openExtensionPage(extId, OPTIONS_PATH, 'seed-watch');
+  const seeded = await page.evaluate(async () => {
+    const APP_SECRET = 'better-github-stars-manager/v1/static-derivation-secret';
+    const DB_NAME = 'better-github-stars-manager';
+    const DEXIE_VERSION = 4;
+    const IDB_VERSION = DEXIE_VERSION * 10;
+    const CONFIG_KEY = 'gsm_config';
+    const CREDENTIALS_KEY = 'gsm_github_credentials_v1';
+    const fetchedAt = '2026-08-05T12:35:00.000Z';
+
+    const b64encode = (value) => {
+      const bytes = value instanceof Uint8Array ? value : new Uint8Array(value);
+      let binary = '';
+      for (const byte of bytes) binary += String.fromCharCode(byte);
+      return btoa(binary);
+    };
+    const encrypt = async (plaintext, saltBytes, ivBytes) => {
+      const encoder = new TextEncoder();
+      const salt = new Uint8Array(saltBytes);
+      const iv = new Uint8Array(ivBytes);
+      const base = await crypto.subtle.importKey(
+        'raw',
+        encoder.encode(APP_SECRET),
+        'PBKDF2',
+        false,
+        ['deriveKey'],
+      );
+      const key = await crypto.subtle.deriveKey(
+        { name: 'PBKDF2', salt, iterations: 150_000, hash: 'SHA-256' },
+        base,
+        { name: 'AES-GCM', length: 256 },
+        false,
+        ['encrypt'],
+      );
+      const cipher = await crypto.subtle.encrypt(
+        { name: 'AES-GCM', iv },
+        key,
+        encoder.encode(plaintext),
+      );
+      return {
+        cipher: b64encode(cipher),
+        meta: { salt: b64encode(salt), iv: b64encode(iv) },
+      };
+    };
+    const openDatabase = () => new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME);
+      let unexpectedUpgrade = false;
+      request.onupgradeneeded = () => {
+        unexpectedUpgrade = true;
+        request.transaction?.abort();
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(new Error(unexpectedUpgrade
+        ? 'the extension did not initialize its Dexie v4 schema before Watch fixture setup'
+        : `failed to open extension IndexedDB: ${request.error?.message ?? 'unknown error'}`));
+      request.onblocked = () => reject(new Error('extension IndexedDB v4 fixture open was blocked'));
+    });
+    const transactionDone = (transaction) => new Promise((resolve, reject) => {
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error ?? new Error('Watch fixture transaction failed'));
+      transaction.onabort = () => reject(transaction.error ?? new Error('Watch fixture transaction aborted'));
+    });
+
+    const [mainCredential, watchCredential] = await Promise.all([
+      encrypt(
+        'github_pat_runtime_smoke_main',
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+      ),
+      encrypt(
+        'ghp_runtime_smoke_notifications',
+        [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31],
+        [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+      ),
+    ]);
+    const current = await chrome.storage.local.get(CONFIG_KEY);
+    const credentials = {
+      version: 1,
+      tokenEncrypted: mainCredential.cipher,
+      tokenCryptoMeta: mainCredential.meta,
+      watchNotificationsTokenEncrypted: watchCredential.cipher,
+      watchNotificationsTokenCryptoMeta: watchCredential.meta,
+      username: 'smoke-user',
+      avatarUrl: null,
+      displayName: null,
+    };
+    await chrome.storage.local.set({
+      [CONFIG_KEY]: {
+        ...(current[CONFIG_KEY] ?? {}),
+        ...credentials,
+        locale: 'en',
+        theme: 'light',
+        onboardingStage: 'done',
+        seenOnboarding: true,
+        autoTagAgentPromptSeen: true,
+        starsPanelDefaultEnabled: true,
+      },
+      [CREDENTIALS_KEY]: credentials,
+    });
+
+    // This message serializes account reconciliation before account-bound rows
+    // are written, so a delayed cleanup cannot erase the new fixture.
+    const initialStatus = await chrome.runtime.sendMessage({ type: 'getWatchStatus' });
+    if (!initialStatus?.ok) {
+      throw new Error(initialStatus?.error ?? 'Watch status did not accept seeded credentials');
+    }
+
+    const database = await openDatabase();
+    if (database.version !== IDB_VERSION) {
+      database.close();
+      throw new Error(`expected Dexie v${DEXIE_VERSION} (IndexedDB ${IDB_VERSION}), got ${database.version}`);
+    }
+    const requiredStores = [
+      'stars',
+      'watchRepositories',
+      'watchNotificationThreads',
+      'watchState',
+    ];
+    for (const storeName of requiredStores) {
+      if (!database.objectStoreNames.contains(storeName)) {
+        database.close();
+        throw new Error(`Dexie v4 is missing required store ${storeName}`);
+      }
+    }
+
+    const star = (fullName, description, language, count) => ({
+      full_name: fullName,
+      html_url: `https://github.com/${fullName}`,
+      description,
+      language,
+      stargazers_count: count,
+      topics: ['runtime-smoke'],
+      pushed_at: '2026-08-04T08:00:00.000Z',
+      created_at: '2024-01-02T03:04:05.000Z',
+      fork: false,
+      archived: false,
+      starred_at: '2026-07-01T09:00:00.000Z',
+      tombstone: false,
+      synced_at: fetchedAt,
+    });
+    const thread = ({ id, repository, title, type, unread, updatedAt, subjectHtmlUrl }) => ({
+      id,
+      repositoryFullName: repository,
+      repositoryHtmlUrl: `https://github.com/${repository}`,
+      reason: unread ? 'subscribed' : 'comment',
+      subjectType: type,
+      subjectTitle: title,
+      subjectApiUrl: null,
+      subjectHtmlUrl,
+      unread,
+      updatedAt,
+      lastReadAt: unread ? null : '2026-08-05T10:45:00.000Z',
+      fetchedAt,
+    });
+    const transaction = database.transaction(requiredStores, 'readwrite');
+    const stars = transaction.objectStore('stars');
+    const repositories = transaction.objectStore('watchRepositories');
+    const threads = transaction.objectStore('watchNotificationThreads');
+    const state = transaction.objectStore('watchState');
+    stars.clear();
+    repositories.clear();
+    threads.clear();
+    state.clear();
+    stars.put(star(
+      'smoke-user/smoke-repo',
+      'Primary repository detail loaded from the live local Star row.',
+      'TypeScript',
+      3210,
+    ));
+    stars.put(star(
+      'smoke-user/secondary-repo',
+      'Secondary watched repository used by the unknown-subject fixture.',
+      'Rust',
+      87,
+    ));
+    stars.put(star(
+      'smoke-user/out-of-scope',
+      'Live star intentionally excluded from the watched-repository scope.',
+      'Go',
+      14,
+    ));
+    repositories.put({ full_name: 'smoke-user/smoke-repo' });
+    repositories.put({ full_name: 'smoke-user/secondary-repo' });
+    threads.put(thread({
+      id: 'watch-unread-issue',
+      repository: 'smoke-user/smoke-repo',
+      title: 'Unread issue thread',
+      type: 'Issue',
+      unread: true,
+      updatedAt: '2026-08-05T12:30:00.000Z',
+      subjectHtmlUrl: 'https://github.com/smoke-user/smoke-repo/issues/17',
+    }));
+    threads.put(thread({
+      id: 'watch-read-pull',
+      repository: 'smoke-user/smoke-repo',
+      title: 'Read pull request thread',
+      type: 'PullRequest',
+      unread: false,
+      updatedAt: '2026-08-05T10:30:00.000Z',
+      subjectHtmlUrl: 'https://github.com/smoke-user/smoke-repo/pull/9',
+    }));
+    threads.put(thread({
+      id: 'watch-unknown-subject',
+      repository: 'smoke-user/secondary-repo',
+      title: 'Future event thread',
+      type: 'FutureEvent',
+      unread: true,
+      updatedAt: '2026-08-05T11:30:00.000Z',
+      subjectHtmlUrl: null,
+    }));
+    threads.put(thread({
+      id: 'watch-out-of-scope',
+      repository: 'smoke-user/out-of-scope',
+      title: 'OUT OF SCOPE MUST NOT RENDER',
+      type: 'Issue',
+      unread: true,
+      updatedAt: '2026-08-05T13:30:00.000Z',
+      subjectHtmlUrl: 'https://github.com/smoke-user/out-of-scope/issues/1',
+    }));
+    state.put({
+      id: 'singleton',
+      accountLogin: 'smoke-user',
+      scope: {
+        lastAttemptAt: '2026-08-05T12:34:00.000Z',
+        lastSuccessfulAt: '2026-08-05T12:00:00.000Z',
+        errorCode: 'network_error',
+        repositoryCount: 2,
+      },
+      inbox: {
+        lastAttemptAt: '2026-08-05T12:35:00.000Z',
+        lastSuccessfulAt: '2026-08-05T12:05:00.000Z',
+        errorCode: 'github_unavailable',
+        lastModified: 'Wed, 05 Aug 2026 12:05:00 GMT',
+        nextAllowedAt: null,
+        candidateCount: 4,
+        matchedCount: 3,
+        truncated: true,
+      },
+    });
+    await transactionDone(transaction);
+    const databaseVersion = database.version / 10;
+    database.close();
+
+    // Direct fixture writes bypass the background publication boundary. Touch
+    // the authoritative same-account credential record after commit so an
+    // already-open Manager exercises its real credential invalidation path.
+    const finalizedCredentials = {
+      ...credentials,
+      avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
+    };
+    const finalized = await chrome.storage.local.get(CONFIG_KEY);
+    await chrome.storage.local.set({
+      [CONFIG_KEY]: {
+        ...(finalized[CONFIG_KEY] ?? {}),
+        ...finalizedCredentials,
+      },
+      [CREDENTIALS_KEY]: finalizedCredentials,
+    });
+
+    const allInbox = await chrome.runtime.sendMessage({
+      type: 'queryWatchInbox',
+      unreadOnly: false,
+    });
+    if (!allInbox?.ok) throw new Error(allInbox?.error ?? 'seeded Watch inbox query failed');
+    const repositoryDetail = await chrome.runtime.sendMessage({
+      type: 'getWatchRepositoryDetail',
+      fullName: 'smoke-user/smoke-repo',
+    });
+    if (
+      !repositoryDetail?.ok ||
+      repositoryDetail.data?.star?.full_name !== 'smoke-user/smoke-repo'
+    ) {
+      throw new Error(repositoryDetail?.error ?? 'seeded Watch repository detail was unavailable');
+    }
+    return {
+      databaseVersion,
+      hasMainToken: allInbox.data.status.hasMainToken,
+      hasNotificationsToken: allInbox.data.status.hasNotificationsToken,
+      allThreadCount: allInbox.data.totalCount,
+      allGroupCount: allInbox.data.groups.length,
+      outOfScopeVisible: allInbox.data.threads.some((item) => item.id === 'watch-out-of-scope'),
+    };
+  });
+  await page.close();
+  return seeded;
+}
+
+async function clearWatchNotificationsCredential(extId) {
+  const page = await openExtensionPage(extId, OPTIONS_PATH, 'clear-watch-credential');
+  const result = await page.evaluate(async () => {
+    const CONFIG_KEY = 'gsm_config';
+    const CREDENTIALS_KEY = 'gsm_github_credentials_v1';
+    const current = await chrome.storage.local.get([CONFIG_KEY, CREDENTIALS_KEY]);
+    const beforeConfig = current[CONFIG_KEY] ?? {};
+    const beforeCredentials = current[CREDENTIALS_KEY] ?? {};
+    let listener;
+    const changed = new Promise((resolve) => {
+      const timeout = setTimeout(() => {
+        chrome.runtime.onMessage.removeListener(listener);
+        resolve(false);
+      }, 5_000);
+      listener = (message) => {
+        if (message?.type !== 'watchChanged') return;
+        clearTimeout(timeout);
+        chrome.runtime.onMessage.removeListener(listener);
+        resolve(true);
+      };
+      chrome.runtime.onMessage.addListener(listener);
+    });
+    const response = await chrome.runtime.sendMessage({ type: 'disconnectWatchInbox' });
+    if (!response?.ok) {
+      chrome.runtime.onMessage.removeListener(listener);
+      throw new Error(response?.error ?? 'Watch disconnect failed');
+    }
+    const watchChangeDelivered = await changed;
+    const stored = await chrome.storage.local.get([CONFIG_KEY, CREDENTIALS_KEY]);
+    const afterConfig = stored[CONFIG_KEY] ?? {};
+    const afterCredentials = stored[CREDENTIALS_KEY] ?? {};
+    return {
+      mainCredentialPreserved:
+        afterCredentials.tokenEncrypted === beforeCredentials.tokenEncrypted &&
+        JSON.stringify(afterCredentials.tokenCryptoMeta ?? null) ===
+          JSON.stringify(beforeCredentials.tokenCryptoMeta ?? null) &&
+        afterCredentials.username === beforeCredentials.username &&
+        afterConfig.tokenEncrypted === beforeConfig.tokenEncrypted &&
+        afterConfig.username === beforeConfig.username,
+      watchCredentialCleared:
+        afterCredentials.watchNotificationsTokenEncrypted === null &&
+        afterCredentials.watchNotificationsTokenCryptoMeta === null &&
+        afterConfig.watchNotificationsTokenEncrypted === null &&
+        afterConfig.watchNotificationsTokenCryptoMeta === null,
+      watchChangeDelivered,
+    };
+  });
+  await page.close();
+  return result;
+}
+
+async function installBackgroundGitHubApiGuard(browser, extId) {
+  const unexpectedUrls = [];
+  const clients = new Set();
+  const attach = async (target) => {
+    if (
+      target.type() !== 'service_worker' ||
+      !target.url().startsWith(`chrome-extension://${extId}/`)
+    ) return;
+    const client = await target.createCDPSession();
+    clients.add(client);
+    await client.send('Fetch.enable', {
+      patterns: [{ urlPattern: 'https://api.github.com/*', requestStage: 'Request' }],
+    });
+    client.on('Fetch.requestPaused', (event) => {
+      unexpectedUrls.push(event.request.url);
+      void client.send('Fetch.failRequest', {
+        requestId: event.requestId,
+        errorReason: 'BlockedByClient',
+      }).catch(() => {});
+    });
+  };
+  const targetListener = (target) => {
+    void attach(target).catch((error) => {
+      recordPageIssue('background-network-guard', formatError(error));
+    });
+  };
+  browser.on('targetcreated', targetListener);
+  await Promise.all(browser.targets().map(attach));
+  backgroundGitHubApiGuard = { browser, targetListener, clients, unexpectedUrls };
+}
+
+async function assertNoBackgroundGitHubApiCalls(browser, extId) {
+  await delay(100);
+  const guard = backgroundGitHubApiGuard;
+  assert.equal(guard?.browser, browser, `GitHub API guard was not installed for ${extId}`);
+  assert.deepEqual(
+    guard.unexpectedUrls,
+    [],
+    `background unexpectedly requested GitHub API URLs: ${guard.unexpectedUrls.join(', ')}`,
+  );
+  browser.off('targetcreated', guard.targetListener);
+  await Promise.all([...guard.clients].map((client) => client.detach().catch(() => {})));
+  backgroundGitHubApiGuard = null;
+}
+
+async function waitForBackgroundIdle(page) {
+  await page.waitForFunction(
+    async () => {
+      const response = await chrome.runtime.sendMessage({ type: 'getStatus' });
+      return response?.ok && response.data?.inFlight === false;
+    },
+    { polling: DOM_POLLING_MS, timeout: 30_000 },
+  );
+}
+
+function resetBackgroundGitHubApiCalls(browser, extId) {
+  const guard = backgroundGitHubApiGuard;
+  assert.equal(guard?.browser, browser, `GitHub API guard was not installed for ${extId}`);
+  guard.unexpectedUrls.length = 0;
 }
 
 async function interceptGitHubApi(page, handler) {
@@ -448,6 +919,317 @@ async function waitForManagerRoot(page) {
     () => !!document.getElementById('gsm-manager-host')?.shadowRoot?.getElementById('gsm-manager-root'),
     { polling: DOM_POLLING_MS, timeout: 20_000 },
   );
+}
+
+async function markManagerMount(page) {
+  const marked = await page.evaluate(() => {
+    const host = document.getElementById('gsm-manager-host');
+    if (!host?.shadowRoot?.getElementById('gsm-manager-root')) return false;
+    host.dataset.watchSmokeMount = 'preserved';
+    return true;
+  });
+  assert.equal(marked, true, 'could not mark the mounted Manager before Watch disconnect');
+}
+
+async function openWatchSurface(page, expectedText) {
+  try {
+    await page.waitForFunction(
+      () => {
+        const root = document.getElementById('gsm-manager-host')?.shadowRoot?.getElementById('gsm-manager-root');
+        const surfaceGroup = [...(root?.querySelectorAll('[role="group"]') ?? [])]
+          .find((candidate) => candidate.getAttribute('aria-label') === 'Watched stars inbox');
+        const button = [...(surfaceGroup?.querySelectorAll('button') ?? [])]
+          .find((candidate) => candidate.textContent?.trim().startsWith('Watch'));
+        return !!button && !button.disabled;
+      },
+      { polling: DOM_POLLING_MS, timeout: 20_000 },
+    );
+  } catch (error) {
+    throw await pageWaitError(page, 'Watch Manager surface switch did not become interactive', error);
+  }
+  const clicked = await page.evaluate(() => {
+    const root = document.getElementById('gsm-manager-host')?.shadowRoot?.getElementById('gsm-manager-root');
+    const surfaceGroup = [...(root?.querySelectorAll('[role="group"]') ?? [])]
+      .find((candidate) => candidate.getAttribute('aria-label') === 'Watched stars inbox');
+    const button = [...(surfaceGroup?.querySelectorAll('button') ?? [])]
+      .find((candidate) => candidate.textContent?.trim().startsWith('Watch'));
+    button?.click();
+    return !!button;
+  });
+  assert.equal(clicked, true, 'could not activate the Watch Manager surface');
+  try {
+    await page.waitForFunction(
+      (text) => {
+        const root = document.getElementById('gsm-manager-host')?.shadowRoot?.getElementById('gsm-manager-root');
+        const section = root?.querySelector('section[aria-label="Watched stars inbox"]');
+        const watchButton = [...(root?.querySelectorAll('button') ?? [])]
+          .find((candidate) => candidate.textContent?.trim().startsWith('Watch'));
+        return !!section && watchButton?.getAttribute('aria-pressed') === 'true' &&
+          !section.textContent?.includes('Loading') && section.textContent?.includes(text);
+      },
+      { polling: DOM_POLLING_MS, timeout: 20_000 },
+      expectedText,
+    );
+  } catch (error) {
+    throw await pageWaitError(page, 'Watch surface did not finish rendering', error);
+  }
+}
+
+async function clickWatchFilter(page, label) {
+  const clicked = await page.evaluate((filterLabel) => {
+    const root = document.getElementById('gsm-manager-host')?.shadowRoot?.getElementById('gsm-manager-root');
+    const group = root?.querySelector('[role="group"][aria-label="Inbox thread filter"]');
+    const button = [...(group?.querySelectorAll('button') ?? [])]
+      .find((candidate) => candidate.textContent?.trim() === filterLabel);
+    button?.click();
+    return !!button;
+  }, label);
+  assert.equal(clicked, true, `could not activate Watch filter ${label}`);
+  try {
+    await page.waitForFunction(
+      (filterLabel) => {
+        const root = document.getElementById('gsm-manager-host')?.shadowRoot?.getElementById('gsm-manager-root');
+        const group = root?.querySelector('[role="group"][aria-label="Inbox thread filter"]');
+        const button = [...(group?.querySelectorAll('button') ?? [])]
+          .find((candidate) => candidate.textContent?.trim() === filterLabel);
+        return button?.getAttribute('aria-pressed') === 'true' && (
+          filterLabel !== 'All' || root?.textContent?.includes('Read pull request thread')
+        );
+      },
+      { polling: DOM_POLLING_MS, timeout: 10_000 },
+      label,
+    );
+  } catch (error) {
+    throw await pageWaitError(page, `Watch filter ${label} did not settle`, error);
+  }
+}
+
+async function readWatchSnapshot(page) {
+  return page.evaluate(() => {
+    const root = document.getElementById('gsm-manager-host')?.shadowRoot?.getElementById('gsm-manager-root');
+    const section = root?.querySelector('section[aria-label="Watched stars inbox"]');
+    const text = section?.textContent ?? '';
+    const filterGroup = section?.querySelector('[role="group"][aria-label="Inbox thread filter"]');
+    const buttonPressed = (label) => [...(filterGroup?.querySelectorAll('button') ?? [])]
+      .find((candidate) => candidate.textContent?.trim() === label)
+      ?.getAttribute('aria-pressed') === 'true';
+    const unknownLink = [...(section?.querySelectorAll('a') ?? [])]
+      .find((candidate) => candidate.getAttribute('aria-label') === 'Open on GitHub: Future event thread');
+    const statuses = [...(section?.querySelectorAll('[role="status"]') ?? [])]
+      .map((candidate) => candidate.textContent ?? '');
+    return {
+      unreadPressed: buttonPressed('Unread'),
+      allPressed: buttonPressed('All'),
+      unreadTitleVisible: text.includes('Unread issue thread'),
+      readTitleVisible: text.includes('Read pull request thread'),
+      unknownTitleVisible: text.includes('Future event thread'),
+      unknownTypeVisible: text.includes('FutureEvent'),
+      unknownFallbackHref: unknownLink?.href ?? null,
+      outOfScopeVisible: text.includes('OUT OF SCOPE MUST NOT RENDER'),
+      staleBannerVisible: statuses.some((value) => value.includes(
+        'Showing the last successful snapshot because the latest refresh failed.',
+      )),
+      truncatedBannerVisible: statuses.some((value) => value.includes(
+        'This is the newest bounded window; more GitHub threads exist beyond it.',
+      )),
+    };
+  });
+}
+
+async function openWatchRepositoryDetail(page, fullName) {
+  const clicked = await page.evaluate((repository) => {
+    const root = document.getElementById('gsm-manager-host')?.shadowRoot?.getElementById('gsm-manager-root');
+    const section = root?.querySelector('section[aria-label="Watched stars inbox"]');
+    const button = [...(section?.querySelectorAll('button') ?? [])]
+      .find((candidate) => candidate.textContent?.trim() === repository);
+    button?.click();
+    return !!button;
+  }, fullName);
+  assert.equal(clicked, true, `could not select Watch repository ${fullName}`);
+  try {
+    await page.waitForFunction(
+      (repository) => {
+        const root = document.getElementById('gsm-manager-host')?.shadowRoot?.getElementById('gsm-manager-root');
+        const drawer = root?.querySelector('.drawer-anim.drawer-enter');
+        const link = [...(drawer?.querySelectorAll('a') ?? [])]
+          .find((candidate) => candidate.textContent?.trim() === repository);
+        return !!link && !!drawer?.querySelector('textarea') && drawer.getBoundingClientRect().width >= 339;
+      },
+      { polling: DOM_POLLING_MS, timeout: 10_000 },
+      fullName,
+    );
+  } catch (error) {
+    const drawerState = await page.evaluate(() => {
+      const root = document.getElementById('gsm-manager-host')?.shadowRoot?.getElementById('gsm-manager-root');
+      const drawer = root?.querySelector('.drawer-anim');
+      return {
+        className: drawer?.className ?? null,
+        width: drawer?.getBoundingClientRect().width ?? null,
+        text: drawer?.textContent?.slice(0, 500) ?? null,
+        textareaCount: drawer?.querySelectorAll('textarea').length ?? 0,
+      };
+    }).catch(() => null);
+    const waitError = await pageWaitError(page, `Watch detail did not open for ${fullName}`, error);
+    throw new Error(`${waitError.message}\nDrawer state: ${JSON.stringify(drawerState)}`);
+  }
+}
+
+async function assertWatchRepositoryDetail(page, fullName) {
+  const detail = await page.evaluate((repository) => {
+    const root = document.getElementById('gsm-manager-host')?.shadowRoot?.getElementById('gsm-manager-root');
+    const drawer = root?.querySelector('.drawer-anim.drawer-enter');
+    const link = [...(drawer?.querySelectorAll('a') ?? [])]
+      .find((candidate) => candidate.textContent?.trim() === repository);
+    return {
+      width: drawer?.getBoundingClientRect().width ?? 0,
+      href: link?.href ?? null,
+      descriptionVisible: drawer?.textContent?.includes(
+        'Primary repository detail loaded from the live local Star row.',
+      ) ?? false,
+      languageVisible: drawer?.textContent?.includes('TypeScript') ?? false,
+      notesPlaceholder: drawer?.querySelector('textarea')?.getAttribute('placeholder') ?? null,
+      closeButtonVisible: !!drawer?.querySelector('button[title="Close (Esc)"]'),
+    };
+  }, fullName);
+  assert.equal(detail.width >= 339 && detail.width <= 341, true, 'Watch detail drawer width was not stable');
+  assert.deepEqual({ ...detail, width: 340 }, {
+    width: 340,
+    href: `https://github.com/${fullName}`,
+    descriptionVisible: true,
+    languageVisible: true,
+    notesPlaceholder: 'Why did you star this repo?',
+    closeButtonVisible: true,
+  });
+}
+
+async function closeWatchRepositoryDetail(page) {
+  const clicked = await page.evaluate(() => {
+    const root = document.getElementById('gsm-manager-host')?.shadowRoot?.getElementById('gsm-manager-root');
+    const button = root?.querySelector('.drawer-anim.drawer-enter button[title="Close (Esc)"]');
+    button?.click();
+    return !!button;
+  });
+  assert.equal(clicked, true, 'could not close Watch repository detail');
+  await page.waitForFunction(
+    () => {
+      const root = document.getElementById('gsm-manager-host')?.shadowRoot?.getElementById('gsm-manager-root');
+      const drawer = root?.querySelector('.drawer-anim');
+      return !!drawer && drawer.classList.contains('drawer-exit') && drawer.getBoundingClientRect().width <= 1;
+    },
+    { polling: DOM_POLLING_MS, timeout: 10_000 },
+  );
+}
+
+async function waitForStableLayout(page) {
+  await page.evaluate(async () => {
+    const fontsReady = document.fonts?.ready ?? Promise.resolve();
+    await Promise.race([
+      fontsReady,
+      new Promise((resolve) => setTimeout(resolve, 500)),
+    ]);
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+  });
+}
+
+async function assertWatchLayout(page, label) {
+  await waitForStableLayout(page);
+  const layout = await page.evaluate(() => {
+    const root = document.getElementById('gsm-manager-host')?.shadowRoot?.getElementById('gsm-manager-root');
+    const section = root?.querySelector('section[aria-label="Watched stars inbox"]');
+    const scrollPane = section?.parentElement;
+    const headerRow = section?.querySelector('header > div');
+    const rootRect = root?.getBoundingClientRect();
+    const sectionRect = section?.getBoundingClientRect();
+    const headerChildren = [...(headerRow?.children ?? [])]
+      .filter((element) => {
+        const style = getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return style.visibility !== 'hidden' && style.display !== 'none' && rect.width > 0 && rect.height > 0;
+      })
+      .map((element) => {
+        const rect = element.getBoundingClientRect();
+        return { left: rect.left, right: rect.right, top: rect.top, bottom: rect.bottom };
+      });
+    const overlappingHeaderPairs = headerChildren.flatMap((left, leftIndex) =>
+      headerChildren.slice(leftIndex + 1).filter((right) => (
+        Math.min(left.right, right.right) - Math.max(left.left, right.left) > 1 &&
+        Math.min(left.bottom, right.bottom) - Math.max(left.top, right.top) > 1
+      )).map(() => leftIndex),
+    ).length;
+    const controlsOutsideSection = [...(section?.querySelectorAll('button, a') ?? [])]
+      .filter((element) => {
+        const style = getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        if (style.visibility === 'hidden' || style.display === 'none' || rect.width === 0 || rect.height === 0) {
+          return false;
+        }
+        return !sectionRect || rect.left < sectionRect.left - 1 || rect.right > sectionRect.right + 1;
+      }).length;
+    return {
+      viewportWidth: innerWidth,
+      rootLeft: rootRect?.left ?? -1,
+      rootRight: rootRect?.right ?? -1,
+      rootOverflow: root ? root.scrollWidth - root.clientWidth : -1,
+      scrollPaneOverflow: scrollPane ? scrollPane.scrollWidth - scrollPane.clientWidth : -1,
+      sectionOverflow: section ? section.scrollWidth - section.clientWidth : -1,
+      sectionLeft: sectionRect?.left ?? -1,
+      sectionRight: sectionRect?.right ?? -1,
+      headerChildren: headerChildren.length,
+      overlappingHeaderPairs,
+      controlsOutsideSection,
+    };
+  });
+  assert.equal(layout.rootLeft >= 0, true, `${label} Manager extended left of the viewport`);
+  assert.equal(layout.rootRight <= layout.viewportWidth + 1, true, `${label} Manager extended right of the viewport`);
+  assert.equal(layout.rootOverflow <= 1, true, `${label} Manager has horizontal overflow`);
+  assert.equal(layout.scrollPaneOverflow <= 1, true, `${label} Watch scroll pane has horizontal overflow`);
+  assert.equal(layout.sectionOverflow <= 1, true, `${label} Watch section has horizontal overflow`);
+  assert.equal(layout.sectionLeft >= -1, true, `${label} Watch section extended left of its viewport`);
+  assert.equal(layout.sectionRight <= layout.viewportWidth + 1, true, `${label} Watch section extended right of its viewport`);
+  assert.equal(layout.headerChildren >= 4, true, `${label} Watch header controls were incomplete`);
+  assert.equal(layout.overlappingHeaderPairs, 0, `${label} Watch header controls overlapped`);
+  assert.equal(layout.controlsOutsideSection, 0, `${label} Watch controls were clipped outside the section`);
+}
+
+async function assertWatchSetupState(page) {
+  try {
+    await page.waitForFunction(
+      () => {
+        const host = document.getElementById('gsm-manager-host');
+        const root = host?.shadowRoot?.getElementById('gsm-manager-root');
+        const section = root?.querySelector('section[aria-label="Watched stars inbox"]');
+        const text = section?.textContent ?? '';
+        return document.querySelectorAll('#gsm-manager-host').length === 1 &&
+          !!root && !!section &&
+          text.includes('Connect a separate classic token with the notifications scope') &&
+          [...(section?.querySelectorAll('button') ?? [])]
+            .some((candidate) => candidate.textContent?.trim() === 'Open options');
+      },
+      { polling: DOM_POLLING_MS, timeout: 20_000 },
+    );
+  } catch (error) {
+    throw await pageWaitError(page, 'Watch classic-token setup state did not render', error);
+  }
+  const state = await page.evaluate(() => {
+    const root = document.getElementById('gsm-manager-host')?.shadowRoot?.getElementById('gsm-manager-root');
+    const surfaceGroup = [...(root?.querySelectorAll('[role="group"]') ?? [])]
+      .find((candidate) => candidate.getAttribute('aria-label') === 'Watched stars inbox');
+    const buttons = [...(surfaceGroup?.querySelectorAll('button') ?? [])];
+    return {
+      managerMounted: !!root,
+      managerMountPreserved: root?.getRootNode()?.host?.dataset?.watchSmokeMount === 'preserved',
+      starsControlPresent: buttons.some((candidate) => candidate.textContent?.trim() === 'Stars'),
+      watchPressed: buttons.some((candidate) => (
+        candidate.textContent?.trim().startsWith('Watch') && candidate.getAttribute('aria-pressed') === 'true'
+      )),
+    };
+  });
+  assert.deepEqual(state, {
+    managerMounted: true,
+    managerMountPreserved: true,
+    starsControlPresent: true,
+    watchPressed: true,
+  });
 }
 
 async function assertScrollLocked(page) {

--- a/tests/unit/agent-provider-credentials.test.ts
+++ b/tests/unit/agent-provider-credentials.test.ts
@@ -25,7 +25,10 @@ function installChrome(initial: StoredState = {}) {
     areaName: string,
   ) => void> = [];
   const local = {
-    get: vi.fn(async (key: string) => ({ [key]: state[key] })),
+    get: vi.fn(async (key: string | string[]) => {
+      const keys = Array.isArray(key) ? key : [key];
+      return Object.fromEntries(keys.map((item) => [item, state[item]]));
+    }),
     set: vi.fn(async (values: StoredState) => {
       for (const [key, value] of Object.entries(values)) {
         const oldValue = state[key];

--- a/tests/unit/agent-provider-monitor.test.ts
+++ b/tests/unit/agent-provider-monitor.test.ts
@@ -10,6 +10,7 @@ vi.mock('@/auth/auth-store', () => ({
   authStore: {
     getConfig: vi.fn(),
     getToken: vi.fn(),
+    getWatchNotificationsToken: vi.fn(),
     getAgentApiKey: vi.fn(),
   },
 }));
@@ -222,6 +223,9 @@ describe('Provider diagnostics runtime probe scrubbing', () => {
     const stored = new Map<string, unknown>();
     const posts: string[] = [];
     vi.mocked(authStore.getToken).mockResolvedValue('configured-github-token-value');
+    vi.mocked(authStore.getWatchNotificationsToken).mockResolvedValue(
+      'configured-watch-token-value',
+    );
     vi.mocked(authStore.getAgentApiKey).mockResolvedValue('agent-key-value-123');
     vi.mocked(authStore.getConfig).mockResolvedValue({
       agentProvider: providerConfig,
@@ -245,7 +249,7 @@ describe('Provider diagnostics runtime probe scrubbing', () => {
 
     runtime.recordProbeFailure('probe:scrub', Date.now(), new AgentProviderError(
       'http_error',
-      'HTTP 401: key agent-key-value-123 rejected; header Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456',
+      'HTTP 401: keys agent-key-value-123 and configured-watch-token-value rejected; header Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456',
       401,
     ));
 
@@ -259,6 +263,7 @@ describe('Provider diagnostics runtime probe scrubbing', () => {
     expect(serialized).not.toContain('agent-key-value-123');
     expect(serialized).not.toContain('abcdefghijklmnopqrstuvwxyz123456');
     expect(serialized).not.toContain('configured-github-token-value');
+    expect(serialized).not.toContain('configured-watch-token-value');
   });
 });
 

--- a/tests/unit/background-mark-unstarred-contract.test.ts
+++ b/tests/unit/background-mark-unstarred-contract.test.ts
@@ -35,8 +35,9 @@ const chromeHarness = vi.hoisted(() => {
   const api = {
     storage: {
       local: {
-        async get(key: string) {
-          return { [key]: storageState[key] };
+        async get(key: string | string[]) {
+          const keys = Array.isArray(key) ? key : [key];
+          return Object.fromEntries(keys.map((item) => [item, storageState[item]]));
         },
         async set(next: Record<string, unknown>) {
           const changes: Record<string, { oldValue: unknown; newValue: unknown }> = {};

--- a/tests/unit/background-watch-integration-contract.test.ts
+++ b/tests/unit/background-watch-integration-contract.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'vitest';
+import { backgroundSource, caseBlock } from '../helpers/background-case-block';
+
+describe('Watch background integration contract', () => {
+  it('uses the shared queue and only publishes a Watch-specific invalidation', () => {
+    assert.match(backgroundSource, /const watchRefreshCoordinator = createWatchRefreshCoordinator\(\{/);
+    assert.match(backgroundSource, /runSerialized: \(operation\) => jobQueue\.run\(operation\)/);
+    assert.match(
+      backgroundSource,
+      /loadLiveRepositoryNames: async \(\) => \(await db\.stars\.toArray\(\)\)\s*\.filter\(\(star\) => !star\.tombstone\)\s*\.map\(\(star\) => star\.full_name\)/,
+    );
+
+    const broadcast = backgroundSource.match(
+      /function broadcastWatchChanged\(\) \{([\s\S]*?)\n\}/,
+    )?.[1] ?? '';
+    assert.match(broadcast, /sendMessage\(\{ type: 'watchChanged' \}\)/);
+    assert.doesNotMatch(broadcast, /invalidateCache|dataChanged/);
+  });
+
+  it('includes the classic Notifications PAT in development capture redaction', () => {
+    const configuredSecrets = backgroundSource.match(
+      /getConfiguredSecrets: async \(\) => Promise\.all\(\[([\s\S]*?)\]\)/,
+    )?.[1] ?? '';
+    assert.match(configuredSecrets, /authStore\.getToken\(\)/);
+    assert.match(configuredSecrets, /authStore\.getWatchNotificationsToken\(\)/);
+    assert.match(configuredSecrets, /authStore\.getAgentApiKey\(\)/);
+  });
+
+  it('keeps Watch request validation and failures out of Stars progress handling', () => {
+    const query = caseBlock('queryWatchInbox', 'refreshWatchInbox');
+    assert.match(query, /req\.unreadOnly !== undefined && typeof req\.unreadOnly !== 'boolean'/);
+    assert.match(query, /const unreadOnly = req\.unreadOnly \?\? true/);
+    assert.match(query, /error: 'Invalid Watch inbox query\.'/);
+    assert.match(query, /error: 'Watch inbox is unavailable\.'/);
+    assert.doesNotMatch(query, /setProgress|translateError/);
+
+    for (const [name, next] of [
+      ['getWatchStatus', 'queryWatchInbox'],
+      ['refreshWatchInbox', 'disconnectWatchInbox'],
+      ['disconnectWatchInbox', 'clearWatchData'],
+      ['clearWatchData', 'getUsername'],
+    ] as const) {
+      const block = caseBlock(name, next);
+      assert.match(block, /catch \{/);
+      assert.doesNotMatch(block, /setProgress|translateError/);
+    }
+  });
+
+  it('reconciles an account boundary without polling or nested queue work', () => {
+    const listener = backgroundSource.match(
+      /chrome\.storage\.onChanged\.addListener\(\(changes, areaName\) => \{([\s\S]*?)\n\}\);\nconst organizeJobRunConnections/,
+    )?.[1] ?? '';
+    assert.match(listener, /changes\[CONFIG_STORAGE_KEY\]\s*\?\?\s*changes\[GITHUB_CREDENTIALS_STORAGE_KEY\]/);
+    assert.match(listener, /watchMainAccountChanged\(configChange\)/);
+    assert.match(listener, /void watchRefreshCoordinator\.reconcileAccount\(\{/);
+    assert.match(listener, /invalidateNotificationsIdentity: watchNotificationsIdentity\(configChange\.oldValue\)/);
+    assert.doesNotMatch(listener, /jobQueue\.run/);
+    assert.doesNotMatch(listener, /watchStore\.clearWatchData/);
+    assert.doesNotMatch(listener, /watchRefreshCoordinator\.refresh|fetchGitHub/);
+  });
+
+  it('keeps same-login main credential replacement separate from an account boundary', () => {
+    const helper = backgroundSource.match(
+      /function watchMainAccountChanged\([\s\S]*?\n\}/,
+    )?.[0] ?? '';
+    assert.match(helper, /const previous = watchAccountLogin\(change\.oldValue\)/);
+    assert.match(helper, /const next = watchAccountLogin\(change\.newValue\)/);
+    assert.doesNotMatch(helper, /tokenEncrypted|tokenCryptoMeta/);
+  });
+
+  it('resolves Watch repository detail independently of the active Stars projection', () => {
+    const detail = caseBlock('getWatchRepositoryDetail', 'refreshWatchInbox');
+    assert.match(detail, /canonicalRepositoryFullName\(req\.fullName\)/);
+    assert.match(detail, /!row\.tombstone/);
+    assert.match(detail, /row\.full_name\.toLowerCase\(\) === fullName/);
+    assert.match(detail, /idbTagStore\.get\(star\.full_name\)/);
+    assert.doesNotMatch(detail, /queryStars|invalidateCache|broadcastDataChanged/);
+  });
+});

--- a/tests/unit/background-watch-integration-contract.test.ts
+++ b/tests/unit/background-watch-integration-contract.test.ts
@@ -2,6 +2,14 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { backgroundSource, caseBlock } from '../helpers/background-case-block';
 
+function extract(source: string, pattern: RegExp, group = 1): string {
+  const match = source.match(pattern);
+  assert.ok(match, `Contract anchor not found: ${pattern}`);
+  const value = match[group];
+  assert.ok(value, `Contract capture ${group} was empty: ${pattern}`);
+  return value;
+}
+
 describe('Watch background integration contract', () => {
   it('uses the shared queue and only publishes a Watch-specific invalidation', () => {
     assert.match(backgroundSource, /const watchRefreshCoordinator = createWatchRefreshCoordinator\(\{/);
@@ -11,17 +19,19 @@ describe('Watch background integration contract', () => {
       /loadLiveRepositoryNames: async \(\) => \(await db\.stars\.toArray\(\)\)\s*\.filter\(\(star\) => !star\.tombstone\)\s*\.map\(\(star\) => star\.full_name\)/,
     );
 
-    const broadcast = backgroundSource.match(
+    const broadcast = extract(
+      backgroundSource,
       /function broadcastWatchChanged\(\) \{([\s\S]*?)\n\}/,
-    )?.[1] ?? '';
+    );
     assert.match(broadcast, /sendMessage\(\{ type: 'watchChanged' \}\)/);
     assert.doesNotMatch(broadcast, /invalidateCache|dataChanged/);
   });
 
   it('includes the classic Notifications PAT in development capture redaction', () => {
-    const configuredSecrets = backgroundSource.match(
+    const configuredSecrets = extract(
+      backgroundSource,
       /getConfiguredSecrets: async \(\) => Promise\.all\(\[([\s\S]*?)\]\)/,
-    )?.[1] ?? '';
+    );
     assert.match(configuredSecrets, /authStore\.getToken\(\)/);
     assert.match(configuredSecrets, /authStore\.getWatchNotificationsToken\(\)/);
     assert.match(configuredSecrets, /authStore\.getAgentApiKey\(\)/);
@@ -31,39 +41,46 @@ describe('Watch background integration contract', () => {
     const query = caseBlock('queryWatchInbox', 'refreshWatchInbox');
     assert.match(query, /req\.unreadOnly !== undefined && typeof req\.unreadOnly !== 'boolean'/);
     assert.match(query, /const unreadOnly = req\.unreadOnly \?\? true/);
-    assert.match(query, /error: 'Invalid Watch inbox query\.'/);
-    assert.match(query, /error: 'Watch inbox is unavailable\.'/);
+    assert.match(query, /const m = await getLocaleMessages\(\)/);
+    assert.match(query, /error: m\.background\.watchInboxQueryInvalid/);
+    assert.match(query, /error: m\.background\.watchInboxUnavailable/);
     assert.doesNotMatch(query, /setProgress|translateError/);
 
-    for (const [name, next] of [
-      ['getWatchStatus', 'queryWatchInbox'],
-      ['refreshWatchInbox', 'disconnectWatchInbox'],
-      ['disconnectWatchInbox', 'clearWatchData'],
-      ['clearWatchData', 'getUsername'],
+    for (const [name, next, message] of [
+      ['getWatchStatus', 'queryWatchInbox', 'watchStatusUnavailable'],
+      ['refreshWatchInbox', 'disconnectWatchInbox', 'watchRefreshFailed'],
+      ['disconnectWatchInbox', 'clearWatchData', 'watchDisconnectFailed'],
+      ['clearWatchData', 'getUsername', 'watchDataClearFailed'],
     ] as const) {
       const block = caseBlock(name, next);
       assert.match(block, /catch \{/);
+      assert.match(block, /const m = await getLocaleMessages\(\)/);
+      assert.match(block, new RegExp(`error: m\\.background\\.${message}`));
       assert.doesNotMatch(block, /setProgress|translateError/);
     }
   });
 
   it('reconciles an account boundary without polling or nested queue work', () => {
-    const listener = backgroundSource.match(
+    const listener = extract(
+      backgroundSource,
       /chrome\.storage\.onChanged\.addListener\(\(changes, areaName\) => \{([\s\S]*?)\n\}\);\nconst organizeJobRunConnections/,
-    )?.[1] ?? '';
-    assert.match(listener, /changes\[CONFIG_STORAGE_KEY\]\s*\?\?\s*changes\[GITHUB_CREDENTIALS_STORAGE_KEY\]/);
-    assert.match(listener, /watchMainAccountChanged\(configChange\)/);
+    );
+    assert.match(listener, /const credentialsChange = changes\[GITHUB_CREDENTIALS_STORAGE_KEY\]/);
+    assert.match(listener, /const accountChange = credentialsChange \?\? changes\[CONFIG_STORAGE_KEY\]/);
+    assert.match(listener, /watchMainAccountChanged\(accountChange\)/);
     assert.match(listener, /void watchRefreshCoordinator\.reconcileAccount\(\{/);
-    assert.match(listener, /invalidateNotificationsIdentity: watchNotificationsIdentity\(configChange\.oldValue\)/);
+    assert.match(listener, /invalidateNotificationsIdentity: watchNotificationsIdentity\(accountChange\.oldValue\)/);
     assert.doesNotMatch(listener, /jobQueue\.run/);
     assert.doesNotMatch(listener, /watchStore\.clearWatchData/);
     assert.doesNotMatch(listener, /watchRefreshCoordinator\.refresh|fetchGitHub/);
   });
 
   it('keeps same-login main credential replacement separate from an account boundary', () => {
-    const helper = backgroundSource.match(
+    const helper = extract(
+      backgroundSource,
       /function watchMainAccountChanged\([\s\S]*?\n\}/,
-    )?.[0] ?? '';
+      0,
+    );
     assert.match(helper, /const previous = watchAccountLogin\(change\.oldValue\)/);
     assert.match(helper, /const next = watchAccountLogin\(change\.newValue\)/);
     assert.doesNotMatch(helper, /tokenEncrypted|tokenCryptoMeta/);
@@ -71,6 +88,9 @@ describe('Watch background integration contract', () => {
 
   it('resolves Watch repository detail independently of the active Stars projection', () => {
     const detail = caseBlock('getWatchRepositoryDetail', 'refreshWatchInbox');
+    assert.match(detail, /const m = await getLocaleMessages\(\)/);
+    assert.match(detail, /error: m\.background\.watchRepositoryInvalid/);
+    assert.match(detail, /error: m\.background\.watchRepositoryDetailUnavailable/);
     assert.match(detail, /canonicalRepositoryFullName\(req\.fullName\)/);
     assert.match(detail, /!row\.tombstone/);
     assert.match(detail, /row\.full_name\.toLowerCase\(\) === fullName/);

--- a/tests/unit/background-watch-refresh.test.ts
+++ b/tests/unit/background-watch-refresh.test.ts
@@ -1,0 +1,646 @@
+import 'fake-indexeddb/auto';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSerializedRunner } from '@/background/serialized-runner';
+import {
+  createWatchRefreshCoordinator,
+  type WatchRefreshCoordinatorDependencies,
+} from '@/background/watch-refresh';
+import { db } from '@/storage/db';
+import * as watchStore from '@/storage/watch-store';
+import type { Config } from '@/types';
+import {
+  GitHubWatchError,
+  type GitHubNotificationThread,
+  type WatchNotificationSnapshot,
+  type WatchScopeSnapshot,
+} from '@/watch/watch-model';
+
+const ACCOUNT = 'idah';
+const NOW = Date.parse('2026-08-05T03:04:05.000Z');
+
+function config(): Config {
+  return {
+    tokenEncrypted: 'main-cipher',
+    tokenCryptoMeta: { iv: 'main-iv', salt: 'main-salt' },
+    watchNotificationsTokenEncrypted: 'watch-cipher',
+    watchNotificationsTokenCryptoMeta: { iv: 'watch-iv', salt: 'watch-salt' },
+    agentProvider: {
+      provider: 'openai',
+      protocol: null,
+      baseUrl: null,
+      model: 'gpt-5.4',
+      declaredContextWindow: null,
+      workingContextWindow: null,
+      apiKeyEncrypted: null,
+      apiKeyCryptoMeta: null,
+      credentialScope: null,
+      credentialRevision: null,
+      capability: null,
+    },
+    agentDataDisclosureAcceptance: null,
+    theme: 'dark',
+    locale: 'en',
+    defaultView: 'table',
+    lastSyncStarredAt: null,
+    gistId: null,
+    gistSyncCursor: null,
+    username: ACCOUNT,
+    avatarUrl: null,
+    displayName: null,
+    onboardingStage: 'done',
+    seenOnboarding: true,
+    seenTooltips: 0,
+    autoTagAgentPromptSeen: false,
+    autoTagLimit: 5,
+    maxTagsPerRepo: 5,
+    minTopicRepoCount: 3,
+    libraryView: {
+      version: 1,
+      filters: {
+        languages: [],
+        tags: [],
+        tagMode: 'any',
+        showTombstone: false,
+        onlyFavorite: false,
+        onlyUntagged: false,
+        onlyArchived: false,
+      },
+      sort: { sortKey: 'starred_at', sortDir: 'desc' },
+    },
+    starsPanelDefaultEnabled: true,
+    columnLayoutMode: 'default',
+    customColumnLayout: null,
+    langTagMigrationDone: true,
+    lastSyncProgress: { phase: 'idle', done: 0, total: null, message: '' },
+    backfills: {},
+  };
+}
+
+function thread(id = '1', repositoryFullName = 'owner/repo'): GitHubNotificationThread {
+  return {
+    id,
+    repositoryFullName,
+    repositoryHtmlUrl: `https://github.com/${repositoryFullName}`,
+    reason: 'subscribed',
+    subjectType: 'Issue',
+    subjectTitle: `Thread ${id}`,
+    subjectApiUrl: `https://api.github.com/repos/${repositoryFullName}/issues/1`,
+    subjectHtmlUrl: `https://github.com/${repositoryFullName}/issues/1`,
+    unread: true,
+    updatedAt: '2026-08-05T03:00:00.000Z',
+    lastReadAt: null,
+    fetchedAt: new Date(NOW).toISOString(),
+  };
+}
+
+function scopeSnapshot(): WatchScopeSnapshot {
+  return {
+    repositories: [{ full_name: 'owner/repo' }, { full_name: 'other/repo' }],
+    pageCount: 1,
+    fetchedAt: new Date(NOW).toISOString(),
+  };
+}
+
+function inboxSnapshot(overrides: Partial<WatchNotificationSnapshot> = {}): WatchNotificationSnapshot {
+  return {
+    threads: [thread()],
+    candidateCount: 1,
+    matchedCount: 1,
+    pageCount: 1,
+    truncated: false,
+    notModified: false,
+    before: new Date(NOW).toISOString(),
+    fetchedAt: new Date(NOW).toISOString(),
+    lastModified: 'Wed, 05 Aug 2026 03:04:05 GMT',
+    pollIntervalSeconds: 60,
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function harness(input: {
+  hasNotificationsToken?: boolean;
+  fetchScope?: WatchRefreshCoordinatorDependencies['fetchScope'];
+  fetchNotifications?: WatchRefreshCoordinatorDependencies['fetchNotifications'];
+  queryInbox?: typeof watchStore.queryStoredWatchInbox;
+  disconnectInbox?: typeof watchStore.disconnectWatchInbox;
+  liveRepositoryNames?: string[];
+  currentTime?: number;
+  now?: () => number;
+  runSerialized?: WatchRefreshCoordinatorDependencies['runSerialized'];
+} = {}) {
+  let currentConfig = config();
+  let mainToken: string | null = 'main-token';
+  let notificationsToken: string | null = input.hasNotificationsToken === false ? null : 'watch-token';
+  if (!notificationsToken) {
+    currentConfig = {
+      ...currentConfig,
+      watchNotificationsTokenEncrypted: null,
+      watchNotificationsTokenCryptoMeta: null,
+    };
+  }
+  const fetchScope = input.fetchScope ?? vi.fn(async () => scopeSnapshot());
+  const fetchNotifications = input.fetchNotifications ?? vi.fn(async () => inboxSnapshot());
+  const broadcastChanged = vi.fn();
+  const clearWatchNotificationsToken = vi.fn(async () => {
+    notificationsToken = null;
+    currentConfig = {
+      ...currentConfig,
+      watchNotificationsTokenEncrypted: null,
+      watchNotificationsTokenCryptoMeta: null,
+    };
+  });
+  const runner = createSerializedRunner();
+  const runSerialized = input.runSerialized ?? ((operation) => runner.run(operation));
+  const coordinator = createWatchRefreshCoordinator({
+    runSerialized,
+    auth: {
+      getGitHubCredentialSnapshot: async () => ({
+        accountLogin: currentConfig.username?.trim().toLowerCase() ?? null,
+        mainToken,
+        notificationsToken,
+        notificationsConfigured: !!(
+          currentConfig.watchNotificationsTokenEncrypted &&
+          currentConfig.watchNotificationsTokenCryptoMeta
+        ),
+        mainIdentity: JSON.stringify([
+          currentConfig.username?.trim().toLowerCase() ?? null,
+          currentConfig.tokenEncrypted,
+          currentConfig.tokenCryptoMeta,
+        ]),
+        notificationsIdentity: JSON.stringify([
+          currentConfig.watchNotificationsTokenEncrypted,
+          currentConfig.watchNotificationsTokenCryptoMeta,
+        ]),
+      }),
+      clearWatchNotificationsToken,
+    },
+    fetchScope,
+    fetchNotifications,
+    loadLiveRepositoryNames: async () => input.liveRepositoryNames ?? ['OWNER/REPO'],
+    store: {
+      getState: watchStore.getWatchState,
+      getRepositories: watchStore.getWatchRepositories,
+      queryInbox: input.queryInbox ?? watchStore.queryStoredWatchInbox,
+      reconcileAccount: watchStore.reconcileWatchAccount,
+      reconcileLiveStars: watchStore.reconcileWatchLiveStars,
+      replaceScope: watchStore.replaceWatchScope,
+      recordScopeFailure: watchStore.recordWatchScopeFailure,
+      replaceInbox: watchStore.replaceWatchInbox,
+      revalidateInbox: watchStore.revalidateWatchInbox,
+      recordInboxFailure: watchStore.recordWatchInboxFailure,
+      disconnectInbox: input.disconnectInbox ?? watchStore.disconnectWatchInbox,
+      clearData: watchStore.clearWatchData,
+    },
+    now: input.now ?? (() => input.currentTime ?? NOW),
+    broadcastChanged,
+  });
+  return {
+    coordinator,
+    fetchScope,
+    fetchNotifications,
+    broadcastChanged,
+    clearWatchNotificationsToken,
+    clearWatchToken() {
+      notificationsToken = null;
+      currentConfig = {
+        ...currentConfig,
+        watchNotificationsTokenEncrypted: null,
+        watchNotificationsTokenCryptoMeta: null,
+      };
+    },
+    setWatchToken(value = 'replacement-watch-token') {
+      notificationsToken = value;
+      currentConfig = {
+        ...currentConfig,
+        watchNotificationsTokenEncrypted: `${value}:cipher`,
+        watchNotificationsTokenCryptoMeta: { iv: `${value}:iv`, salt: `${value}:salt` },
+      };
+    },
+    logout() {
+      currentConfig = { ...currentConfig, username: null };
+      mainToken = null;
+    },
+    changeAccount(login: string) {
+      currentConfig = {
+        ...currentConfig,
+        username: login,
+        tokenEncrypted: `${currentConfig.tokenEncrypted}:${login}`,
+      };
+      mainToken = `main-token:${login}`;
+    },
+  };
+}
+
+beforeEach(async () => {
+  await db.delete();
+  await db.open();
+  await db.stars.put({
+    full_name: 'owner/repo',
+    html_url: 'https://github.com/owner/repo',
+    description: '',
+    language: null,
+    stargazers_count: 0,
+    topics: [],
+    pushed_at: null,
+    created_at: null,
+    fork: false,
+    archived: false,
+    starred_at: new Date(NOW).toISOString(),
+    tombstone: false,
+    synced_at: new Date(NOW).toISOString(),
+  });
+});
+
+afterAll(async () => {
+  await db.close();
+});
+
+describe('Watch background refresh coordinator', () => {
+  it('coalesces repeated refresh requests and publishes only live watched stars', async () => {
+    const pendingScope = deferred<WatchScopeSnapshot>();
+    const fetchScope = vi.fn(async () => pendingScope.promise);
+    const h = harness({ fetchScope });
+
+    const first = h.coordinator.refresh();
+    const second = h.coordinator.refresh();
+    await Promise.resolve();
+    pendingScope.resolve(scopeSnapshot());
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult).toEqual(secondResult);
+    expect(fetchScope).toHaveBeenCalledTimes(1);
+    expect(h.fetchNotifications).toHaveBeenCalledTimes(1);
+    expect(await watchStore.getWatchRepositories(ACCOUNT)).toEqual([{ full_name: 'owner/repo' }]);
+    expect((await watchStore.queryStoredWatchInbox({ accountLogin: ACCOUNT })).threads).toHaveLength(1);
+    expect(h.broadcastChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('makes no network requests during the persisted poll cooldown', async () => {
+    await watchStore.replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/repo' }],
+      attemptedAt: new Date(NOW - 1_000).toISOString(),
+    });
+    await watchStore.replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads: [thread()],
+      attemptedAt: new Date(NOW - 1_000).toISOString(),
+      lastModified: null,
+      nextAllowedAt: new Date(NOW + 30_000).toISOString(),
+      candidateCount: 1,
+      truncated: false,
+    });
+    const h = harness();
+
+    const result = await h.coordinator.refresh();
+
+    expect(h.fetchScope).not.toHaveBeenCalled();
+    expect(h.fetchNotifications).not.toHaveBeenCalled();
+    expect(result.status.inboxStatus).toBe('cooldown');
+    expect(h.broadcastChanged).not.toHaveBeenCalled();
+  });
+
+  it('refreshes native scope without a classic Notifications token', async () => {
+    const h = harness({ hasNotificationsToken: false });
+    const result = await h.coordinator.refresh();
+
+    expect(h.fetchScope).toHaveBeenCalledTimes(1);
+    expect(h.fetchNotifications).not.toHaveBeenCalled();
+    expect(result.scopePublished).toBe(true);
+    expect(result.status.inboxStatus).toBe('not_configured');
+  });
+
+  it('continues Inbox refresh against a stale successful scope', async () => {
+    await watchStore.replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/repo' }],
+      attemptedAt: new Date(NOW - 120_000).toISOString(),
+    });
+    const fetchScope = vi.fn(async () => {
+      throw new GitHubWatchError('network_error');
+    });
+    const h = harness({ fetchScope });
+
+    const result = await h.coordinator.refresh();
+
+    expect(h.fetchNotifications).toHaveBeenCalledTimes(1);
+    expect(result.inboxPublished).toBe(true);
+    expect(result.status.scopeStatus).toBe('stale');
+    expect((await watchStore.queryStoredWatchInbox({ accountLogin: ACCOUNT })).threads).toHaveLength(1);
+  });
+
+  it('does not request Notifications without a successful scope snapshot', async () => {
+    const fetchScope = vi.fn(async () => {
+      throw new GitHubWatchError('permission_denied');
+    });
+    const h = harness({ fetchScope });
+
+    const result = await h.coordinator.refresh();
+
+    expect(h.fetchNotifications).not.toHaveBeenCalled();
+    expect(result.status.scopeStatus).toBe('error');
+    expect(result.status.inboxStatus).toBe('scope_unavailable');
+  });
+
+  it('revalidates a 304 without replacing cached rows', async () => {
+    await watchStore.replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/repo' }],
+      attemptedAt: new Date(NOW - 120_000).toISOString(),
+    });
+    await watchStore.replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads: [thread('cached')],
+      attemptedAt: new Date(NOW - 120_000).toISOString(),
+      lastModified: 'Tue, 04 Aug 2026 03:04:05 GMT',
+      nextAllowedAt: new Date(NOW - 60_000).toISOString(),
+      candidateCount: 1,
+      truncated: true,
+    });
+    await watchStore.recordWatchInboxFailure({
+      accountLogin: ACCOUNT,
+      attemptedAt: new Date(NOW - 30_000).toISOString(),
+      errorCode: 'network_error',
+    });
+    const h = harness({
+      fetchNotifications: vi.fn(async () => inboxSnapshot({
+        threads: [],
+        candidateCount: 0,
+        matchedCount: 0,
+        notModified: true,
+        pollIntervalSeconds: 120,
+      })),
+    });
+
+    const result = await h.coordinator.refresh();
+
+    expect(result.notModified).toBe(true);
+    expect(result.inboxPublished).toBe(false);
+    const stored = await watchStore.queryStoredWatchInbox({ accountLogin: ACCOUNT });
+    expect(stored.threads.map((item) => item.id)).toEqual(['cached']);
+    expect(stored.state?.inbox.errorCode).toBeNull();
+    expect(stored.state?.inbox.truncated).toBe(true);
+  });
+
+  it('invalidates the Notifications validator when the effective scope changes', async () => {
+    await watchStore.replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/repo' }],
+      attemptedAt: new Date(NOW - 120_000).toISOString(),
+    });
+    await watchStore.replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads: [thread('cached')],
+      attemptedAt: new Date(NOW - 120_000).toISOString(),
+      lastModified: 'Tue, 04 Aug 2026 03:04:05 GMT',
+      nextAllowedAt: new Date(NOW - 60_000).toISOString(),
+      candidateCount: 1,
+      truncated: false,
+    });
+    const fetchNotifications = vi.fn(async (options) => {
+      expect(options.lastModified).toBeNull();
+      return inboxSnapshot({
+        threads: [thread('new-scope', 'other/repo')],
+        candidateCount: 1,
+        matchedCount: 1,
+      });
+    });
+    const h = harness({
+      fetchNotifications,
+      liveRepositoryNames: ['owner/repo', 'other/repo'],
+    });
+
+    await h.coordinator.refresh();
+
+    expect(fetchNotifications).toHaveBeenCalledTimes(1);
+    const stored = await watchStore.queryStoredWatchInbox({
+      accountLogin: ACCOUNT,
+      unreadOnly: false,
+    });
+    expect(stored.threads.map((item) => item.id)).toEqual(['new-scope']);
+    expect(stored.state?.inbox.lastModified).toBe(
+      'Wed, 05 Aug 2026 03:04:05 GMT',
+    );
+  });
+
+  it('does not return cached private rows when the account changes during a query', async () => {
+    await watchStore.replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/repo' }],
+      attemptedAt: new Date(NOW - 120_000).toISOString(),
+    });
+    await watchStore.replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads: [thread('private')],
+      attemptedAt: new Date(NOW - 120_000).toISOString(),
+      lastModified: null,
+      nextAllowedAt: null,
+      candidateCount: 1,
+      truncated: false,
+    });
+    const queryStarted = deferred<void>();
+    const releaseQuery = deferred<void>();
+    const queryInbox: typeof watchStore.queryStoredWatchInbox = async (input) => {
+      const result = await watchStore.queryStoredWatchInbox(input);
+      queryStarted.resolve();
+      await releaseQuery.promise;
+      return result;
+    };
+    const h = harness({ queryInbox });
+
+    const pending = h.coordinator.queryInbox(false);
+    await queryStarted.promise;
+    h.changeAccount('another-user');
+    releaseQuery.resolve();
+    const result = await pending;
+
+    expect(result.threads).toEqual([]);
+    expect(result.groups).toEqual([]);
+    expect(result).not.toHaveProperty('state');
+    expect(result.status.accountLogin).toBe('another-user');
+  });
+
+  it('repairs a tombstoned star before returning a cached Watch projection', async () => {
+    const h = harness();
+    await watchStore.replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/repo' }],
+      attemptedAt: new Date(NOW).toISOString(),
+    });
+    await watchStore.replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads: [thread('cached')],
+      attemptedAt: new Date(NOW).toISOString(),
+      lastModified: null,
+      nextAllowedAt: null,
+      candidateCount: 1,
+      truncated: false,
+    });
+    await db.stars.update('owner/repo', { tombstone: true });
+
+    const result = await h.coordinator.queryInbox(false);
+
+    expect(result.threads).toEqual([]);
+    expect(result.groups).toEqual([]);
+    expect(h.broadcastChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('queues a new refresh when credentials change during an in-flight refresh', async () => {
+    const firstScope = deferred<WatchScopeSnapshot>();
+    const fetchScope = vi.fn(async () => (
+      fetchScope.mock.calls.length === 1 ? firstScope.promise : scopeSnapshot()
+    ));
+    const h = harness({
+      hasNotificationsToken: false,
+      fetchScope,
+    });
+
+    const first = h.coordinator.refresh();
+    await vi.waitFor(() => expect(fetchScope).toHaveBeenCalledTimes(1));
+    h.changeAccount('another-user');
+    const second = h.coordinator.refresh();
+    firstScope.resolve(scopeSnapshot());
+    await Promise.all([first, second]);
+
+    expect(fetchScope).toHaveBeenCalledTimes(2);
+    expect((await watchStore.getWatchState('another-user'))?.scope.lastSuccessfulAt)
+      .toBe(new Date(NOW).toISOString());
+  });
+
+  it('starts the poll cooldown after the response completes', async () => {
+    let clock = NOW;
+    const h = harness({
+      now: () => clock,
+      fetchNotifications: vi.fn(async () => {
+        clock += 120_000;
+        return inboxSnapshot({ pollIntervalSeconds: 60 });
+      }),
+    });
+
+    await h.coordinator.refresh();
+
+    const state = await watchStore.getWatchState(ACCOUNT);
+    expect(state?.inbox.nextAllowedAt).toBe(new Date(clock + 60_000).toISOString());
+  });
+
+  it('does not send the old Notifications token when it is revoked during scope refresh', async () => {
+    const pendingScope = deferred<WatchScopeSnapshot>();
+    const h = harness({ fetchScope: vi.fn(async () => pendingScope.promise) });
+
+    const refresh = h.coordinator.refresh();
+    await vi.waitFor(() => expect(h.fetchScope).toHaveBeenCalledTimes(1));
+    h.clearWatchToken();
+    pendingScope.resolve(scopeSnapshot());
+
+    await refresh;
+    expect(h.fetchNotifications).not.toHaveBeenCalled();
+  });
+
+  it('skips a queued refresh whose credential snapshot became stale before it started', async () => {
+    const pending: Array<() => Promise<void>> = [];
+    const runSerialized = ((operation: () => Promise<unknown>) => new Promise<unknown>((resolve, reject) => {
+      pending.push(async () => {
+        try {
+          resolve(await operation());
+        } catch (error) {
+          reject(error);
+        }
+      });
+    })) as WatchRefreshCoordinatorDependencies['runSerialized'];
+    const h = harness({ runSerialized });
+
+    const refresh = h.coordinator.refresh();
+    await vi.waitFor(() => expect(pending).toHaveLength(1));
+    await pending.shift()!(); // entry reconciliation
+    await vi.waitFor(() => expect(pending).toHaveLength(1));
+    h.clearWatchToken();
+    await pending.shift()!(); // refresh operation
+
+    const result = await refresh;
+    expect(result.scopePublished).toBe(false);
+    expect(h.fetchScope).not.toHaveBeenCalled();
+    expect(h.fetchNotifications).not.toHaveBeenCalled();
+  });
+
+  it('reconciles an interrupted account cleanup without deleting a newer Watch token', async () => {
+    await watchStore.replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/repo' }],
+      attemptedAt: new Date(NOW).toISOString(),
+    });
+    const h = harness();
+    h.changeAccount('another-user');
+    h.setWatchToken();
+
+    await h.coordinator.reconcileAccount({
+      invalidateNotificationsIdentity: JSON.stringify([
+        'watch-cipher',
+        { iv: 'watch-iv', salt: 'watch-salt' },
+      ]),
+    });
+
+    expect(await watchStore.getWatchState(ACCOUNT)).toBeNull();
+    expect((await h.coordinator.getStatus()).hasNotificationsToken).toBe(true);
+  });
+
+  it('clears the old classic credential only when its persisted identity still matches', async () => {
+    await watchStore.replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/repo' }],
+      attemptedAt: new Date(NOW).toISOString(),
+    });
+    const h = harness();
+    h.changeAccount('another-user');
+
+    await h.coordinator.reconcileAccount({
+      invalidateNotificationsIdentity: JSON.stringify([
+        'watch-cipher',
+        { iv: 'watch-iv', salt: 'watch-salt' },
+      ]),
+    });
+
+    expect((await h.coordinator.getStatus()).hasNotificationsToken).toBe(false);
+    expect(await watchStore.getWatchState(ACCOUNT)).toBeNull();
+  });
+
+  it('clears stale account data and the classic credential after logout on the next Watch entry', async () => {
+    await watchStore.replaceWatchScope({
+      accountLogin: ACCOUNT,
+      repositories: [{ full_name: 'owner/repo' }],
+      attemptedAt: new Date(NOW).toISOString(),
+    });
+    const h = harness();
+    h.logout();
+
+    const status = await h.coordinator.getStatus();
+
+    expect(status.hasNotificationsToken).toBe(false);
+    expect(await watchStore.getWatchState(ACCOUNT)).toBeNull();
+  });
+
+  it('broadcasts disconnect invalidation only after cached threads are cleared', async () => {
+    const pendingDisconnect = deferred<void>();
+    const disconnectInbox = vi.fn(async () => pendingDisconnect.promise);
+    const h = harness({ disconnectInbox });
+
+    const disconnect = h.coordinator.disconnectInbox();
+    await vi.waitFor(() => {
+      expect(h.clearWatchNotificationsToken).toHaveBeenCalledTimes(1);
+      expect(disconnectInbox).toHaveBeenCalledWith(ACCOUNT);
+    });
+    expect(h.broadcastChanged).not.toHaveBeenCalled();
+
+    pendingDisconnect.resolve();
+    await disconnect;
+
+    expect(h.broadcastChanged).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/github-watch-sources.test.ts
+++ b/tests/unit/github-watch-sources.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchGitHubNotifications } from '@/api/github-notifications-source';
+import { fetchGitHubWatchScope } from '@/api/github-watch-scope-source';
+import { createSerializedRunner } from '@/background/serialized-runner';
+import { GitHubWatchError } from '@/watch/watch-model';
+
+const NOW = '2026-08-05T03:04:05.000Z';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers);
+  headers.set('content-type', 'application/json; charset=utf-8');
+  return new Response(JSON.stringify(body), { ...init, headers });
+}
+
+function hangingJsonResponse(signal: AbortSignal): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: () => new Promise((_, reject) => {
+      signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), {
+        once: true,
+      });
+    }),
+  } as Response;
+}
+
+function notification(id: string, fullName = 'Owner/Repo', overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    unread: true,
+    reason: 'future_reason',
+    updated_at: '2026-08-05T02:00:00Z',
+    last_read_at: null,
+    repository: {
+      full_name: fullName,
+      html_url: `https://github.com/${fullName}`,
+    },
+    subject: {
+      title: `Thread ${id}`,
+      type: 'PullRequest',
+      url: `https://api.github.com/repos/${fullName}/pulls/7`,
+    },
+    ...overrides,
+  };
+}
+
+describe('GitHub Watch API sources', () => {
+  it('publishes a complete canonical watched-repository snapshot after every page succeeds', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+      const url = new URL(String(input));
+      if (url.searchParams.get('page') === '1') {
+        return jsonResponse([{ full_name: 'Owner/One' }], {
+          headers: {
+            link: '<https://api.github.com/user/subscriptions?per_page=100&page=2>; rel="next", <https://api.github.com/user/subscriptions?per_page=100&page=2>; rel="last"',
+          },
+        });
+      }
+      return jsonResponse([{ full_name: 'owner/TWO' }, { full_name: 'OWNER/one' }]);
+    });
+
+    const result = await fetchGitHubWatchScope({
+      token: 'github_pat_scope',
+      fetchImpl,
+      now: () => NOW,
+    });
+
+    expect(result).toEqual({
+      repositories: [{ full_name: 'owner/one' }, { full_name: 'owner/two' }],
+      pageCount: 2,
+      fetchedAt: NOW,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    for (const [url, init] of fetchImpl.mock.calls) {
+      expect(String(url)).toContain('/user/subscriptions?per_page=100&page=');
+      expect(new Headers(init?.headers).get('authorization')).toBe('Bearer github_pat_scope');
+      expect(init?.cache).toBe('no-store');
+    }
+  });
+
+  it('rejects a failed later scope page without returning a partial snapshot', async () => {
+    let requestCount = 0;
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      requestCount++;
+      return requestCount === 1
+        ? jsonResponse([{ full_name: 'owner/one' }], {
+          headers: {
+            link: '<https://api.github.com/user/subscriptions?per_page=100&page=2>; rel="next"',
+          },
+        })
+        : jsonResponse({ message: 'unavailable' }, { status: 503 });
+    });
+
+    await expect(fetchGitHubWatchScope({ token: 'token', fetchImpl }))
+      .rejects.toMatchObject({ code: 'github_unavailable', page: 2 });
+  });
+
+  it('rejects skipped pages instead of publishing incomplete snapshots', async () => {
+    const scopeFetch = vi.fn<typeof fetch>(async () => jsonResponse(
+      [{ full_name: 'owner/one' }],
+      {
+        headers: {
+          link: '<https://api.github.com/user/subscriptions?per_page=100&page=3>; rel="next"',
+        },
+      },
+    ));
+    await expect(fetchGitHubWatchScope({ token: 'token', fetchImpl: scopeFetch }))
+      .rejects.toMatchObject({ code: 'invalid_pagination', page: 1 });
+    expect(scopeFetch).toHaveBeenCalledTimes(1);
+
+    const notificationsFetch = vi.fn<typeof fetch>(async () => jsonResponse(
+      [notification('1')],
+      {
+        headers: {
+          link: `<https://api.github.com/notifications?all=true&participating=false&per_page=50&before=${encodeURIComponent(NOW)}&page=3>; rel="next"`,
+        },
+      },
+    ));
+    await expect(fetchGitHubNotifications({
+      token: 'token',
+      fetchImpl: notificationsFetch,
+      now: () => NOW,
+    })).rejects.toMatchObject({ code: 'invalid_pagination', page: 1 });
+    expect(notificationsFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts valid repository names that begin with punctuation', async () => {
+    const scope = await fetchGitHubWatchScope({
+      token: 'token',
+      fetchImpl: vi.fn(async () => jsonResponse([{ full_name: 'github/.github' }])),
+      now: () => NOW,
+    });
+    expect(scope.repositories).toEqual([{ full_name: 'github/.github' }]);
+
+    const inbox = await fetchGitHubNotifications({
+      token: 'token',
+      fetchImpl: vi.fn(async () => jsonResponse([
+        notification('dot', 'github/.github'),
+      ])),
+      now: () => NOW,
+    });
+    expect(inbox.threads[0]?.repositoryFullName).toBe('github/.github');
+  });
+
+  it('uses one frozen Notifications boundary and preserves unknown reason/type values', async () => {
+    const calls: Array<{ url: URL; headers: Headers }> = [];
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      const url = new URL(String(input));
+      calls.push({ url, headers: new Headers(init?.headers) });
+      if (url.searchParams.get('page') === '1') {
+        return jsonResponse([notification('1')], {
+          headers: {
+            link: '<https://api.github.com/notifications?all=true&participating=false&per_page=50&before=2026-08-05T03%3A04%3A05.000Z&page=2>; rel="next"',
+            'last-modified': 'Wed, 05 Aug 2026 03:04:05 GMT',
+            'x-poll-interval': '90',
+          },
+        });
+      }
+      return jsonResponse([notification('2', 'owner/Repo', {
+        subject: {
+          title: 'Future subject',
+          type: 'FutureSubject',
+          url: 'https://api.github.com/repos/owner/Repo/releases/4',
+        },
+      })]);
+    });
+
+    const result = await fetchGitHubNotifications({
+      token: 'classic_notifications',
+      fetchImpl,
+      now: () => NOW,
+      lastModified: 'Tue, 04 Aug 2026 03:04:05 GMT',
+    });
+
+    expect(result.pageCount).toBe(2);
+    expect(result.before).toBe(NOW);
+    expect(result.lastModified).toBe('Wed, 05 Aug 2026 03:04:05 GMT');
+    expect(result.pollIntervalSeconds).toBe(90);
+    expect(result.truncated).toBe(false);
+    expect(result.threads.map((thread) => [thread.id, thread.reason, thread.subjectType]))
+      .toEqual([
+        ['1', 'future_reason', 'PullRequest'],
+        ['2', 'future_reason', 'FutureSubject'],
+      ]);
+    expect(result.threads[0]?.subjectHtmlUrl).toBe('https://github.com/owner/repo/pull/7');
+    expect(result.threads[1]?.subjectHtmlUrl).toBeNull();
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.headers.get('if-modified-since')).toBe('Tue, 04 Aug 2026 03:04:05 GMT');
+    expect(calls[1]?.headers.get('if-modified-since')).toBeNull();
+    for (const call of calls) {
+      expect(call.url.searchParams.get('all')).toBe('true');
+      expect(call.url.searchParams.get('participating')).toBe('false');
+      expect(call.url.searchParams.get('per_page')).toBe('50');
+      expect(call.url.searchParams.get('before')).toBe(NOW);
+    }
+  });
+
+  it('returns a non-destructive 304 revalidation result', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(null, {
+      status: 304,
+      headers: { 'x-poll-interval': '120' },
+    }));
+
+    const result = await fetchGitHubNotifications({
+      token: 'classic_notifications',
+      fetchImpl,
+      now: () => NOW,
+      lastModified: 'Wed, 05 Aug 2026 03:04:05 GMT',
+    });
+
+    expect(result.notModified).toBe(true);
+    expect(result.threads).toEqual([]);
+    expect(result.lastModified).toBe('Wed, 05 Aug 2026 03:04:05 GMT');
+    expect(result.pollIntervalSeconds).toBe(120);
+  });
+
+  it('limits absurd poll intervals to the conservative default', async () => {
+    const result = await fetchGitHubNotifications({
+      token: 'classic_notifications',
+      fetchImpl: vi.fn(async () => jsonResponse([], {
+        headers: { 'x-poll-interval': '999999999999999999999' },
+      })),
+      now: () => NOW,
+    });
+
+    expect(result.pollIntervalSeconds).toBe(60);
+  });
+
+  it('keeps the timeout active while consuming a response body and releases the shared queue', async () => {
+    const runner = createSerializedRunner();
+    const hangingFetch = vi.fn<typeof fetch>(async (_input, init) => {
+      const signal = init?.signal;
+      if (!(signal instanceof AbortSignal)) throw new Error('expected abort signal');
+      return hangingJsonResponse(signal);
+    });
+
+    const scope = runner.run(() => fetchGitHubWatchScope({
+      token: 'token',
+      fetchImpl: hangingFetch,
+      timeoutMs: 5,
+    }));
+    const next = runner.run(async () => 'next operation');
+    await expect(scope).rejects.toMatchObject({ code: 'deadline_exceeded', page: 1 });
+    await expect(next).resolves.toBe('next operation');
+
+    await expect(fetchGitHubNotifications({
+      token: 'token',
+      fetchImpl: hangingFetch,
+      timeoutMs: 5,
+    })).rejects.toMatchObject({ code: 'deadline_exceeded', page: 1 });
+  });
+
+  it('rejects an unsolicited 304 and clears a validator missing from a new 200', async () => {
+    const unsolicited = vi.fn<typeof fetch>(async () => new Response(null, { status: 304 }));
+    await expect(fetchGitHubNotifications({
+      token: 'classic_notifications',
+      fetchImpl: unsolicited,
+      now: () => NOW,
+    })).rejects.toMatchObject({ code: 'invalid_response', status: 304, page: 1 });
+
+    const replaced = await fetchGitHubNotifications({
+      token: 'classic_notifications',
+      fetchImpl: vi.fn(async () => jsonResponse([])),
+      now: () => NOW,
+      lastModified: 'Tue, 04 Aug 2026 03:04:05 GMT',
+    });
+    expect(replaced.notModified).toBe(false);
+    expect(replaced.lastModified).toBeNull();
+  });
+
+  it('classifies a secondary rate limit from Retry-After without reading the body', async () => {
+    const limited = vi.fn<typeof fetch>(async () => jsonResponse(
+      { message: 'slow down' },
+      { status: 403, headers: { 'retry-after': '60' } },
+    ));
+    await expect(fetchGitHubWatchScope({ token: 'token', fetchImpl: limited }))
+      .rejects.toMatchObject({ code: 'rate_limited', status: 403 });
+    await expect(fetchGitHubNotifications({ token: 'token', fetchImpl: limited }))
+      .rejects.toMatchObject({ code: 'rate_limited', status: 403 });
+  });
+
+  it('marks the bounded Notifications window truncated only when another page exists', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+      const url = new URL(String(input));
+      const page = Number(url.searchParams.get('page'));
+      return jsonResponse([notification(String(page))], {
+        headers: {
+          link: `<https://api.github.com/notifications?all=true&participating=false&per_page=50&before=${encodeURIComponent(NOW)}&page=${page + 1}>; rel="next"`,
+        },
+      });
+    });
+
+    const result = await fetchGitHubNotifications({
+      token: 'classic_notifications',
+      fetchImpl,
+      now: () => NOW,
+      maxPages: 3,
+    });
+
+    expect(result.pageCount).toBe(3);
+    expect(result.truncated).toBe(true);
+    expect(result.candidateCount).toBe(3);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('classifies malformed thread payloads with a stable error code', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => jsonResponse([{ id: 'bad' }]));
+    await expect(fetchGitHubNotifications({ token: 'token', fetchImpl }))
+      .rejects.toEqual(expect.objectContaining<Partial<GitHubWatchError>>({
+        code: 'invalid_thread',
+        page: 1,
+      }));
+  });
+});

--- a/tests/unit/github-watch-sources.test.ts
+++ b/tests/unit/github-watch-sources.test.ts
@@ -95,6 +95,24 @@ describe('GitHub Watch API sources', () => {
       .rejects.toMatchObject({ code: 'github_unavailable', page: 2 });
   });
 
+  it('rejects a scope snapshot that exceeds its bounded page window', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+      const page = Number(new URL(String(input)).searchParams.get('page'));
+      return jsonResponse([{ full_name: `owner/repo-${page}` }], {
+        headers: {
+          link: `<https://api.github.com/user/subscriptions?per_page=100&page=${page + 1}>; rel="next"`,
+        },
+      });
+    });
+
+    await expect(fetchGitHubWatchScope({
+      token: 'token',
+      fetchImpl,
+      maxPages: 2,
+    })).rejects.toMatchObject({ code: 'page_limit_exceeded', page: 2 });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
   it('rejects skipped pages instead of publishing incomplete snapshots', async () => {
     const scopeFetch = vi.fn<typeof fetch>(async () => jsonResponse(
       [{ full_name: 'owner/one' }],

--- a/tests/unit/i18n-locale-provider.test.tsx
+++ b/tests/unit/i18n-locale-provider.test.tsx
@@ -158,6 +158,16 @@ describe('i18n catalog and locale propagation invariants', () => {
     );
   });
 
+  it('localizes Watch background failures in both product locales', () => {
+    const english = getMessages('en').background;
+    const chinese = getMessages('zh-CN').background;
+
+    assert.equal(english.watchDisconnectFailed, 'Watch Inbox disconnect failed.');
+    assert.equal(chinese.watchDisconnectFailed, '断开 Watch 收件箱失败。');
+    assert.equal(english.watchInboxQueryInvalid, 'Invalid Watch inbox query.');
+    assert.equal(chinese.watchInboxQueryInvalid, 'Watch 收件箱查询无效。');
+  });
+
   it('localizes the development Cubby diagnostics surface while preserving raw evidence identifiers', () => {
     const english = getAgentDiagnosticsMessages('en');
     const chinese = getAgentDiagnosticsMessages('zh-CN');

--- a/tests/unit/i18n-locale-provider.test.tsx
+++ b/tests/unit/i18n-locale-provider.test.tsx
@@ -145,7 +145,7 @@ describe('i18n catalog and locale propagation invariants', () => {
         english.agentPanel.agentSettings,
         english.options.agentHeading,
       ],
-      ['Cubby', 'Cubby', 'Cubby settings', '2. Cubby'],
+      ['Cubby', 'Cubby', 'Cubby settings', '3. Cubby'],
     );
     assert.deepEqual(
       [
@@ -154,7 +154,7 @@ describe('i18n catalog and locale propagation invariants', () => {
         chinese.agentPanel.agentSettings,
         chinese.options.agentHeading,
       ],
-      ['Cubby', 'Cubby', 'Cubby 设置', '2. Cubby'],
+      ['Cubby', 'Cubby', 'Cubby 设置', '3. Cubby'],
     );
   });
 

--- a/tests/unit/library-view-persistence.test.tsx
+++ b/tests/unit/library-view-persistence.test.tsx
@@ -38,6 +38,8 @@ function baseConfig(): Config {
   return {
     tokenEncrypted: null,
     tokenCryptoMeta: null,
+    watchNotificationsTokenEncrypted: null,
+    watchNotificationsTokenCryptoMeta: null,
     agentProvider: {
       provider: 'openai',
       protocol: null,

--- a/tests/unit/manager-panel-unstar.test.tsx
+++ b/tests/unit/manager-panel-unstar.test.tsx
@@ -13,6 +13,7 @@ const managerMocks = vi.hoisted(() => ({
   bgCall: vi.fn(),
   setInfo: vi.fn(),
   refreshStars: vi.fn(),
+  resetFilters: vi.fn(),
   row: {
     full_name: 'owner/repo',
     html_url: 'https://github.com/owner/repo',
@@ -69,7 +70,7 @@ vi.mock('@/ui/filter-store', async (importOriginal) => {
     setOnlyArchived: vi.fn(),
     setSort: vi.fn(),
     applyLibraryViewPrefs: vi.fn(),
-    resetFilters: vi.fn(),
+    resetFilters: managerMocks.resetFilters,
   };
   const useFilterStore = Object.assign(() => filterState, {
     getState: () => filterState,
@@ -114,6 +115,19 @@ vi.mock('@/ui/hooks/use-theme', () => ({
     theme: 'light',
     themeClass: '',
     toggle: vi.fn(),
+  }),
+}));
+
+vi.mock('@/ui/hooks/use-watch-inbox', () => ({
+  useWatchInbox: () => ({
+    unreadOnly: true,
+    setUnreadOnly: vi.fn(),
+    result: { unreadCount: 3 },
+    loading: false,
+    refreshing: false,
+    error: null,
+    refresh: vi.fn(),
+    reload: vi.fn(),
   }),
 }));
 
@@ -178,7 +192,39 @@ vi.mock('@/content/stars-page/panel-toggle', () => ({
 }));
 
 vi.mock('@/ui/components/Toolbar', () => ({
-  Toolbar: () => <div data-testid="toolbar" />,
+  Toolbar: ({
+    surface,
+    onSurfaceChange,
+    watchUnreadCount,
+  }: {
+    surface: 'stars' | 'watch';
+    onSurfaceChange: (surface: 'stars' | 'watch') => void;
+    watchUnreadCount: number;
+  }) => (
+    <div data-testid="toolbar" data-watch-unread={watchUnreadCount}>
+      <button type="button" data-testid="stars-surface" onClick={() => onSurfaceChange('stars')}>
+        Stars
+      </button>
+      <button type="button" data-testid="watch-surface" onClick={() => onSurfaceChange('watch')}>
+        Watch
+      </button>
+      <span data-testid="active-surface">{surface}</span>
+    </div>
+  ),
+}));
+
+vi.mock('@/ui/components/WatchInbox', () => ({
+  WatchInbox: ({ onSelectRepository }: { onSelectRepository?: (fullName: string) => void }) => (
+    <div data-testid="watch-inbox">
+      <button
+        type="button"
+        data-testid="watch-repository"
+        onClick={() => onSelectRepository?.('owner/repo')}
+      >
+        owner/repo
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('@/ui/components/FilterSidebar', () => ({
@@ -249,6 +295,7 @@ beforeEach(() => {
   managerMocks.bgCall.mockReturnValue(new Promise(() => {}));
   managerMocks.setInfo.mockReset();
   managerMocks.refreshStars.mockReset();
+  managerMocks.resetFilters.mockReset();
 });
 
 afterEach(() => {
@@ -262,6 +309,75 @@ afterEach(() => {
 });
 
 describe('ManagerPanel unstar flow', () => {
+  it('switches to Watch without resetting Stars filters and opens targeted repository detail', async () => {
+    managerMocks.bgCall.mockImplementation((type: string) => {
+      if (type === 'getWatchRepositoryDetail') {
+        return Promise.resolve({ star: managerMocks.row, tag: null });
+      }
+      return new Promise(() => {});
+    });
+    const { container } = mountPanel();
+
+    expect(container.querySelector('[data-testid="filter-sidebar"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="select-row"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="toolbar"]')?.getAttribute('data-watch-unread'))
+      .toBe('3');
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('[data-testid="watch-surface"]')?.click();
+    });
+
+    expect(container.querySelector('[data-testid="active-surface"]')?.textContent).toBe('watch');
+    expect(container.querySelector('[data-testid="watch-inbox"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="filter-sidebar"]')).toBeNull();
+    expect(container.querySelector('[data-testid="select-row"]')).toBeNull();
+    expect(managerMocks.resetFilters).not.toHaveBeenCalled();
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="watch-repository"]')?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(managerMocks.bgCall).toHaveBeenCalledWith('getWatchRepositoryDetail', {
+      fullName: 'owner/repo',
+    });
+    expect(container.querySelector('[data-testid="repo-detail"]')?.textContent).toBe('owner/repo');
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('[data-testid="stars-surface"]')?.click();
+    });
+    expect(container.querySelector('[data-testid="filter-sidebar"]')).not.toBeNull();
+    expect(managerMocks.resetFilters).not.toHaveBeenCalled();
+  });
+
+  it('discards a late Watch detail response after returning to Stars', async () => {
+    let resolveDetail!: (value: { star: Star; tag: null }) => void;
+    const detail = new Promise<{ star: Star; tag: null }>((resolve) => {
+      resolveDetail = resolve;
+    });
+    managerMocks.bgCall.mockImplementation((type: string) => (
+      type === 'getWatchRepositoryDetail' ? detail : new Promise(() => {})
+    ));
+    const { container } = mountPanel();
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('[data-testid="watch-surface"]')?.click();
+    });
+    act(() => {
+      container.querySelector<HTMLButtonElement>('[data-testid="watch-repository"]')?.click();
+      container.querySelector<HTMLButtonElement>('[data-testid="stars-surface"]')?.click();
+    });
+    await act(async () => {
+      resolveDetail({ star: managerMocks.row, tag: null });
+      await detail;
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('[data-testid="active-surface"]')?.textContent).toBe('stars');
+    expect(container.querySelector('[data-testid="repo-detail"]')).toBeNull();
+  });
+
   it('dispatches markUnstarred immediately without an optimistic hide timer', () => {
     const { container } = mountPanel();
     const confirm = container.querySelector<HTMLButtonElement>('[data-testid="confirm-unstar"]');

--- a/tests/unit/manager-sync-actions.test.tsx
+++ b/tests/unit/manager-sync-actions.test.tsx
@@ -12,6 +12,10 @@ const mountedRoots: MountedRoot[] = [];
 const sendMessage = vi.fn();
 let latest: ReturnType<typeof useManagerSyncActions> | null = null;
 let messageListeners: Array<(message: { type?: string }) => void> = [];
+let storageListeners: Array<(
+  changes: Record<string, chrome.storage.StorageChange>,
+  areaName: string,
+) => void> = [];
 
 function baseStatus(patch: Partial<SyncStatus> = {}): SyncStatus {
   const backfills = patch.backfills ?? {};
@@ -89,6 +93,7 @@ async function waitFor(assertion: () => void) {
 
 beforeEach(() => {
   messageListeners = [];
+  storageListeners = [];
   sendMessage.mockReset();
   vi.stubGlobal('chrome', {
     runtime: {
@@ -102,6 +107,16 @@ beforeEach(() => {
         }),
       },
     },
+    storage: {
+      onChanged: {
+        addListener: vi.fn((listener) => {
+          storageListeners.push(listener);
+        }),
+        removeListener: vi.fn((listener) => {
+          storageListeners = storageListeners.filter((item) => item !== listener);
+        }),
+      },
+    },
   });
 });
 
@@ -111,6 +126,53 @@ afterEach(() => {
 });
 
 describe('useManagerSyncActions', () => {
+  it('refreshes status on authoritative credential changes without starting a sync', async () => {
+    let hasToken = false;
+    sendMessage.mockImplementation((message: { type: string }) => {
+      if (message.type === 'getStatus') {
+        return ok(baseStatus({
+          hasToken,
+          onboardingStage: hasToken ? 'done' : 'needs_token',
+          seenOnboarding: hasToken,
+        }));
+      }
+      throw new Error(`Unexpected message: ${message.type}`);
+    });
+
+    const hook = mountHook();
+    await waitFor(() => expect(hook.current.statusLoaded).toBe(true));
+    expect(hook.current.status?.hasToken).toBe(false);
+    expect(storageListeners).toHaveLength(1);
+
+    await act(async () => {
+      storageListeners[0]?.({ gsm_github_credentials_v1: { newValue: {} } }, 'sync');
+      storageListeners[0]?.({ gsm_config: { newValue: {} } }, 'local');
+      await Promise.resolve();
+    });
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    hasToken = true;
+    await act(async () => {
+      storageListeners[0]?.({
+        gsm_github_credentials_v1: {
+          oldValue: { tokenEncrypted: null },
+          newValue: { tokenEncrypted: 'ciphertext' },
+        },
+      }, 'local');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(hook.current.status?.hasToken).toBe(true);
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage).not.toHaveBeenCalledWith({ type: 'syncFull' });
+    expect(sendMessage).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'query' }));
+
+    const root = mountedRoots.pop();
+    act(() => root?.unmount());
+    expect(storageListeners).toHaveLength(0);
+  });
+
   it('runs the initial sync and advances onboarding after data appears', async () => {
     const refreshStars = vi.fn();
     const queryGrandTotals = [0, 3];

--- a/tests/unit/options-preferences.test.tsx
+++ b/tests/unit/options-preferences.test.tsx
@@ -17,8 +17,10 @@ import {
 const authMocks = vi.hoisted(() => ({
   getConfig: vi.fn(),
   hasToken: vi.fn(),
+  hasWatchNotificationsToken: vi.fn(),
   setToken: vi.fn(),
   clearToken: vi.fn(),
+  setWatchNotificationsToken: vi.fn(),
   updateAgentProviderConfig: vi.fn(),
   acceptAgentDataDisclosure: vi.fn(),
   clearAgentProviderApiKey: vi.fn(),
@@ -29,6 +31,7 @@ const authMocks = vi.hoisted(() => ({
 
 vi.mock('@/auth/auth-store', () => ({
   CONFIG_STORAGE_KEY: 'gsm_config',
+  GITHUB_CREDENTIALS_STORAGE_KEY: 'gsm_github_credentials_v1',
   authStore: authMocks,
 }));
 
@@ -56,6 +59,8 @@ function config(overrides: Partial<Config> = {}): Config {
     ...overrides,
     tokenEncrypted: overrides.tokenEncrypted ?? 'cipher',
     tokenCryptoMeta: overrides.tokenCryptoMeta ?? { iv: 'iv', salt: 'salt' },
+    watchNotificationsTokenEncrypted: overrides.watchNotificationsTokenEncrypted ?? null,
+    watchNotificationsTokenCryptoMeta: overrides.watchNotificationsTokenCryptoMeta ?? null,
     agentProvider: overrides.agentProvider
       ? {
           declaredContextWindow: overrides.agentProvider.provider === 'custom-openai-compatible'
@@ -137,12 +142,28 @@ async function blur(input: HTMLInputElement) {
   });
 }
 
+async function setTextareaValue(textarea: HTMLTextAreaElement, value: string) {
+  await act(async () => {
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      'value',
+    )?.set;
+    valueSetter?.call(textarea, value);
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    textarea.dispatchEvent(new Event('change', { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
 describe('Options preferences', () => {
   beforeEach(() => {
     authMocks.getConfig.mockReset();
     authMocks.hasToken.mockReset();
+    authMocks.hasWatchNotificationsToken.mockReset();
+    authMocks.hasWatchNotificationsToken.mockResolvedValue(false);
     authMocks.setToken.mockReset();
     authMocks.clearToken.mockReset();
+    authMocks.setWatchNotificationsToken.mockReset();
     authMocks.updateAgentProviderConfig.mockReset();
     authMocks.acceptAgentDataDisclosure.mockReset();
     authMocks.clearAgentProviderApiKey.mockReset();
@@ -317,6 +338,133 @@ describe('Options preferences', () => {
     });
 
     expect(document.querySelector('a[href="https://github.com/idah?tab=stars"]')).toBeNull();
+  });
+
+  it.each([
+    {
+      errorCode: 'TOKEN_WATCHING_FORBIDDEN',
+      expected: 'Watch needs Account · Watching (read).',
+    },
+    {
+      errorCode: 'TOKEN_WATCHING_NETWORK',
+      expected: 'Watch access could not be verified.',
+    },
+  ])('keeps a saved main token successful but surfaces $errorCode beside its form', async ({
+    errorCode,
+    expected,
+  }) => {
+    authMocks.getConfig.mockResolvedValue(config());
+    authMocks.hasToken.mockResolvedValue(true);
+    authMocks.setToken.mockResolvedValue({
+      username: 'idah',
+      watching: { available: false, errorCode },
+    });
+
+    await renderOptions();
+
+    const input = document.querySelector<HTMLTextAreaElement>('textarea[placeholder="github_pat_..."]');
+    expect(input).toBeInstanceOf(HTMLTextAreaElement);
+    await setTextareaValue(input!, 'github_pat_without_watching');
+    const save = [...document.querySelectorAll<HTMLButtonElement>('button')]
+      .find((button) => button.textContent?.trim() === 'Save & verify');
+    await click(save!);
+
+    expect(authMocks.setToken).toHaveBeenCalledWith('github_pat_without_watching');
+    expect(input?.value).toBe('');
+    const status = document.querySelector('[data-testid="main-token-status"]');
+    expect(status?.getAttribute('role')).toBe('status');
+    expect(status?.className).toContain('text-warning');
+    expect(status?.textContent).toContain(expected);
+  });
+
+  it('keeps the Watch Inbox token disabled until the main token is usable', async () => {
+    authMocks.getConfig.mockResolvedValue(config());
+    authMocks.hasToken.mockResolvedValue(false);
+
+    await renderOptions();
+
+    const input = document.querySelector<HTMLInputElement>('#watch-notifications-token');
+    const connect = document.querySelector<HTMLButtonElement>(
+      '[data-testid="watch-token-connect"]',
+    );
+    expect(input?.disabled).toBe(true);
+    expect(connect).toBeInstanceOf(HTMLButtonElement);
+    expect((connect as HTMLButtonElement).disabled).toBe(true);
+    expect(document.body.textContent).toContain('Connect a usable main GitHub token first.');
+  });
+
+  it('connects a same-account classic token and clears the submitted secret', async () => {
+    authMocks.getConfig.mockResolvedValue(config());
+    authMocks.hasToken.mockResolvedValue(true);
+    authMocks.hasWatchNotificationsToken
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(true);
+    authMocks.setWatchNotificationsToken.mockResolvedValue({ username: 'idah' });
+
+    await renderOptions();
+
+    const input = document.querySelector<HTMLInputElement>('#watch-notifications-token');
+    expect(input).not.toBeNull();
+    await setInputValue(input!, 'ghp-watch');
+    const connect = document.querySelector<HTMLButtonElement>(
+      '[data-testid="watch-token-connect"]',
+    );
+    await click(connect!);
+
+    expect(authMocks.setWatchNotificationsToken).toHaveBeenCalledWith('ghp-watch');
+    expect(input?.value).toBe('');
+    expect(document.body.textContent).toContain('Watch Inbox connected as @idah.');
+  });
+
+  it('preserves a replacement token draft when verification fails', async () => {
+    authMocks.getConfig.mockResolvedValue(config({
+      watchNotificationsTokenEncrypted: 'watch-cipher',
+      watchNotificationsTokenCryptoMeta: { iv: 'watch-iv', salt: 'watch-salt' },
+    }));
+    authMocks.hasToken.mockResolvedValue(true);
+    authMocks.hasWatchNotificationsToken.mockResolvedValue(true);
+    authMocks.setWatchNotificationsToken.mockRejectedValue(new Error('WATCH_TOKEN_FORBIDDEN'));
+
+    await renderOptions();
+
+    const input = document.querySelector<HTMLInputElement>('#watch-notifications-token');
+    await setInputValue(input!, 'ghp-replacement');
+    const replace = document.querySelector<HTMLButtonElement>(
+      '[data-testid="watch-token-connect"]',
+    );
+    await click(replace!);
+
+    expect(input?.value).toBe('ghp-replacement');
+    expect(document.querySelector('[data-testid="watch-token-status"]')?.getAttribute('role'))
+      .toBe('alert');
+    expect(document.body.textContent).toContain('Watch Inbox connected as @idah.');
+  });
+
+  it('disconnects Watch Inbox through the background cache boundary', async () => {
+    authMocks.getConfig.mockResolvedValue(config({
+      watchNotificationsTokenEncrypted: 'watch-cipher',
+      watchNotificationsTokenCryptoMeta: { iv: 'watch-iv', salt: 'watch-salt' },
+    }));
+    authMocks.hasToken.mockResolvedValue(true);
+    authMocks.hasWatchNotificationsToken
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValue(false);
+
+    await renderOptions();
+
+    const disconnect = document.querySelector<HTMLButtonElement>(
+      '[data-testid="watch-token-disconnect"]',
+    );
+    await click(disconnect!);
+
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+      type: 'disconnectWatchInbox',
+    });
+    expect(document.body.textContent).toContain(
+      'Watch Inbox disconnected and cached threads removed.',
+    );
   });
 
   it('saves and automatically tests Cubby settings with the saved key', async () => {

--- a/tests/unit/use-watch-inbox.test.tsx
+++ b/tests/unit/use-watch-inbox.test.tsx
@@ -1,0 +1,402 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useWatchInbox } from '@/ui/hooks/use-watch-inbox';
+import type { WatchInboxQueryResponse } from '@/watch/watch-contract';
+import {
+  cleanupMountedRootsAndBody,
+  click,
+  mountReact,
+  type MountedRoot,
+} from './test-utils';
+
+const watchMocks = vi.hoisted(() => ({
+  bgCall: vi.fn(),
+}));
+
+type RuntimeListener = (message: { type?: string }) => void;
+type StorageListener = (
+  changes: Record<string, chrome.storage.StorageChange>,
+  areaName: string,
+) => void;
+
+const runtimeListeners: RuntimeListener[] = [];
+const storageListeners: StorageListener[] = [];
+
+vi.mock('@/utils/messaging', () => ({
+  bgCall: watchMocks.bgCall,
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function queryResponse(totalCount: number): WatchInboxQueryResponse {
+  return {
+    threads: [],
+    groups: [],
+    unreadCount: totalCount,
+    totalCount,
+    status: {
+      accountLogin: 'idah',
+      hasMainToken: true,
+      hasNotificationsToken: true,
+      refreshing: false,
+      scopeStatus: 'fresh',
+      inboxStatus: 'fresh',
+      state: null,
+    },
+  };
+}
+
+function cooldownResponse(
+  totalCount: number,
+  nextAllowedAt: string,
+): WatchInboxQueryResponse {
+  const response = queryResponse(totalCount);
+  response.status.inboxStatus = 'cooldown';
+  response.status.state = {
+    id: 'singleton',
+    accountLogin: 'idah',
+    scope: {
+      lastAttemptAt: '2026-08-05T11:59:00Z',
+      lastSuccessfulAt: '2026-08-05T11:59:00Z',
+      errorCode: null,
+      repositoryCount: 1,
+    },
+    inbox: {
+      lastAttemptAt: '2026-08-05T11:59:00Z',
+      lastSuccessfulAt: '2026-08-05T11:59:00Z',
+      errorCode: null,
+      lastModified: null,
+      nextAllowedAt,
+      candidateCount: totalCount,
+      matchedCount: totalCount,
+      truncated: false,
+    },
+  };
+  return response;
+}
+
+function Harness() {
+  const inbox = useWatchInbox();
+  return (
+    <div>
+      <button type="button" data-testid="all" onClick={() => inbox.setUnreadOnly(false)}>
+        All
+      </button>
+      <button type="button" data-testid="refresh" onClick={() => void inbox.refresh()}>
+        Refresh
+      </button>
+      <span data-testid="mode">{inbox.unreadOnly ? 'unread' : 'all'}</span>
+      <span data-testid="loading">{inbox.loading ? 'loading' : 'ready'}</span>
+      <span data-testid="count">{inbox.result?.totalCount ?? 'none'}</span>
+    </div>
+  );
+}
+
+const mountedRoots: MountedRoot[] = [];
+
+beforeEach(() => {
+  watchMocks.bgCall.mockReset();
+  runtimeListeners.length = 0;
+  storageListeners.length = 0;
+  vi.stubGlobal('chrome', {
+    runtime: {
+      onMessage: {
+        addListener: vi.fn((listener: RuntimeListener) => runtimeListeners.push(listener)),
+        removeListener: vi.fn((listener: RuntimeListener) => {
+          const index = runtimeListeners.indexOf(listener);
+          if (index >= 0) runtimeListeners.splice(index, 1);
+        }),
+      },
+    },
+    storage: {
+      onChanged: {
+        addListener: vi.fn((listener: StorageListener) => storageListeners.push(listener)),
+        removeListener: vi.fn((listener: StorageListener) => {
+          const index = storageListeners.indexOf(listener);
+          if (index >= 0) storageListeners.splice(index, 1);
+        }),
+      },
+    },
+  });
+});
+
+afterEach(() => {
+  cleanupMountedRootsAndBody(mountedRoots);
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('useWatchInbox', () => {
+  it('uses the latest Unread/All mode after an in-flight refresh completes', async () => {
+    const refresh = deferred<unknown>();
+    const queryModes: boolean[] = [];
+    watchMocks.bgCall.mockImplementation((type: string, payload?: { unreadOnly?: boolean }) => {
+      if (type === 'refreshWatchInbox') return refresh.promise;
+      if (type === 'queryWatchInbox') {
+        const unreadOnly = payload?.unreadOnly ?? true;
+        queryModes.push(unreadOnly);
+        return Promise.resolve(queryResponse(unreadOnly ? 1 : 2));
+      }
+      throw new Error(`Unexpected request: ${type}`);
+    });
+
+    const container = mountReact(<Harness />, mountedRoots);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-testid="count"]')?.textContent).toBe('1');
+
+    await click(container.querySelector<HTMLButtonElement>('[data-testid="refresh"]')!);
+    await click(container.querySelector<HTMLButtonElement>('[data-testid="all"]')!);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('[data-testid="mode"]')?.textContent).toBe('all');
+    expect(container.querySelector('[data-testid="count"]')?.textContent).toBe('2');
+
+    await act(async () => {
+      refresh.resolve({});
+      await refresh.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(queryModes).toEqual([true, false, false]);
+    expect(container.querySelector('[data-testid="mode"]')?.textContent).toBe('all');
+    expect(container.querySelector('[data-testid="count"]')?.textContent).toBe('2');
+    expect(container.querySelector('[data-testid="loading"]')?.textContent).toBe('ready');
+  });
+
+  it('marks a projection mode change as loading until the new query commits', async () => {
+    const allQuery = deferred<WatchInboxQueryResponse>();
+    watchMocks.bgCall.mockImplementation((type: string, payload?: { unreadOnly?: boolean }) => {
+      if (type !== 'queryWatchInbox') throw new Error(`Unexpected request: ${type}`);
+      return payload?.unreadOnly === false
+        ? allQuery.promise
+        : Promise.resolve(queryResponse(1));
+    });
+
+    const container = mountReact(<Harness />, mountedRoots);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await click(container.querySelector<HTMLButtonElement>('[data-testid="all"]')!);
+
+    expect(container.querySelector('[data-testid="loading"]')?.textContent).toBe('loading');
+
+    await act(async () => {
+      allQuery.resolve(queryResponse(2));
+      await allQuery.promise;
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('[data-testid="loading"]')?.textContent).toBe('ready');
+    expect(container.querySelector('[data-testid="count"]')?.textContent).toBe('2');
+  });
+
+  it('silently reloads when the authoritative GitHub credential record changes', async () => {
+    const credentialQuery = deferred<WatchInboxQueryResponse>();
+    const queryModes: boolean[] = [];
+    watchMocks.bgCall.mockImplementation((
+      type: string,
+      payload?: { unreadOnly?: boolean },
+    ) => {
+      if (type !== 'queryWatchInbox') throw new Error(`Unexpected request: ${type}`);
+      const mode = payload?.unreadOnly ?? true;
+      queryModes.push(mode);
+      if (queryModes.length === 3) return credentialQuery.promise;
+      return Promise.resolve(queryResponse(queryModes.length));
+    });
+
+    const container = mountReact(<Harness />, mountedRoots);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-testid="count"]')?.textContent).toBe('1');
+    expect(storageListeners).toHaveLength(1);
+    await click(container.querySelector<HTMLButtonElement>('[data-testid="all"]')!);
+    expect(container.querySelector('[data-testid="count"]')?.textContent).toBe('2');
+
+    await act(async () => {
+      storageListeners[0]?.({
+        gsm_github_credentials_v1: { newValue: {} },
+      }, 'sync');
+      storageListeners[0]?.({
+        gsm_config: { newValue: {} },
+      }, 'local');
+      await Promise.resolve();
+    });
+    expect(queryModes).toEqual([true, false]);
+
+    await act(async () => {
+      storageListeners[0]?.({
+        gsm_github_credentials_v1: {
+          oldValue: { watchNotificationsTokenEncrypted: null },
+          newValue: { watchNotificationsTokenEncrypted: 'ciphertext' },
+        },
+      }, 'local');
+      await Promise.resolve();
+    });
+
+    expect(queryModes).toEqual([true, false, false]);
+    expect(container.querySelector('[data-testid="loading"]')?.textContent).toBe('ready');
+    expect(container.querySelector('[data-testid="count"]')?.textContent).toBe('2');
+
+    await act(async () => {
+      credentialQuery.resolve(queryResponse(3));
+      await credentialQuery.promise;
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-testid="count"]')?.textContent).toBe('3');
+  });
+
+  it('requeries local status once the persisted cooldown expires', async () => {
+    vi.useFakeTimers();
+    const now = Date.parse('2026-08-05T12:00:00Z');
+    vi.setSystemTime(now);
+    const cooldown = cooldownResponse(1, '2026-08-05T12:00:01Z');
+    let queryCount = 0;
+    watchMocks.bgCall.mockImplementation((type: string) => {
+      if (type !== 'queryWatchInbox') throw new Error(`Unexpected request: ${type}`);
+      queryCount++;
+      return Promise.resolve(queryCount === 1 ? cooldown : queryResponse(2));
+    });
+
+    const container = mountReact(<Harness />, mountedRoots);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(queryCount).toBe(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(queryCount).toBe(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(25);
+      await Promise.resolve();
+    });
+    expect(queryCount).toBe(2);
+    expect(container.querySelector('[data-testid="count"]')?.textContent).toBe('2');
+  });
+
+  it('reschedules a changed cooldown and clears its timer on unmount', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.parse('2026-08-05T12:00:00Z'));
+    const responses = [
+      cooldownResponse(1, '2026-08-05T12:00:01Z'),
+      cooldownResponse(2, '2026-08-05T12:00:02Z'),
+      cooldownResponse(3, '2026-08-05T12:00:04Z'),
+    ];
+    let queryCount = 0;
+    watchMocks.bgCall.mockImplementation((type: string) => {
+      if (type !== 'queryWatchInbox') throw new Error(`Unexpected request: ${type}`);
+      const response = responses[queryCount];
+      queryCount++;
+      if (!response) throw new Error('Unexpected cooldown query');
+      return Promise.resolve(response);
+    });
+
+    mountReact(<Harness />, mountedRoots);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(queryCount).toBe(1);
+
+    await act(async () => {
+      runtimeListeners[0]?.({ type: 'watchChanged' });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(queryCount).toBe(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_025);
+    });
+    expect(queryCount).toBe(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(queryCount).toBe(3);
+
+    const root = mountedRoots.pop();
+    act(() => root?.unmount());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+    expect(queryCount).toBe(3);
+  });
+
+  it('rechecks the remaining deadline when the wall clock moves backward', async () => {
+    vi.useFakeTimers();
+    const now = Date.parse('2026-08-05T12:00:00Z');
+    vi.setSystemTime(now);
+    const cooldown = cooldownResponse(1, '2026-08-05T12:00:01Z');
+    let queryCount = 0;
+    watchMocks.bgCall.mockImplementation((type: string) => {
+      if (type !== 'queryWatchInbox') throw new Error(`Unexpected request: ${type}`);
+      queryCount++;
+      return Promise.resolve(queryCount < 3 ? cooldown : queryResponse(3));
+    });
+
+    const container = mountReact(<Harness />, mountedRoots);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(queryCount).toBe(1);
+
+    vi.setSystemTime(now - 1_000);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_025);
+      await Promise.resolve();
+    });
+    expect(queryCount).toBe(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(999);
+    });
+    expect(queryCount).toBe(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+      await Promise.resolve();
+    });
+    expect(queryCount).toBe(3);
+    expect(container.querySelector('[data-testid="count"]')?.textContent).toBe('3');
+  });
+
+  it('removes credential and runtime invalidation listeners on unmount', async () => {
+    watchMocks.bgCall.mockResolvedValue(queryResponse(1));
+    mountReact(<Harness />, mountedRoots);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(runtimeListeners).toHaveLength(1);
+    expect(storageListeners).toHaveLength(1);
+
+    const root = mountedRoots.pop();
+    act(() => root?.unmount());
+
+    expect(runtimeListeners).toHaveLength(0);
+    expect(storageListeners).toHaveLength(0);
+  });
+});

--- a/tests/unit/watch-inbox-presentation.test.ts
+++ b/tests/unit/watch-inbox-presentation.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import {
+  countWatchReasons,
+  filterWatchInboxProjection,
+  formatWatchRelativeTime,
+  watchReasonPresetValues,
+} from '@/ui/watch-inbox-presentation';
+import {
+  KNOWN_NOTIFICATION_REASONS,
+  type GitHubNotificationThread,
+  type WatchInboxProjection,
+} from '@/watch/watch-model';
+
+const NOW = Date.parse('2026-08-05T12:00:00Z');
+
+describe('formatWatchRelativeTime', () => {
+  it.each([
+    ['2026-08-05T12:00:30Z', '<1m'],
+    ['2026-08-05T11:59:01Z', '<1m'],
+    ['2026-08-05T11:59:00Z', '1m'],
+    ['2026-08-05T11:01:00Z', '59m'],
+    ['2026-08-05T11:00:00Z', '1h'],
+    ['2026-08-04T12:00:00Z', '1d'],
+    ['2026-07-06T12:00:00Z', '1mo'],
+    ['2025-08-05T12:00:00Z', '1y'],
+  ])('formats %s against an injected clock as %s', (value, expected) => {
+    expect(formatWatchRelativeTime(value, NOW)).toBe(expected);
+  });
+
+  it('returns null for missing or invalid input', () => {
+    expect(formatWatchRelativeTime(null, NOW)).toBeNull();
+    expect(formatWatchRelativeTime('', NOW)).toBeNull();
+    expect(formatWatchRelativeTime('not-a-date', NOW)).toBeNull();
+    expect(formatWatchRelativeTime('2026-08-05T12:00:00Z', Number.NaN)).toBeNull();
+  });
+});
+
+function thread(
+  id: string,
+  repositoryFullName: string,
+  subjectTitle: string,
+  reason: string,
+): GitHubNotificationThread {
+  return {
+    id,
+    repositoryFullName,
+    repositoryHtmlUrl: `https://github.com/${repositoryFullName}`,
+    reason,
+    subjectType: 'Issue',
+    subjectTitle,
+    subjectApiUrl: null,
+    subjectHtmlUrl: null,
+    unread: true,
+    updatedAt: `2026-08-05T0${id}:00:00Z`,
+    lastReadAt: null,
+    fetchedAt: '2026-08-05T12:00:00Z',
+  };
+}
+
+const threads = [
+  thread('1', 'owner/alpha', 'Review the parser', 'review_requested'),
+  thread('2', 'owner/alpha', 'Parser follow-up', 'review_requested'),
+  thread('3', 'owner/security', 'Advisory credit', 'security_advisory_credit'),
+  thread('4', 'owner/future', 'Future event', 'future_reason'),
+];
+const projection: WatchInboxProjection = {
+  threads,
+  groups: [],
+  unreadCount: threads.length,
+  totalCount: threads.length,
+};
+
+describe('Watch inbox presentation filters', () => {
+  it('counts raw reasons and keeps unknown values', () => {
+    expect(countWatchReasons(threads)).toEqual([
+      { reason: 'future_reason', count: 1 },
+      { reason: 'review_requested', count: 2 },
+      { reason: 'security_advisory_credit', count: 1 },
+    ]);
+    expect(watchReasonPresetValues('other', countWatchReasons(threads).map((item) => item.reason)))
+      .toEqual(['future_reason']);
+  });
+
+  it('combines repository/title search with multi-reason filtering', () => {
+    const filtered = filterWatchInboxProjection(projection, {
+      query: 'parser',
+      reasons: ['review_requested', 'future_reason'],
+    });
+    expect(filtered.threads.map((item) => item.id)).toEqual(['2', '1']);
+    expect(filtered.groups.map((group) => group.repositoryFullName)).toEqual(['owner/alpha']);
+    expect(filtered.totalCount).toBe(2);
+  });
+
+  it('searches only repository names and subject titles', () => {
+    expect(filterWatchInboxProjection(projection, { query: 'issue' }).threads).toEqual([]);
+    expect(filterWatchInboxProjection(projection, { query: 'review_requested' }).threads)
+      .toEqual([]);
+    expect(filterWatchInboxProjection(projection, { query: ' OWNER/SECURITY ' }).threads)
+      .toHaveLength(1);
+  });
+
+  it('treats an empty reason selection as all and normalizes selected values', () => {
+    expect(filterWatchInboxProjection(projection, { reasons: [] }).totalCount).toBe(4);
+    expect(filterWatchInboxProjection(projection, {
+      reasons: [' REVIEW_REQUESTED '],
+    }).threads.map((item) => item.id)).toEqual(['2', '1']);
+  });
+
+  it('maps documented presets only to reasons present in the current projection', () => {
+    const available = countWatchReasons(threads).map((item) => item.reason);
+    expect(watchReasonPresetValues('direct', available)).toEqual(['review_requested']);
+    expect(watchReasonPresetValues('security', available)).toEqual(['security_advisory_credit']);
+    expect(watchReasonPresetValues('watching', available)).toEqual([]);
+  });
+
+  it('partitions every documented reason into exactly one preset', () => {
+    const presets = ['direct', 'security', 'participation', 'watching'] as const;
+    const partitioned = presets.flatMap((preset) => (
+      watchReasonPresetValues(preset, KNOWN_NOTIFICATION_REASONS)
+    ));
+
+    expect(partitioned).toHaveLength(KNOWN_NOTIFICATION_REASONS.length);
+    expect(new Set(partitioned)).toEqual(new Set(KNOWN_NOTIFICATION_REASONS));
+    expect(watchReasonPresetValues('other', KNOWN_NOTIFICATION_REASONS)).toEqual([]);
+    expect(watchReasonPresetValues('other', [
+      ...KNOWN_NOTIFICATION_REASONS,
+      'future_reason',
+    ])).toEqual(['future_reason']);
+  });
+});

--- a/tests/unit/watch-inbox.test.tsx
+++ b/tests/unit/watch-inbox.test.tsx
@@ -1,0 +1,422 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WatchInbox } from '@/ui/components/WatchInbox';
+import type { GitHubNotificationThread } from '@/watch/watch-model';
+import type { WatchInboxQueryResponse } from '@/watch/watch-contract';
+import {
+  cleanupMountedRootsAndBody,
+  click,
+  mountReact,
+  setInputValue,
+  type MountedRoot,
+} from './test-utils';
+
+function thread(
+  index: number,
+  overrides: Partial<GitHubNotificationThread> = {},
+): GitHubNotificationThread {
+  const repositoryFullName = `owner/repo-${index}`;
+  return {
+    id: String(index),
+    repositoryFullName,
+    repositoryHtmlUrl: `https://github.com/${repositoryFullName}`,
+    reason: index === 0 ? 'future_reason' : 'subscribed',
+    subjectType: 'Issue',
+    subjectTitle: `Thread ${index}`,
+    subjectApiUrl: `https://api.github.com/repos/${repositoryFullName}/issues/1`,
+    subjectHtmlUrl: `https://github.com/${repositoryFullName}/issues/1`,
+    unread: true,
+    updatedAt: '2026-08-05T00:00:00Z',
+    lastReadAt: null,
+    fetchedAt: '2026-08-05T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function result(overrides: Partial<WatchInboxQueryResponse> = {}): WatchInboxQueryResponse {
+  const threads = overrides.threads ?? [thread(0)];
+  return {
+    threads,
+    groups: overrides.groups ?? threads.map((item) => ({
+      repositoryFullName: item.repositoryFullName,
+      repositoryHtmlUrl: item.repositoryHtmlUrl,
+      latestUpdatedAt: item.updatedAt,
+      threads: [item],
+    })),
+    unreadCount: overrides.unreadCount ?? threads.length,
+    totalCount: overrides.totalCount ?? threads.length,
+    status: overrides.status ?? {
+      accountLogin: 'idah',
+      hasMainToken: true,
+      hasNotificationsToken: true,
+      refreshing: false,
+      scopeStatus: 'fresh',
+      inboxStatus: 'fresh',
+      state: {
+        id: 'singleton',
+        accountLogin: 'idah',
+        scope: {
+          lastAttemptAt: '2026-08-05T00:00:00Z',
+          lastSuccessfulAt: '2026-08-05T00:00:00Z',
+          errorCode: null,
+          repositoryCount: threads.length,
+        },
+        inbox: {
+          lastAttemptAt: '2026-08-05T00:00:00Z',
+          lastSuccessfulAt: '2026-08-05T00:00:00Z',
+          errorCode: null,
+          lastModified: null,
+          nextAllowedAt: null,
+          candidateCount: threads.length,
+          matchedCount: threads.length,
+          truncated: false,
+        },
+      },
+    },
+  };
+}
+
+const mountedRoots: MountedRoot[] = [];
+
+afterEach(() => {
+  cleanupMountedRootsAndBody(mountedRoots);
+});
+
+function renderInbox(props: Partial<React.ComponentProps<typeof WatchInbox>> = {}) {
+  return mountReact(
+    <WatchInbox
+      result={result()}
+      loading={false}
+      refreshing={false}
+      error={null}
+      unreadOnly
+      onUnreadOnlyChange={vi.fn()}
+      onRefresh={vi.fn()}
+      onRetryQuery={vi.fn()}
+      onOpenOptions={vi.fn()}
+      {...props}
+    />,
+    mountedRoots,
+  );
+}
+
+function findButtonByText(root: ParentNode, text: string): HTMLButtonElement {
+  const button = Array.from(root.querySelectorAll<HTMLButtonElement>('button'))
+    .find((candidate) => candidate.textContent?.trim() === text);
+  if (!button) throw new Error(`Expected button labelled "${text}"`);
+  return button;
+}
+
+function findReasonControl(
+  popover: HTMLElement,
+  reason: string,
+): { control: HTMLButtonElement; row: HTMLElement } {
+  const label = Array.from(popover.querySelectorAll<HTMLElement>('*'))
+    .find((candidate) => (
+      candidate.children.length === 0 && candidate.textContent?.trim() === reason
+    ));
+  if (!label) throw new Error(`Expected raw reason "${reason}"`);
+
+  let row: HTMLElement | null = label;
+  while (row && row !== popover) {
+    const control = row.querySelector<HTMLButtonElement>('[role="checkbox"]');
+    if (control) return { control, row };
+    row = row.parentElement;
+  }
+  throw new Error(`Expected checkbox for reason "${reason}"`);
+}
+
+function keydown(target: HTMLElement, key: string) {
+  target.dispatchEvent(new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+  }));
+}
+
+describe('WatchInbox', () => {
+  it('distinguishes a query failure from missing main-token setup', () => {
+    const retry = vi.fn();
+    const container = renderInbox({ result: null, error: 'query', onRetryQuery: retry });
+
+    expect(container.textContent).toContain('The Watch snapshot could not be loaded.');
+    expect(container.textContent).not.toContain('Add Watching: read');
+  });
+
+  it('renders a specific Watching permission action on a terminal scope failure', () => {
+    const permissionResult = result();
+    permissionResult.groups = [];
+    permissionResult.threads = [];
+    permissionResult.status.scopeStatus = 'error';
+    permissionResult.status.inboxStatus = 'scope_unavailable';
+    permissionResult.status.state!.scope.lastSuccessfulAt = null;
+    permissionResult.status.state!.scope.errorCode = 'permission_denied';
+
+    const container = renderInbox({ result: permissionResult });
+
+    expect(container.textContent).toContain('main token cannot read Watching');
+    expect(container.textContent).toContain('Open options');
+  });
+
+  it('renders raw reason metadata, the repository unread count, and a safe GitHub link', () => {
+    const unreadThread = thread(0);
+    const readThread = thread(0, {
+      id: 'read-thread',
+      subjectTitle: 'Read thread',
+      subjectApiUrl: 'https://api.github.com/repos/owner/repo-0/issues/2',
+      subjectHtmlUrl: 'https://github.com/owner/repo-0/issues/2',
+      unread: false,
+    });
+    const container = renderInbox({
+      result: result({
+        threads: [unreadThread, readThread],
+        groups: [{
+          repositoryFullName: unreadThread.repositoryFullName,
+          repositoryHtmlUrl: unreadThread.repositoryHtmlUrl,
+          latestUpdatedAt: unreadThread.updatedAt,
+          threads: [unreadThread, readThread],
+        }],
+        unreadCount: 1,
+        totalCount: 2,
+      }),
+    });
+    const link = container.querySelector<HTMLAnchorElement>(
+      'a[aria-label="Open on GitHub: Thread 0"]',
+    );
+    const reason = link?.querySelector('code');
+    const updated = link?.querySelector('time');
+    const repository = container
+      .querySelector('[aria-label="Collapse owner/repo-0"]')
+      ?.closest('section');
+    const unreadPill = Array.from(repository?.querySelectorAll('span') ?? [])
+      .find((element) => element.textContent === '1 unread');
+
+    expect(reason?.textContent).toBe('future_reason');
+    expect(reason?.getAttribute('title')).toBe('future_reason');
+    expect(unreadPill).toBeDefined();
+    expect(link?.href).toBe('https://github.com/owner/repo-0/issues/1');
+    expect(link?.target).toBe('_blank');
+    expect(link?.relList.contains('noreferrer')).toBe(true);
+    expect(updated?.dateTime).toBe('2026-08-05T00:00:00Z');
+    expect(updated?.title).toBe(new Intl.DateTimeFormat('en', {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date('2026-08-05T00:00:00Z')));
+    expect(updated?.textContent).toMatch(/^(?:<1m|\d+(?:mo|[mhdy]))$/);
+  });
+
+  it('falls back to the repository page and exposes unknown metadata as its description', () => {
+    const unknownThread = thread(0, {
+      subjectType: 'FutureType',
+      subjectApiUrl: 'https://api.github.com/repos/owner/repo-0/releases/1',
+      subjectHtmlUrl: null,
+    });
+    const container = renderInbox({ result: result({ threads: [unknownThread] }) });
+    const link = container.querySelector<HTMLAnchorElement>(
+      'a[aria-label="Open on GitHub: Thread 0"]',
+    );
+    const descriptionId = link?.getAttribute('aria-describedby');
+    const description = descriptionId
+      ? container.ownerDocument.getElementById(descriptionId)
+      : null;
+
+    expect(link?.href).toBe('https://github.com/owner/repo-0');
+    expect(description).not.toBeNull();
+    expect(description?.textContent).toContain('FutureType. future_reason.');
+  });
+
+  it('uses separate accessible group controls and lazily mounts later thread groups', async () => {
+    const threads = Array.from({ length: 9 }, (_, index) => thread(index));
+    const container = renderInbox({ result: result({ threads }) });
+
+    expect(container.querySelector('summary')).toBeNull();
+    expect(container.querySelector('[role="group"]')?.getAttribute('aria-label'))
+      .toBe('Inbox thread filter');
+    expect(container.textContent).toContain('Thread 7');
+    expect(container.textContent).not.toContain('Thread 8');
+
+    const expand = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Expand owner/repo-8"]',
+    );
+    expect(expand).not.toBeNull();
+    expect(expand?.getAttribute('aria-expanded')).toBe('false');
+    await click(expand!);
+
+    expect(container.textContent).toContain('Thread 8');
+    expect(expand?.getAttribute('aria-expanded')).toBe('true');
+    expect(expand?.getAttribute('aria-label')).toBe('Collapse owner/repo-8');
+  });
+
+  it('searches repository names and thread titles, then shows a filter-specific empty state', async () => {
+    const release = thread(0, {
+      repositoryFullName: 'acme/release-tools',
+      subjectTitle: 'Prepare the changelog',
+      reason: 'subscribed',
+    });
+    const security = thread(1, {
+      repositoryFullName: 'acme/security-center',
+      subjectTitle: 'Dependency alert',
+      reason: 'security_alert',
+    });
+    const review = thread(2, {
+      repositoryFullName: 'team/frontend',
+      subjectTitle: 'Review requested for navigation',
+      reason: 'review_requested',
+    });
+    const container = renderInbox({
+      result: result({ threads: [release, security, review] }),
+    });
+    const search = container.querySelector<HTMLInputElement>(
+      'input[placeholder="Search repositories and threads"]',
+    );
+    if (!search) throw new Error('Expected Watch search input');
+
+    await setInputValue(search, 'SECURITY-CENTER');
+
+    expect(container.textContent).toContain('Dependency alert');
+    expect(container.textContent).not.toContain('Prepare the changelog');
+    expect(container.textContent).not.toContain('Review requested for navigation');
+    expect(container.querySelector('header')?.textContent).toContain('1 thread');
+
+    await setInputValue(search, 'requested for NAVIGATION');
+
+    expect(container.textContent).toContain('Review requested for navigation');
+    expect(container.textContent).not.toContain('Dependency alert');
+
+    await setInputValue(search, 'no such repository or thread');
+
+    expect(container.textContent).toContain(
+      'No threads match the current Watch search and reason filters.',
+    );
+    expect(container.textContent).not.toContain('No unread threads in the latest Watch snapshot.');
+    expect(container.querySelector('header')?.textContent).toContain('0 threads');
+  });
+
+  it('temporarily reveals matching lazy groups and restores their collapsed state', async () => {
+    const threads = Array.from({ length: 9 }, (_, index) => thread(index));
+    const container = renderInbox({ result: result({ threads }) });
+    const search = container.querySelector<HTMLInputElement>(
+      'input[placeholder="Search repositories and threads"]',
+    );
+    if (!search) throw new Error('Expected Watch search input');
+
+    expect(container.textContent).not.toContain('Thread 8');
+    await setInputValue(search, 'Thread 8');
+
+    expect(container.textContent).toContain('Thread 8');
+    expect(container.querySelector('[aria-label="Collapse owner/repo-8"]')?.hasAttribute('disabled'))
+      .toBe(true);
+
+    await setInputValue(search, '');
+
+    expect(container.textContent).not.toContain('Thread 8');
+    expect(container.querySelector('[aria-label="Expand owner/repo-8"]')?.hasAttribute('disabled'))
+      .toBe(false);
+  });
+
+  it('shows raw reason facets with counts, supports multi-select, and applies presets', async () => {
+    const mentionOne = thread(0, {
+      repositoryFullName: 'acme/alpha',
+      subjectTitle: 'Mention one',
+      reason: 'mention',
+    });
+    const mentionTwo = thread(1, {
+      repositoryFullName: 'acme/beta',
+      subjectTitle: 'Mention two',
+      reason: 'mention',
+    });
+    const security = thread(2, {
+      repositoryFullName: 'acme/security',
+      subjectTitle: 'Security alert',
+      reason: 'security_alert',
+    });
+    const review = thread(3, {
+      repositoryFullName: 'acme/review',
+      subjectTitle: 'Review request',
+      reason: 'review_requested',
+    });
+    const future = thread(4, {
+      repositoryFullName: 'acme/future',
+      subjectTitle: 'Future event',
+      reason: 'future_reason',
+    });
+    const container = renderInbox({
+      result: result({ threads: [mentionOne, mentionTwo, security, review, future] }),
+    });
+    const trigger = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Notification reasons"]',
+    );
+    if (!trigger) throw new Error('Expected notification reason filter');
+    await click(trigger);
+
+    const contentId = trigger.getAttribute('aria-controls');
+    const popover = contentId ? document.getElementById(contentId) : null;
+    if (!popover) throw new Error('Expected notification reason popover');
+
+    const mention = findReasonControl(popover, 'mention');
+    const securityAlert = findReasonControl(popover, 'security_alert');
+    const unknown = findReasonControl(popover, 'future_reason');
+    expect(mention.row.textContent).toContain('2 threads');
+    expect(securityAlert.row.textContent).toContain('1 thread');
+    expect(unknown.row.textContent).toContain('1 thread');
+
+    await click(mention.control);
+    await click(securityAlert.control);
+
+    expect(trigger.getAttribute('aria-label')).toBe('Notification reasons, 2 selected');
+    expect(container.textContent).toContain('Mention one');
+    expect(container.textContent).toContain('Mention two');
+    expect(container.textContent).toContain('Security alert');
+    expect(container.textContent).not.toContain('Review request');
+    expect(container.textContent).not.toContain('Future event');
+    expect(container.querySelector('header')?.textContent).toContain('3 threads');
+
+    await click(findButtonByText(popover, 'Direct'));
+
+    expect(container.textContent).toContain('Mention one');
+    expect(container.textContent).toContain('Mention two');
+    expect(container.textContent).toContain('Review request');
+    expect(container.textContent).not.toContain('Security alert');
+    expect(container.textContent).not.toContain('Future event');
+  });
+
+  it('moves focus with Arrow Up/Down/Home/End across visible thread links only', async () => {
+    const first = thread(0, { subjectTitle: 'First visible thread' });
+    const collapsed = thread(1, { subjectTitle: 'Collapsed thread' });
+    const last = thread(2, { subjectTitle: 'Last visible thread' });
+    const container = renderInbox({ result: result({ threads: [first, collapsed, last] }) });
+    const collapseMiddle = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Collapse owner/repo-1"]',
+    );
+    if (!collapseMiddle) throw new Error('Expected middle repository collapse control');
+    await click(collapseMiddle);
+
+    const firstLink = container.querySelector<HTMLAnchorElement>(
+      'a[data-watch-thread][aria-label="Open on GitHub: First visible thread"]',
+    );
+    const lastLink = container.querySelector<HTMLAnchorElement>(
+      'a[data-watch-thread][aria-label="Open on GitHub: Last visible thread"]',
+    );
+    if (!firstLink || !lastLink) throw new Error('Expected visible Watch thread links');
+    expect(container.querySelector(
+      'a[data-watch-thread][aria-label="Open on GitHub: Collapsed thread"]',
+    )).toBeNull();
+
+    firstLink.focus();
+    keydown(firstLink, 'ArrowDown');
+    expect(document.activeElement).toBe(lastLink);
+
+    keydown(lastLink, 'ArrowUp');
+    expect(document.activeElement).toBe(firstLink);
+
+    keydown(firstLink, 'End');
+    expect(document.activeElement).toBe(lastLink);
+
+    keydown(lastLink, 'Home');
+    expect(document.activeElement).toBe(firstLink);
+  });
+});

--- a/tests/unit/watch-model.test.ts
+++ b/tests/unit/watch-model.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+  groupNotificationThreads,
+  KNOWN_NOTIFICATION_REASONS,
+  normalizeNotificationThread,
+  safeSubjectHtmlUrl,
+} from '@/watch/watch-model';
+
+function thread(id: string, repositoryFullName: string, updatedAt: string, unread = true) {
+  return normalizeNotificationThread({
+    id,
+    unread,
+    reason: 'mention',
+    updated_at: updatedAt,
+    last_read_at: null,
+    repository: {
+      full_name: repositoryFullName,
+      html_url: `https://github.com/${repositoryFullName}`,
+    },
+    subject: {
+      title: `Thread ${id}`,
+      type: 'Issue',
+      url: `https://api.github.com/repos/${repositoryFullName}/issues/1`,
+    },
+  }, { fetchedAt: '2026-08-05T04:00:00Z' });
+}
+
+describe('Watch domain model', () => {
+  it('maps only strict same-repository browser-safe subject routes', () => {
+    expect(safeSubjectHtmlUrl('owner/repo', 'Issue', 'https://api.github.com/repos/owner/repo/issues/12'))
+      .toBe('https://github.com/owner/repo/issues/12');
+    expect(safeSubjectHtmlUrl('owner/repo', 'PullRequest', 'https://api.github.com/repos/owner/repo/issues/12'))
+      .toBe('https://github.com/owner/repo/pull/12');
+    expect(safeSubjectHtmlUrl('owner/repo', 'Discussion', 'https://api.github.com/repos/owner/repo/discussions/12'))
+      .toBe('https://github.com/owner/repo/discussions/12');
+    expect(safeSubjectHtmlUrl('owner/repo', 'Commit', 'https://api.github.com/repos/owner/repo/commits/abcdef1'))
+      .toBe('https://github.com/owner/repo/commit/abcdef1');
+    expect(safeSubjectHtmlUrl('owner/repo', 'Release', 'https://api.github.com/repos/owner/repo/releases/1'))
+      .toBeNull();
+    expect(safeSubjectHtmlUrl('owner/repo', 'Issue', 'https://evil.example/repos/owner/repo/issues/12'))
+      .toBeNull();
+    expect(safeSubjectHtmlUrl('owner/repo', 'Issue', 'https://api.github.com/repos/other/repo/issues/12'))
+      .toBeNull();
+  });
+
+  it('groups newest first with deterministic repository and thread ties', () => {
+    const groups = groupNotificationThreads([
+      thread('b', 'Beta/Repo', '2026-08-05T02:00:00Z'),
+      thread('a', 'beta/repo', '2026-08-05T02:00:00Z'),
+      thread('c', 'alpha/repo', '2026-08-05T03:00:00Z', false),
+    ]);
+
+    expect(groups.map((group) => group.repositoryFullName)).toEqual(['alpha/repo', 'beta/repo']);
+    expect(groups[1]?.threads.map((item) => item.id)).toEqual(['a', 'b']);
+    expect(groupNotificationThreads(groups.flatMap((group) => group.threads), { unreadOnly: true })
+      .map((group) => group.repositoryFullName)).toEqual(['beta/repo']);
+  });
+
+  it('keeps the current documented notification reason catalog', () => {
+    expect(KNOWN_NOTIFICATION_REASONS).toEqual([
+      'approval_requested',
+      'assign',
+      'author',
+      'comment',
+      'ci_activity',
+      'invitation',
+      'manual',
+      'member_feature_requested',
+      'mention',
+      'review_requested',
+      'security_advisory_credit',
+      'security_alert',
+      'state_change',
+      'subscribed',
+      'team_mention',
+    ]);
+  });
+});

--- a/tests/unit/watch-model.test.ts
+++ b/tests/unit/watch-model.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  filterNotificationThreads,
   groupNotificationThreads,
   KNOWN_NOTIFICATION_REASONS,
   normalizeNotificationThread,
@@ -43,6 +44,28 @@ describe('Watch domain model', () => {
       .toBeNull();
   });
 
+  it('rebuilds repository links from the canonical name instead of remote HTML URLs', () => {
+    const normalized = normalizeNotificationThread({
+      id: 'hostile-repository-url',
+      unread: true,
+      reason: 'mention',
+      updated_at: '2026-08-05T02:00:00Z',
+      last_read_at: null,
+      repository: {
+        full_name: 'Owner/Repo',
+        html_url: 'https://evil.example/owner/repo',
+      },
+      subject: {
+        title: 'Safe fallback',
+        type: 'Release',
+        url: 'https://api.github.com/repos/owner/repo/releases/1',
+      },
+    }, { fetchedAt: '2026-08-05T04:00:00Z' });
+
+    expect(normalized.repositoryHtmlUrl).toBe('https://github.com/owner/repo');
+    expect(normalized.subjectHtmlUrl).toBeNull();
+  });
+
   it('groups newest first with deterministic repository and thread ties', () => {
     const groups = groupNotificationThreads([
       thread('b', 'Beta/Repo', '2026-08-05T02:00:00Z'),
@@ -54,6 +77,16 @@ describe('Watch domain model', () => {
     expect(groups[1]?.threads.map((item) => item.id)).toEqual(['a', 'b']);
     expect(groupNotificationThreads(groups.flatMap((group) => group.threads), { unreadOnly: true })
       .map((group) => group.repositoryFullName)).toEqual(['beta/repo']);
+  });
+
+  it('includes all threads by default and filters unread only when requested', () => {
+    const unread = thread('unread', 'owner/repo', '2026-08-05T03:00:00Z');
+    const read = thread('read', 'owner/repo', '2026-08-05T02:00:00Z', false);
+
+    expect(filterNotificationThreads([read, unread]).map((item) => item.id))
+      .toEqual(['unread', 'read']);
+    expect(filterNotificationThreads([read, unread], true).map((item) => item.id))
+      .toEqual(['unread']);
   });
 
   it('keeps the current documented notification reason catalog', () => {


### PR DESCRIPTION
## Summary
- add a GitHub-native Watch scope backed by starred repository subscriptions
- add an account-bound classic Notifications token and atomic Watch snapshots
- add a read-only Watch Inbox with unread/all modes, search, reason facets, presets, counts, and keyboard navigation
- preserve safe GitHub links and repository detail integration without writing subscriptions or notifications

## Security and data boundaries
- Watch data is stored in IndexedDB; lightweight account/token state remains in chrome.storage.local
- notification reasons are modeled separately and are never written as Tags
- GitHub subscription and notification APIs are read-only in this feature

## Verification
- pnpm typecheck
- pnpm test:logic
- pnpm test:integration
- pnpm test:regressions
- pnpm build
- pnpm test:runtime
- pnpm test:smoke
- git diff --cached --check

Target: develop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 GitHub Watch Inbox，支持按仓库查看通知、未读筛选、搜索、原因筛选、刷新及详情跳转。
  * 支持配置、替换和断开独立的 Watch 通知令牌，并显示账户匹配、权限及连接状态。
  * 新增 Watch 仓库范围同步、通知缓存、增量刷新和冷却提示。
* **安全与稳定性**
  * 增强凭据隔离、账户切换处理及敏感令牌脱敏。
  * 补充网络、权限、超时和响应异常提示，并完善中英文文案。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->