### PR TITLE
Improve repository search, layout controls, and Agent context

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -123,6 +123,7 @@ import {
   type OrganizeRunIdentity,
 } from "./organize-job-controller";
 import { OrganizeProposalAnalyzer } from "@/bgsm-agent/organize-proposal-analyzer";
+import { createBgsmAgentTagAssignmentPolicy } from '@/bgsm-agent/tag-assignment-policy';
 import {
   issueContinuationCursor,
   resolveContinuationCursor,
@@ -154,6 +155,7 @@ import {
 } from "@/bgsm-agent/organize-job";
 import {
   createEmptyRunBudgetUsage,
+  createOrganizeTagPolicySnapshot,
   createProductionRunBudget,
   type RunBudget,
   type RunBudgetUsage,
@@ -743,6 +745,7 @@ organizeJobRunScheduler = createBgsmOrganizeJobScheduler({
           fingerprint: state.frozenScope.fingerprint,
         },
         taskInstruction: context.taskInstruction,
+        tagPolicy: state.tagPolicy,
         taxonomy: {
           fingerprint: taxonomyBundle.fingerprint,
           snapshot: {
@@ -1335,8 +1338,23 @@ async function runBgsmAgentTurn(
       sessionId,
       scopeFingerprint,
     );
-    const activeOrganizeJob = await getActiveOrganizeJob();
+    const [activeOrganizeJob, agentConfig] = await Promise.all([
+      getActiveOrganizeJob(),
+      authStore.getConfig(),
+    ]);
     const organizeApplyActive = organizeApplyBlocksAgentWrites(activeOrganizeJob);
+    const tagAssignmentPolicy = createBgsmAgentTagAssignmentPolicy(agentConfig, async () => {
+      const [stars, storedTags, tagMeta] = await Promise.all([
+        db.stars.toArray(),
+        db.tags.toArray(),
+        db.tagMeta.toArray(),
+      ]);
+      return {
+        stars,
+        tags: storedTags.map((tag) => normalizeStoredTag(tag as LegacyTagRow)),
+        tagMeta,
+      };
+    });
     if (liveness.signal.aborted) return terminalAfterAbort();
     const toolRegistry = createBgsmAgentToolRegistry({
       repositoryScope,
@@ -1359,6 +1377,7 @@ async function runBgsmAgentTurn(
         return { status: 'accepted' };
       },
       assignManualTags: agentManualTagWriter,
+      tagAssignmentPolicy,
       removeVisibleTags: agentVisibleTagRemovalWriter,
       deleteTagsEverywhere: agentGlobalTagDeletionWriter,
     });
@@ -2326,7 +2345,10 @@ chrome.runtime.onConnect.addListener((port) => {
               message,
               result.preflightToken,
             );
-            const taxonomyBundle = await loadOrganizeJobRunTaxonomy();
+            const [taxonomyBundle, config] = await Promise.all([
+              loadOrganizeJobRunTaxonomy(),
+              authStore.getConfig(),
+            ]);
             await createOrganizePreflight({
               jobId: context.jobId,
               controllerId: message.controllerId,
@@ -2342,6 +2364,7 @@ chrome.runtime.onConnect.addListener((port) => {
                 fingerprint: context.frozenScope.fingerprint,
               },
               taskInstruction: message.taskInstruction,
+              tagPolicy: createOrganizeTagPolicySnapshot(config),
               taxonomy: {
                 fingerprint: taxonomyBundle.fingerprint,
                 snapshot: {
@@ -3554,6 +3577,7 @@ function buildRestoredOrganizeAnalysisState(
       capturedAt: job.frozenScope.capturedAt,
       fingerprint: parseScopeFingerprintV1(job.frozenScope.fingerprint),
     }),
+    tagPolicy: createOrganizeTagPolicySnapshot(job.tagPolicy),
     budget: job.budget as RunBudget,
     usage: job.usage as RunBudgetUsage,
     nextFrozenIndex: job.nextFrozenIndex,

--- a/src/background/query.ts
+++ b/src/background/query.ts
@@ -11,6 +11,7 @@ import {
   validateLaunchCandidateContract,
   type LaunchCandidateContract,
 } from '@/bgsm-agent/scope';
+import { createRepositorySearchMatcher } from '@/search/repository-search';
 
 /**
  * Star query engine (runs in the SW, owns IDB); returns a filtered+sorted window
@@ -100,9 +101,18 @@ export function compareNullableDate(
   return dir === 'asc' ? cmp : -cmp;
 }
 
-function sortRows(rows: Star[], key: SortKey, dir: 'asc' | 'desc'): Star[] {
+function sortRows(
+  rows: Star[],
+  key: SortKey,
+  dir: 'asc' | 'desc',
+  relevance?: ReadonlyMap<Star, number>,
+): Star[] {
   const mul = dir === 'asc' ? 1 : -1;
   return rows.sort((a, b) => {
+    if (relevance) {
+      const relevanceDifference = (relevance.get(b) ?? 0) - (relevance.get(a) ?? 0);
+      if (relevanceDifference !== 0) return relevanceDifference;
+    }
     let cmp = 0;
     switch (key) {
       case 'starred_at':
@@ -130,7 +140,8 @@ function filterAndSortRows(
   tags: ReadonlyMap<string, Tag>,
   filter: QueryFilter,
 ): Star[] {
-  const q = filter.query.trim().toLowerCase();
+  const search = createRepositorySearchMatcher(filter.query);
+  const relevance = new Map<Star, number>();
   const langSet = filter.languages.length ? new Set(filter.languages) : null;
   const tagSet = filter.tags.length
     ? new Set(filter.tags.map((tag) => canonicalTagKey(tag)))
@@ -150,15 +161,26 @@ function filterAndSortRows(
         if (!filter.tags.every((tag) => myTagKeys.includes(canonicalTagKey(tag)))) return false;
       } else if (!myTagKeys.some((tag) => tagSet.has(tag))) return false;
     }
-    if (q) {
+    if (!search.empty) {
       const notes = tagRecord?.notes ?? '';
-      const hay = `${s.full_name} ${s.description} ${s.topics.join(' ')} ${notes}`.toLowerCase();
-      if (!hay.includes(q)) return false;
+      const match = search.match({
+        fullName: s.full_name,
+        description: s.description,
+        topics: s.topics,
+        notes,
+      });
+      if (!match.matched) return false;
+      relevance.set(s, match.relevance);
     }
     return true;
   });
 
-  return sortRows(filtered, filter.sortKey, filter.sortDir);
+  return sortRows(
+    filtered,
+    filter.sortKey,
+    filter.sortDir,
+    search.empty ? undefined : relevance,
+  );
 }
 
 /** Resolves every matching repository ID using the same authoritative filter/sort semantics as queryStars. */

--- a/src/bgsm-agent/organize-job.ts
+++ b/src/bgsm-agent/organize-job.ts
@@ -1,5 +1,7 @@
 import {
   createEmptyRunBudgetUsage,
+  createOrganizeTagPolicySnapshot,
+  reconcileOrganizeTagCoverage,
   validateRunBudget,
   validateRunBudgetUsage,
   type BudgetExhaustionReason,
@@ -36,6 +38,7 @@ import {
   reserveAnalyzerBatch,
   reserveProviderAttempt,
 } from './run-budget';
+import type { OrganizeTagPolicySnapshot } from '@/types';
 
 export type OrganizeJobRunAnalysisStatus =
   | 'analyzing'
@@ -55,6 +58,7 @@ export type OrganizeJobRunAnalysisState = Readonly<{
   generation: number;
   proposalId: ProposalId;
   frozenScope: FrozenScope;
+  tagPolicy: OrganizeTagPolicySnapshot;
   budget: RunBudget;
   usage: RunBudgetUsage;
   startFrozenIndex: number;
@@ -118,6 +122,7 @@ export function restoreOrganizeJobRunAnalysisState(input: Readonly<{
   generation: number;
   proposalId: ProposalId;
   frozenScope: FrozenScope;
+  tagPolicy?: unknown;
   budget: RunBudget;
   usage: RunBudgetUsage;
   startFrozenIndex?: number;
@@ -133,6 +138,7 @@ export function restoreOrganizeJobRunAnalysisState(input: Readonly<{
     generation: input.generation,
     proposalId: input.proposalId,
     frozenScope: input.frozenScope,
+    tagPolicy: input.tagPolicy,
     budget: input.budget,
     startFrozenIndex: input.startFrozenIndex ?? 0,
   });
@@ -170,6 +176,7 @@ export function createOrganizeJobRunAnalysisState(input: Readonly<{
   generation: number;
   proposalId: ProposalId;
   frozenScope: FrozenScope;
+  tagPolicy?: unknown;
   budget: RunBudget;
   startFrozenIndex?: number;
 }>): OrganizeJobRunAnalysisState {
@@ -188,6 +195,7 @@ export function createOrganizeJobRunAnalysisState(input: Readonly<{
     generation: input.generation,
     proposalId: input.proposalId,
     frozenScope: input.frozenScope,
+    tagPolicy: createOrganizeTagPolicySnapshot(input.tagPolicy),
     budget: input.budget,
     usage: createEmptyRunBudgetUsage(),
     startFrozenIndex,
@@ -220,6 +228,7 @@ export function resumeOrganizeJobRunAnalysisState(input: Readonly<{
     generation: input.generation,
     proposalId: input.proposalId,
     frozenScope: input.previous.frozenScope,
+    tagPolicy: input.previous.tagPolicy,
     budget: input.budget,
     startFrozenIndex: input.previous.startFrozenIndex,
   });
@@ -384,6 +393,11 @@ export function finalizeAnalyzerBatch(input: Readonly<{
   taxonomyFingerprint: TaxonomyFingerprintV1;
 }>): FinalizedBatch {
   validateAnalyzerBatchProposal(input.proposal);
+  for (const row of input.proposal.rows) {
+    if (row.classifications.length > input.state.tagPolicy.maxTagsPerRepo) {
+      throw new RangeError('Analyzer classifications exceed the snapshotted per-repository tag limit.');
+    }
+  }
   validateAnalyzerIdentity(input.state, input.proposal);
   const live = input.positions.filter(
     (position): position is Extract<OrganizeJobRunPagePosition, { kind: 'live' }> =>
@@ -537,6 +551,7 @@ export function buildSemanticAnalyzerBatch(input: Readonly<{
     generation: input.state.generation,
     scopeFingerprint: input.state.frozenScope.fingerprint,
     taskInstruction: input.taskInstruction,
+    tagPolicy: input.state.tagPolicy,
     repositories: Object.freeze(repositories),
     taxonomy: input.taxonomy,
   });
@@ -629,6 +644,9 @@ function finalizeClassifications(
     completedScope &&
     analyzed.length === state.frozenScope.count;
   const analysisBlocked = nonActionable.some((row) => row.kind === 'analysis_failed');
+  const reconciled = completedCoverage && !analysisBlocked
+    ? reconcileCompletedTagCoverage(state.tagPolicy, analyzed, nonActionable, actionable)
+    : { analyzed, nonActionable, actionable };
   const nextState = freezeState({
     ...state,
     usage: consumeFrozenPositions(state.budget, state.usage, accepted),
@@ -645,15 +663,60 @@ function finalizeClassifications(
       : completedCoverage
         ? 'scope_complete'
         : null,
-    analyzedFrozenPositions: analyzed,
-    nonActionableAnalysisOutcomes: nonActionable,
-    actionableProposalRows: actionable,
+    analyzedFrozenPositions: reconciled.analyzed,
+    nonActionableAnalysisOutcomes: reconciled.nonActionable,
+    actionableProposalRows: reconciled.actionable,
   });
   validateAnalysisUniverses(nextState);
   return Object.freeze({
     state: nextState,
     continuationRequired: false,
     nextFrozenIndex,
+  });
+}
+
+function reconcileCompletedTagCoverage(
+  policy: OrganizeTagPolicySnapshot,
+  analyzed: readonly AnalyzedFrozenPosition[],
+  nonActionable: readonly NonActionableAnalysisOutcome[],
+  actionable: readonly ActionableProposalRow[],
+): Readonly<{
+  analyzed: readonly AnalyzedFrozenPosition[];
+  nonActionable: readonly NonActionableAnalysisOutcome[];
+  actionable: readonly ActionableProposalRow[];
+}> {
+  const retainedActions = reconcileOrganizeTagCoverage(
+    actionable.map((row) => ({ repositoryId: row.repositoryId, actions: row.actions })),
+    policy,
+  );
+  const emptied = new Map<number, ActionableProposalRow>();
+  const retainedRows: ActionableProposalRow[] = [];
+  actionable.forEach((row, index) => {
+    const actions = retainedActions[index] ?? [];
+    if (actions.length === 0) {
+      emptied.set(row.frozenIndex, row);
+      return;
+    }
+    retainedRows.push(actions.length === row.actions.length
+      ? row
+      : Object.freeze({ ...row, actions }));
+  });
+  if (emptied.size === 0) {
+    return Object.freeze({ analyzed, nonActionable, actionable: retainedRows });
+  }
+
+  const coverageOutcomes = [...emptied.values()].map((row) => Object.freeze({
+    frozenIndex: row.frozenIndex,
+    repositoryId: row.repositoryId,
+    kind: 'insufficient_evidence' as const,
+  }));
+  return Object.freeze({
+    analyzed: analyzed.map((row) => emptied.has(row.frozenIndex)
+      ? Object.freeze({ ...row, classification: 'non_actionable' as const })
+      : row),
+    nonActionable: [...nonActionable, ...coverageOutcomes]
+      .sort((left, right) => left.frozenIndex - right.frozenIndex),
+    actionable: retainedRows,
   });
 }
 
@@ -820,6 +883,7 @@ function freezeState(input: OrganizeJobRunAnalysisState): OrganizeJobRunAnalysis
   validateAnalysisSplitState(input);
   return Object.freeze({
     ...input,
+    tagPolicy: Object.freeze({ ...input.tagPolicy }),
     analysisPendingRanges: Object.freeze(input.analysisPendingRanges.map((range) => Object.freeze({ ...range }))),
     analyzedFrozenPositions: Object.freeze([...input.analyzedFrozenPositions]),
     nonActionableAnalysisOutcomes: Object.freeze([...input.nonActionableAnalysisOutcomes]),

--- a/src/bgsm-agent/organize-proposal-analyzer.ts
+++ b/src/bgsm-agent/organize-proposal-analyzer.ts
@@ -24,6 +24,7 @@ import {
 import {
   ANALYZER_OUTPUT_TOKENS_DEFAULT,
   ANALYZER_OUTPUT_TOKENS_HARD_LIMIT,
+  validateOrganizeTagPolicySnapshot,
 } from './policy';
 import {
   ORGANIZE_PROPOSAL_ANALYZER_TOOL_NAME,
@@ -34,6 +35,7 @@ import type { RunId } from './identity';
 import type { ScopeFingerprintV1 } from './scope';
 import type { SemanticRepositoryDto, SemanticTaxonomyDto } from './semantic-dto';
 import type { BudgetExhaustionReason, ProviderActualTokenTelemetry } from './policy';
+import type { OrganizeTagPolicySnapshot } from '@/types';
 
 export const MAX_ANALYZER_TASK_INSTRUCTION_BYTES = 4_096;
 export const MAX_ANALYZER_RETRY_DETAIL_BYTES = 1_024;
@@ -69,6 +71,7 @@ export type SemanticAnalyzerBatch = Readonly<{
   generation: number;
   scopeFingerprint: ScopeFingerprintV1;
   taskInstruction: string;
+  tagPolicy: OrganizeTagPolicySnapshot;
   repositories: readonly SemanticRepositoryDto[];
   taxonomy: SemanticTaxonomyDto;
 }>;
@@ -210,7 +213,7 @@ function analyzerToolForBatch(batch: SemanticAnalyzerBatch): AgentToolDefinition
                   {
                     type: 'array',
                     minItems: 1,
-                    maxItems: 5,
+                    maxItems: batch.tagPolicy.maxTagsPerRepo,
                     items: actionableClassification,
                   },
                   {
@@ -744,9 +747,17 @@ function proposalContractDiagnostic(
   const receivedCounts = new Map<number, number>();
   const unexpectedFrozenIndexes: number[] = [];
   const identityMismatchFrozenIndexes: number[] = [];
+  let classificationLimitExceeded = false;
   let diagnosticIndexesTruncated = false;
 
   for (const row of value.rows) {
+    if (
+      isRecord(row)
+      && Array.isArray(row.classifications)
+      && row.classifications.length > batch.tagPolicy.maxTagsPerRepo
+    ) {
+      classificationLimitExceeded = true;
+    }
     if (!isRecord(row) || !isNonnegativeSafeInteger(row.frozenIndex)) continue;
     const frozenIndex = row.frozenIndex;
     const expected = expectedByIndex.get(frozenIndex);
@@ -791,6 +802,7 @@ function proposalContractDiagnostic(
     && duplicateFrozenIndexes.length === 0
     && unexpectedFrozenIndexes.length === 0
     && identityMismatchFrozenIndexes.length === 0
+    && !classificationLimitExceeded
   ) {
     return null;
   }
@@ -803,7 +815,9 @@ function proposalContractDiagnostic(
         ? 'row_coverage'
         : identityMismatchFrozenIndexes.length > 0
           ? 'row_identity'
-          : schemaRejectionCode ?? 'schema',
+          : classificationLimitExceeded
+            ? 'classification'
+            : schemaRejectionCode ?? 'schema',
     expectedRowCount: batch.repositories.length,
     receivedRowCount: value.rows.length,
     batchIdentityMismatch,
@@ -811,9 +825,12 @@ function proposalContractDiagnostic(
     duplicateFrozenIndexes,
     unexpectedFrozenIndexes,
     identityMismatchFrozenIndexes,
-    schemaViolation: schemaViolation ?? (batchIdentityMismatch
-      ? 'Proposal run, generation, or scope identity did not match the unchanged batch.'
-      : null),
+    schemaViolation: schemaViolation
+      ?? (batchIdentityMismatch
+        ? 'Proposal run, generation, or scope identity did not match the unchanged batch.'
+        : classificationLimitExceeded
+          ? 'Proposal classifications exceeded the snapshotted per-repository tag limit.'
+          : null),
   }, diagnosticIndexesTruncated);
 }
 
@@ -1001,6 +1018,7 @@ function isNonnegativeSafeInteger(value: unknown): value is number {
 }
 
 function validateBatch(batch: SemanticAnalyzerBatch): void {
+  validateOrganizeTagPolicySnapshot(batch.tagPolicy);
   if (!batch.taskInstruction.trim() || batch.taskInstruction.trim() !== batch.taskInstruction) {
     throw new TypeError('Analyzer task instruction must be trimmed and nonempty.');
   }

--- a/src/bgsm-agent/policy.ts
+++ b/src/bgsm-agent/policy.ts
@@ -1,3 +1,14 @@
+import type {
+  OrganizeProposedAction,
+  OrganizeTagPolicySnapshot,
+} from '@/types';
+import {
+  MAX_AUTO_TAG_LIMIT,
+  normalizeMaxTagsPerRepo,
+  normalizeMinTopicRepoCount,
+} from '@/preferences';
+import { canonicalTagKey } from '@/tags/tag-model';
+
 export const FROZEN_SCOPE_PAGE_DEFAULT = 25;
 export const FROZEN_SCOPE_PAGE_HARD_LIMIT = 50;
 export const ANALYZER_OUTPUT_TOKENS_DEFAULT = 4_096;
@@ -10,6 +21,61 @@ export const PROPOSAL_REVIEW_PAGE_HARD_LIMIT = 100;
 export const TAG_ADDITIONS_PER_REPOSITORY_HARD_LIMIT = 5;
 export const MAX_SEMANTIC_TAG_NAME_BYTES = 256;
 export const MAX_SEMANTIC_EVIDENCE_BYTES = 1_024;
+
+export function createOrganizeTagPolicySnapshot(value: unknown): OrganizeTagPolicySnapshot {
+  const source = isRecord(value) ? value : {};
+  return Object.freeze({
+    maxTagsPerRepo: Math.min(
+      TAG_ADDITIONS_PER_REPOSITORY_HARD_LIMIT,
+      normalizeMaxTagsPerRepo(source.maxTagsPerRepo, source.autoTagLimit),
+    ),
+    minTopicRepoCount: normalizeMinTopicRepoCount(source.minTopicRepoCount),
+  });
+}
+
+export function validateOrganizeTagPolicySnapshot(
+  value: unknown,
+): asserts value is OrganizeTagPolicySnapshot {
+  if (!isRecord(value)) throw new TypeError('Organize tag policy must be an object.');
+  assertExactKeys(value, ['maxTagsPerRepo', 'minTopicRepoCount']);
+  assertPositiveSafeInteger(value.maxTagsPerRepo, 'Organize tag policy maxTagsPerRepo');
+  if (value.maxTagsPerRepo > TAG_ADDITIONS_PER_REPOSITORY_HARD_LIMIT) {
+    throw new RangeError('Organize tag policy maxTagsPerRepo exceeds the hard limit.');
+  }
+  assertPositiveSafeInteger(value.minTopicRepoCount, 'Organize tag policy minTopicRepoCount');
+  if (value.minTopicRepoCount > MAX_AUTO_TAG_LIMIT) {
+    throw new RangeError('Organize tag policy minTopicRepoCount exceeds the preference limit.');
+  }
+}
+
+export type OrganizeTagCoverageRow = Readonly<{
+  repositoryId: string;
+  actions: readonly OrganizeProposedAction[];
+}>;
+
+/** Filters tag actions by distinct-repository coverage across the complete live analysis. */
+export function reconcileOrganizeTagCoverage(
+  rows: readonly OrganizeTagCoverageRow[],
+  policy: OrganizeTagPolicySnapshot,
+): readonly (readonly OrganizeProposedAction[])[] {
+  validateOrganizeTagPolicySnapshot(policy);
+  const repositoriesByTag = new Map<string, Set<string>>();
+  for (const row of rows) {
+    const seenForRepository = new Set<string>();
+    for (const action of row.actions) {
+      const key = canonicalTagKey(action.tag);
+      if (!key || seenForRepository.has(key)) continue;
+      seenForRepository.add(key);
+      const repositories = repositoriesByTag.get(key) ?? new Set<string>();
+      repositories.add(row.repositoryId);
+      repositoriesByTag.set(key, repositories);
+    }
+  }
+
+  return Object.freeze(rows.map((row) => Object.freeze(row.actions.filter((action) => (
+    (repositoriesByTag.get(canonicalTagKey(action.tag))?.size ?? 0) >= policy.minTopicRepoCount
+  )))));
+}
 
 export type RunBudget = Readonly<{
   wallDeadlineMs: number;

--- a/src/bgsm-agent/tag-assignment-policy.ts
+++ b/src/bgsm-agent/tag-assignment-policy.ts
@@ -1,0 +1,107 @@
+import type { Star, Tag, TagMeta } from '@/types';
+import {
+  normalizeMaxTagsPerRepo,
+  normalizeMinTopicRepoCount,
+} from '@/preferences';
+import {
+  canonicalTagKey,
+  excludedCanonicalTagKeys,
+  visibleTagNames,
+} from '@/tags/tag-model';
+
+export type BgsmAgentTagCoverageSnapshot = Readonly<{
+  repositoriesByTag: ReadonlyMap<string, ReadonlySet<string>>;
+  visibleTagsByRepository: ReadonlyMap<string, ReadonlySet<string>>;
+  excludedTagKeys: ReadonlySet<string>;
+}>;
+
+export type BgsmAgentTagAssignmentPolicy = Readonly<{
+  maxTagsPerRepo: number;
+  minRepoCount: number;
+  loadCoverage(): Promise<BgsmAgentTagCoverageSnapshot>;
+  invalidateCoverage(): void;
+}>;
+
+export type BgsmAgentTagPolicyLibrary = Readonly<{
+  stars: readonly Star[];
+  tags: readonly Tag[];
+  tagMeta: readonly TagMeta[];
+}>;
+
+/** Snapshots preferences now and loads whole-library coverage only if Chat writes tags. */
+export function createBgsmAgentTagAssignmentPolicy(
+  config: unknown,
+  loadLibrary: () => BgsmAgentTagPolicyLibrary | Promise<BgsmAgentTagPolicyLibrary>,
+): BgsmAgentTagAssignmentPolicy {
+  const source = isRecord(config) ? config : {};
+  let coverage: Promise<BgsmAgentTagCoverageSnapshot> | null = null;
+  return Object.freeze({
+    maxTagsPerRepo: normalizeMaxTagsPerRepo(source.maxTagsPerRepo, source.autoTagLimit),
+    minRepoCount: normalizeMinTopicRepoCount(source.minTopicRepoCount),
+    loadCoverage() {
+      coverage ??= Promise.resolve(loadLibrary()).then(buildBgsmAgentTagCoverageSnapshot);
+      return coverage;
+    },
+    invalidateCoverage() {
+      coverage = null;
+    },
+  });
+}
+
+export function buildBgsmAgentTagCoverageSnapshot(
+  library: BgsmAgentTagPolicyLibrary,
+): BgsmAgentTagCoverageSnapshot {
+  const liveRepositoryIds = new Set(
+    library.stars.filter((star) => !star.tombstone).map((star) => star.full_name),
+  );
+  const excludedTagKeys = excludedCanonicalTagKeys(library.tagMeta);
+  const tagsByRepository = new Map(
+    library.tags
+      .filter((tag) => liveRepositoryIds.has(tag.full_name))
+      .map((tag) => [tag.full_name, tag] as const),
+  );
+  const repositoriesByTag = new Map<string, Set<string>>();
+  const visibleTagsByRepository = new Map<string, ReadonlySet<string>>();
+
+  for (const star of library.stars) {
+    if (star.tombstone) continue;
+    const visibleTagKeys = new Set(
+      visibleTagNames(tagsByRepository.get(star.full_name))
+        .map(canonicalTagKey)
+        .filter((key) => key && !excludedTagKeys.has(key)),
+    );
+    visibleTagsByRepository.set(star.full_name, visibleTagKeys);
+
+    const sourceKeys = new Set([
+      ...star.topics.map(canonicalTagKey),
+      ...visibleTagKeys,
+    ]);
+    for (const key of sourceKeys) {
+      if (!key || excludedTagKeys.has(key)) continue;
+      const repositories = repositoriesByTag.get(key) ?? new Set<string>();
+      repositories.add(star.full_name);
+      repositoriesByTag.set(key, repositories);
+    }
+  }
+
+  return Object.freeze({
+    repositoriesByTag,
+    visibleTagsByRepository,
+    excludedTagKeys,
+  });
+}
+
+export function prospectiveBgsmAgentTagCoverage(
+  coverage: BgsmAgentTagCoverageSnapshot,
+  fullName: string,
+  tag: string,
+): number {
+  const key = canonicalTagKey(tag);
+  if (!key || coverage.excludedTagKeys.has(key)) return 0;
+  const repositories = coverage.repositoriesByTag.get(key);
+  return (repositories?.size ?? 0) + (repositories?.has(fullName) ? 0 : 1);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/bgsm-agent/tools.ts
+++ b/src/bgsm-agent/tools.ts
@@ -24,8 +24,12 @@ import {
 import type { OrganizeStoredJobStatus, Star, Tag } from '@/types';
 import {
   MAX_SEMANTIC_TAG_NAME_BYTES,
-  TAG_ADDITIONS_PER_REPOSITORY_HARD_LIMIT,
 } from './policy';
+import {
+  createBgsmAgentTagAssignmentPolicy,
+  prospectiveBgsmAgentTagCoverage,
+  type BgsmAgentTagAssignmentPolicy,
+} from './tag-assignment-policy';
 import {
   createRepositoryCodeTools,
   type RepositoryCodeRefAuthority,
@@ -175,12 +179,14 @@ export type CreateBgsmAgentToolRegistryOptions = Readonly<{
     action: BgsmAgentOrganizeLibraryAction,
   ) => BgsmAgentOrganizeLibraryHandoffDecision | Promise<BgsmAgentOrganizeLibraryHandoffDecision>;
   assignManualTags?: BgsmAgentManualTagWriter;
+  tagAssignmentPolicy?: BgsmAgentTagAssignmentPolicy;
   removeVisibleTags?: BgsmAgentVisibleTagRemovalWriter;
   deleteTagsEverywhere?: BgsmAgentGlobalTagDeletionWriter;
 }>;
 
 type BgsmAgentToolFactoryContext = Readonly<{
   options: CreateBgsmAgentToolRegistryOptions;
+  tagAssignmentPolicy: BgsmAgentTagAssignmentPolicy;
   repositoryScope: ReadonlySet<string>;
   repositorySearchScope: RepositorySearchScope;
   repositoryCodeTools: ReadonlyMap<string, AgentTool>;
@@ -212,29 +218,40 @@ const BGSM_AGENT_TOOL_FACTORIES = {
     searchStarsTool(repositorySearchScope)
   ),
   [BGSM_AGENT_TOOL_NAMES.inspectTag]: ({ repositoryScope }) => inspectTagTool(repositoryScope),
-  [BGSM_AGENT_TOOL_NAMES.assignRepoTags]: ({ options, repositorySearchScope }) => (
+  [BGSM_AGENT_TOOL_NAMES.assignRepoTags]: ({
+    options,
+    repositorySearchScope,
+    tagAssignmentPolicy,
+  }) => (
     options.enableTagWrites === false
       ? undefined
       : assignRepoTagsTool(
           repositorySearchScope,
           options.scopeFingerprint,
           options.assignManualTags ?? directManualTagWriter,
+          tagAssignmentPolicy,
         )
   ),
-  [BGSM_AGENT_TOOL_NAMES.removeRepoTags]: ({ options, repositorySearchScope }) => (
+  [BGSM_AGENT_TOOL_NAMES.removeRepoTags]: ({
+    options,
+    repositorySearchScope,
+    tagAssignmentPolicy,
+  }) => (
     options.enableTagWrites === false
       ? undefined
       : removeRepoTagsTool(
           repositorySearchScope,
           options.scopeFingerprint,
           options.removeVisibleTags ?? directVisibleTagRemovalWriter,
+          tagAssignmentPolicy,
         )
   ),
-  [BGSM_AGENT_TOOL_NAMES.deleteTagsEverywhere]: ({ options }) => (
+  [BGSM_AGENT_TOOL_NAMES.deleteTagsEverywhere]: ({ options, tagAssignmentPolicy }) => (
     options.enableTagWrites === false
       ? undefined
       : deleteTagsEverywhereTool(
           options.deleteTagsEverywhere ?? directGlobalTagDeletionWriter,
+          tagAssignmentPolicy,
         )
   ),
   [BGSM_AGENT_TOOL_NAMES.listRepositoryFiles]: ({ repositoryCodeTools }) => (
@@ -260,6 +277,7 @@ export function createBgsmAgentToolRegistry(
     throw new TypeError('Full-library handoff requires an execution callback.');
   }
   const repositoryScope = new Set(options.repositoryScope);
+  const tagAssignmentPolicy = options.tagAssignmentPolicy ?? defaultTagAssignmentPolicy();
   const repositorySearchScope = createRepositorySearchScope(
     repositoryScope,
     options.scopeLabel,
@@ -273,6 +291,7 @@ export function createBgsmAgentToolRegistry(
   );
   const context: BgsmAgentToolFactoryContext = {
     options,
+    tagAssignmentPolicy,
     repositoryScope,
     repositorySearchScope,
     repositoryCodeTools,
@@ -707,14 +726,17 @@ function assignRepoTagsTool(
   repositoryScope: RepositorySearchScope,
   scopeFingerprint: string | undefined,
   assignManualTags: BgsmAgentManualTagWriter,
+  policy: BgsmAgentTagAssignmentPolicy,
 ): AgentTool<
   { full_name: string; tags: string[] },
   { full_name: string; tags: string[]; changed: boolean; reason: BgsmAgentManualTagAdditionResult['reason'] }
 > {
+  const assignedTagKeysByRepository = new Map<string, Set<string>>();
+  let assignmentTail: Promise<void> = Promise.resolve();
   return {
     name: BGSM_AGENT_TOOL_NAMES.assignRepoTags,
     description:
-      'Add one or more manual tags to a repository only when the user wants its tags changed. Arguments: full_name string, tags string array. Use after inspecting local repository data in the current turn.',
+      `Add up to ${policy.maxTagsPerRepo} manual tags to one repository only when the user wants its tags changed. Every tag must reach at least ${policy.minRepoCount} live repositories across GitHub topics or visible local tags after this assignment. Use after inspecting local repository data in the current turn.`,
     risk: 'write',
     parameters: {
       type: 'object',
@@ -723,7 +745,7 @@ function assignRepoTagsTool(
         tags: {
           type: 'array',
           items: { type: 'string' },
-          maxItems: TAG_ADDITIONS_PER_REPOSITORY_HARD_LIMIT,
+          maxItems: policy.maxTagsPerRepo,
         },
       },
       required: ['full_name', 'tags'],
@@ -736,7 +758,7 @@ function assignRepoTagsTool(
         full_name: repositoryScope.canonicalByNormalizedFullName.get(
           normalizeRepositoryIdentity(requestedFullName),
         ) ?? requestedFullName,
-        tags: expectAgentTagArray(value.tags, 'tags'),
+        tags: expectAgentTagArray(value.tags, 'tags', policy.maxTagsPerRepo),
       };
     },
     ...(scopeFingerprint ? { writeEffectPlan: {
@@ -777,17 +799,55 @@ function assignRepoTagsTool(
       startBoundary: 'delegated',
     } } : {}),
     async execute(args, context) {
-      assertRepositoryInSearchScope(repositoryScope, args.full_name);
-      const write = await assignManualTags(args.full_name, args.tags, context);
-      const excluded = await loadExcludedTagKeys();
-      return {
-        full_name: args.full_name,
-        tags: write.manualTags.filter((tag) => !excluded.has(policyTagKey(tag))),
-        changed: write.changed,
-        reason: write.reason,
-      };
+      const pending = assignmentTail.then(async () => {
+        assertRepositoryInSearchScope(repositoryScope, args.full_name);
+        const coverage = await policy.loadCoverage();
+        const visibleTagKeys = coverage.visibleTagsByRepository.get(args.full_name) ?? new Set<string>();
+        const assignedTagKeys = assignedTagKeysByRepository.get(args.full_name) ?? new Set<string>();
+        const newTags = args.tags.filter((tag) => {
+          const key = policyTagKey(tag);
+          return !visibleTagKeys.has(key) && !assignedTagKeys.has(key);
+        });
+        const ineligibleTags = newTags.filter((tag) => (
+          prospectiveBgsmAgentTagCoverage(coverage, args.full_name, tag) < policy.minRepoCount
+        ));
+        if (ineligibleTags.length > 0) {
+          throw new TypeError(
+            `Tags do not meet the minimum live-repository coverage of ${policy.minRepoCount}: ${ineligibleTags.join(', ')}`,
+          );
+        }
+
+        const newTagKeys = newTags.map(policyTagKey);
+        if (assignedTagKeys.size + newTagKeys.length > policy.maxTagsPerRepo) {
+          throw new TypeError(
+            `Cubby may add at most ${policy.maxTagsPerRepo} tags to one repository in a turn.`,
+          );
+        }
+
+        const write = await assignManualTags(args.full_name, args.tags, context);
+        if (write.reason === null) {
+          newTagKeys.forEach((key) => assignedTagKeys.add(key));
+          assignedTagKeysByRepository.set(args.full_name, assignedTagKeys);
+        }
+        const excluded = await loadExcludedTagKeys();
+        return {
+          full_name: args.full_name,
+          tags: write.manualTags.filter((tag) => !excluded.has(policyTagKey(tag))),
+          changed: write.changed,
+          reason: write.reason,
+        };
+      });
+      assignmentTail = pending.then(() => undefined, () => undefined);
+      return pending;
     },
   };
+}
+
+function defaultTagAssignmentPolicy(): BgsmAgentTagAssignmentPolicy {
+  return createBgsmAgentTagAssignmentPolicy(
+    { maxTagsPerRepo: 5, minTopicRepoCount: 1 },
+    () => ({ stars: [], tags: [], tagMeta: [] }),
+  );
 }
 
 const directManualTagWriter: BgsmAgentManualTagWriter = (fullName, tags, context) => {
@@ -799,6 +859,7 @@ function removeRepoTagsTool(
   repositoryScope: RepositorySearchScope,
   scopeFingerprint: string | undefined,
   removeVisibleTags: BgsmAgentVisibleTagRemovalWriter,
+  tagAssignmentPolicy: BgsmAgentTagAssignmentPolicy,
 ): AgentTool<
   { changes: VisibleTagBulkRemoval[] },
   VisibleTagBulkRemovalResult
@@ -880,13 +941,16 @@ function removeRepoTagsTool(
       for (const change of args.changes) {
         assertRepositoryInSearchScope(repositoryScope, change.full_name);
       }
-      return removeVisibleTags(args.changes, context);
+      const result = await removeVisibleTags(args.changes, context);
+      if (result.changed > 0) tagAssignmentPolicy.invalidateCoverage();
+      return result;
     },
   };
 }
 
 function deleteTagsEverywhereTool(
   deleteTagsEverywhere: BgsmAgentGlobalTagDeletionWriter,
+  tagAssignmentPolicy: BgsmAgentTagAssignmentPolicy,
 ): AgentTool<
   { tags: string[] },
   GlobalTagBulkDeletionResult
@@ -940,7 +1004,9 @@ function deleteTagsEverywhereTool(
       startBoundary: 'delegated',
     },
     async execute(args, context) {
-      return deleteTagsEverywhere(args.tags, context);
+      const result = await deleteTagsEverywhere(args.tags, context);
+      tagAssignmentPolicy.invalidateCoverage();
+      return result;
     },
   };
 }
@@ -1389,8 +1455,8 @@ function expectString(input: unknown, field: string): string {
   return input;
 }
 
-function expectAgentTagArray(input: unknown, field: string): string[] {
-  return expectTagArray(input, field, TAG_ADDITIONS_PER_REPOSITORY_HARD_LIMIT);
+function expectAgentTagArray(input: unknown, field: string, maxItems: number): string[] {
+  return expectTagArray(input, field, maxItems);
 }
 
 function expectTagArray(input: unknown, field: string, maxItems: number): string[] {

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -161,6 +161,7 @@ export interface MessageCatalog {
     editingLayout: string;
     columnsButton: string;
     columnsButtonTitle: string;
+    showRepositoryOwner: string;
     hiddenColumns: (count: number) => string;
     hiddenColumnsTip: string;
     hideColumn: (label: string) => string;
@@ -216,6 +217,7 @@ export interface MessageCatalog {
     functionReviewNotesDescription: string;
     askingAboutCurrentView: (count: number) => string;
     askingAboutAllLiveStars: (count?: number) => string;
+    conversationSwitchPending: (scope: string) => string;
     agentChanged: (count: number) => string;
     turnFailed: string;
     attemptStateLost: string;
@@ -1032,6 +1034,7 @@ const messages: Record<Locale, MessageCatalog> = {
       editingLayout: "Editing layout",
       columnsButton: "Columns",
       columnsButtonTitle: "Show or hide columns",
+      showRepositoryOwner: "Show repository owner",
       hiddenColumns: (count) => `${count} hidden`,
       hiddenColumnsTip: "Click to restore · drag into the header to place",
       hideColumn: (label) => `Hide ${label}`,
@@ -1110,6 +1113,9 @@ const messages: Record<Locale, MessageCatalog> = {
             ? "All starred repositories · 1 repository"
             : `All starred repositories · ${count} repositories`)
           : "All starred repositories"
+      ),
+      conversationSwitchPending: (scope) => (
+        `Selected ${scope} · finish or discard the current Organize run to switch conversations`
       ),
       agentChanged: (count) => `${count} tag update${count === 1 ? '' : 's'} applied`,
       turnFailed: "Cubby couldn't complete this request",
@@ -1658,12 +1664,12 @@ const messages: Record<Locale, MessageCatalog> = {
       agentAccessGranted: "Access allowed",
       agentHostAccessRequired: "Allow Chrome access to test or use this custom service.",
       behaviorHeading: "5. Preference",
-      maxTagsPerRepoLabel: "Max Auto Tags per repo",
+      maxTagsPerRepoLabel: "Max automatic tags per repo",
       maxTagsPerRepoHint:
-        "When you run Auto Tags, each repo can receive at most this many topic tags.",
-      minTopicRepoCountLabel: "Minimum topic coverage",
+        "Auto Tags uses this limit. In Chat, Cubby may add at most this many tags to a repository per turn; Organize uses the lower of this value and its 5-tag safety cap.",
+      minTopicRepoCountLabel: "Minimum shared tag coverage",
       minTopicRepoCountHint:
-        "Auto Tags adds a topic only when it appears on at least this many repositories.",
+        "Cubby Chat assigns a tag only when the target brings its topic-or-visible-tag coverage to this many live repositories. Organize uses proposal-wide coverage; Auto Tags applies the same threshold to topics.",
       starsPanelDefaultLabel: "Open my stars page with the manager panel by default",
       starsPanelDefaultHint:
         "Turn this off if you prefer to land on GitHub's native stars list and open the overlay manually.",
@@ -2058,6 +2064,7 @@ const messages: Record<Locale, MessageCatalog> = {
       editingLayout: "正在编辑布局",
       columnsButton: "列",
       columnsButtonTitle: "显示或隐藏列",
+      showRepositoryOwner: "显示仓库作者名",
       hiddenColumns: (count) => `已隐藏 ${count}`,
       hiddenColumnsTip: "点击恢复 · 拖回表头可插入位置",
       hideColumn: (label) => `隐藏「${label}」`,
@@ -2136,6 +2143,9 @@ const messages: Record<Locale, MessageCatalog> = {
             ? "全部星标仓库 · 1 个仓库"
             : `全部星标仓库 · ${count} 个仓库`)
           : "全部星标仓库"
+      ),
+      conversationSwitchPending: (scope) => (
+        `已选择 ${scope} · 完成或放弃当前整理任务后切换对话`
       ),
       agentChanged: (count) => `已应用 ${count} 次标签更新`,
       turnFailed: "Cubby 未能完成这次请求",
@@ -2685,10 +2695,10 @@ const messages: Record<Locale, MessageCatalog> = {
       behaviorHeading: "5. 偏好",
       maxTagsPerRepoLabel: "每个仓库最多自动标签数",
       maxTagsPerRepoHint:
-        "点击 Auto Tags 时，单个仓库最多自动添加这么多个主题标签。",
-      minTopicRepoCountLabel: "主题最低覆盖数",
+        "Auto Tags 使用此上限；聊天中 Cubby 每轮最多为单个仓库新增这么多个标签；整理功能取此值与 5 个标签安全上限中的较小值。",
+      minTopicRepoCountLabel: "共同标签最低覆盖数",
       minTopicRepoCountHint:
-        "只有当一个主题至少出现在这么多个仓库中，Auto Tags 才会添加它。",
+        "聊天中，只有目标仓库加入后，同一主题或可见标签至少覆盖这么多个有效仓库，Cubby 才会分配该标签；整理功能按整批建议计算，Auto Tags 对主题使用相同阈值。",
       starsPanelDefaultLabel: "默认打开自己的 stars 页面时显示管理面板",
       starsPanelDefaultHint:
         "关闭后会优先显示 GitHub 原生 stars 列表，需要时再手动打开悬浮面板。",

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -2064,7 +2064,7 @@ const messages: Record<Locale, MessageCatalog> = {
       editingLayout: "正在编辑布局",
       columnsButton: "列",
       columnsButtonTitle: "显示或隐藏列",
-      showRepositoryOwner: "显示仓库作者名",
+      showRepositoryOwner: "显示仓库所有者",
       hiddenColumns: (count) => `已隐藏 ${count}`,
       hiddenColumnsTip: "点击恢复 · 拖回表头可插入位置",
       hideColumn: (label) => `隐藏「${label}」`,

--- a/src/search/repository-search.ts
+++ b/src/search/repository-search.ts
@@ -1,0 +1,272 @@
+export type SearchTextRange = Readonly<{
+  start: number;
+  end: number;
+}>;
+
+export type RepositorySearchMatchKind =
+  | 'empty'
+  | 'full-name-exact'
+  | 'repository-exact'
+  | 'repository-prefix'
+  | 'repository-substring'
+  | 'repository-fuzzy'
+  | 'full-name-prefix'
+  | 'full-name-substring'
+  | 'full-name-fuzzy'
+  | 'metadata-substring'
+  | 'none';
+
+export type RepositorySearchMatch = Readonly<{
+  matched: boolean;
+  relevance: number;
+  kind: RepositorySearchMatchKind;
+  nameRanges: readonly SearchTextRange[];
+}>;
+
+export type RepositorySearchDocument = Readonly<{
+  fullName: string;
+  description: string;
+  topics: readonly string[];
+  notes: string;
+}>;
+
+type NormalizedText = Readonly<{
+  text: string;
+  sourceStarts: readonly number[];
+  sourceEnds: readonly number[];
+}>;
+
+const RELEVANCE = {
+  fullNameExact: 900,
+  repositoryExact: 800,
+  repositoryPrefix: 700,
+  repositorySubstring: 600,
+  repositoryFuzzy: 500,
+  fullNamePrefix: 400,
+  fullNameSubstring: 300,
+  fullNameFuzzy: 200,
+  metadataSubstring: 100,
+} as const;
+
+const EMPTY_MATCH: RepositorySearchMatch = {
+  matched: true,
+  relevance: 0,
+  kind: 'empty',
+  nameRanges: [],
+};
+
+const NO_MATCH: RepositorySearchMatch = {
+  matched: false,
+  relevance: 0,
+  kind: 'none',
+  nameRanges: [],
+};
+
+/** Compiles one query so background filtering does not renormalize it per repository. */
+export function createRepositorySearchMatcher(rawQuery: string) {
+  const query = normalizeSearchText(rawQuery.trim());
+  const fuzzyQuery = compactFuzzySearchText(query);
+  const qualifiedQuery = query.includes('/');
+
+  const matchName = (fullName: string): RepositorySearchMatch => {
+    if (!query) return EMPTY_MATCH;
+
+    const fullNameText = normalizeSearchTextWithMap(fullName);
+    const repositoryOffset = Math.max(0, fullName.lastIndexOf('/') + 1);
+    const repositoryText = normalizeSearchTextWithMap(fullName.slice(repositoryOffset));
+
+    if (fullNameText.text === query) {
+      return contiguousMatch(
+        'full-name-exact',
+        RELEVANCE.fullNameExact,
+        fullNameText,
+        0,
+        query.length,
+      );
+    }
+    if (!qualifiedQuery) {
+      if (repositoryText.text === query) {
+        return contiguousMatch(
+          'repository-exact',
+          RELEVANCE.repositoryExact,
+          repositoryText,
+          0,
+          query.length,
+          repositoryOffset,
+        );
+      }
+      if (repositoryText.text.startsWith(query)) {
+        return contiguousMatch(
+          'repository-prefix',
+          RELEVANCE.repositoryPrefix,
+          repositoryText,
+          0,
+          query.length,
+          repositoryOffset,
+        );
+      }
+
+      const repositorySubstringIndex = repositoryText.text.indexOf(query);
+      if (repositorySubstringIndex >= 0) {
+        return contiguousMatch(
+          'repository-substring',
+          RELEVANCE.repositorySubstring,
+          repositoryText,
+          repositorySubstringIndex,
+          query.length,
+          repositoryOffset,
+        );
+      }
+
+      const repositoryFuzzyIndexes = fuzzyMatchIndexes(repositoryText.text, fuzzyQuery);
+      if (repositoryFuzzyIndexes) {
+        return fuzzyMatch(
+          'repository-fuzzy',
+          RELEVANCE.repositoryFuzzy,
+          repositoryText,
+          repositoryFuzzyIndexes,
+          repositoryOffset,
+        );
+      }
+    }
+
+    if (fullNameText.text.startsWith(query)) {
+      return contiguousMatch(
+        'full-name-prefix',
+        RELEVANCE.fullNamePrefix,
+        fullNameText,
+        0,
+        query.length,
+      );
+    }
+
+    const fullNameSubstringIndex = fullNameText.text.indexOf(query);
+    if (fullNameSubstringIndex >= 0) {
+      return contiguousMatch(
+        'full-name-substring',
+        RELEVANCE.fullNameSubstring,
+        fullNameText,
+        fullNameSubstringIndex,
+        query.length,
+      );
+    }
+
+    const fullNameFuzzyIndexes = fuzzyMatchIndexes(fullNameText.text, fuzzyQuery);
+    if (fullNameFuzzyIndexes) {
+      return fuzzyMatch(
+        'full-name-fuzzy',
+        RELEVANCE.fullNameFuzzy,
+        fullNameText,
+        fullNameFuzzyIndexes,
+      );
+    }
+
+    return NO_MATCH;
+  };
+
+  return {
+    empty: query.length === 0,
+    normalizedQuery: query,
+    matchName,
+    match(document: RepositorySearchDocument): RepositorySearchMatch {
+      const nameMatch = matchName(document.fullName);
+      if (nameMatch.matched) return nameMatch;
+
+      const metadata = normalizeSearchText(
+        `${document.description} ${document.topics.join(' ')} ${document.notes}`,
+      );
+      if (metadata.includes(query)) {
+        return {
+          matched: true,
+          relevance: RELEVANCE.metadataSubstring,
+          kind: 'metadata-substring',
+          nameRanges: [],
+        };
+      }
+      return NO_MATCH;
+    },
+  };
+}
+
+function normalizeSearchText(value: string): string {
+  return value.normalize('NFKC').toLocaleLowerCase('en-US');
+}
+
+function compactFuzzySearchText(value: string): string {
+  return value.replace(/[-_./\s]+/gu, '');
+}
+
+function normalizeSearchTextWithMap(value: string): NormalizedText {
+  let text = '';
+  const sourceStarts: number[] = [];
+  const sourceEnds: number[] = [];
+
+  for (let sourceStart = 0; sourceStart < value.length;) {
+    const codePoint = value.codePointAt(sourceStart);
+    if (codePoint === undefined) break;
+    const sourceEnd = sourceStart + (codePoint > 0xffff ? 2 : 1);
+    const normalized = normalizeSearchText(value.slice(sourceStart, sourceEnd));
+    text += normalized;
+    for (let index = 0; index < normalized.length; index += 1) {
+      sourceStarts.push(sourceStart);
+      sourceEnds.push(sourceEnd);
+    }
+    sourceStart = sourceEnd;
+  }
+
+  return { text, sourceStarts, sourceEnds };
+}
+
+function fuzzyMatchIndexes(candidate: string, query: string): number[] | null {
+  if (!query || query.length > candidate.length) return null;
+  const indexes: number[] = [];
+  let candidateIndex = 0;
+  for (let queryIndex = 0; queryIndex < query.length; queryIndex += 1) {
+    const matchIndex = candidate.indexOf(query[queryIndex], candidateIndex);
+    if (matchIndex < 0) return null;
+    indexes.push(matchIndex);
+    candidateIndex = matchIndex + 1;
+  }
+  return indexes;
+}
+
+function contiguousMatch(
+  kind: RepositorySearchMatchKind,
+  relevance: number,
+  source: NormalizedText,
+  normalizedStart: number,
+  normalizedLength: number,
+  sourceOffset = 0,
+): RepositorySearchMatch {
+  const normalizedEnd = normalizedStart + normalizedLength - 1;
+  return {
+    matched: true,
+    relevance,
+    kind,
+    nameRanges: [{
+      start: sourceOffset + (source.sourceStarts[normalizedStart] ?? 0),
+      end: sourceOffset + (source.sourceEnds[normalizedEnd] ?? 0),
+    }],
+  };
+}
+
+function fuzzyMatch(
+  kind: RepositorySearchMatchKind,
+  relevance: number,
+  source: NormalizedText,
+  normalizedIndexes: readonly number[],
+  sourceOffset = 0,
+): RepositorySearchMatch {
+  const ranges: SearchTextRange[] = [];
+  for (const normalizedIndex of normalizedIndexes) {
+    const start = sourceOffset + (source.sourceStarts[normalizedIndex] ?? 0);
+    const end = sourceOffset + (source.sourceEnds[normalizedIndex] ?? start);
+    const previous = ranges.at(-1);
+    if (previous && start <= previous.end) {
+      ranges[ranges.length - 1] = { start: previous.start, end: Math.max(previous.end, end) };
+    } else {
+      ranges.push({ start, end });
+    }
+  }
+  return { matched: true, relevance, kind, nameRanges: ranges };
+}

--- a/src/storage/organize-job-store.ts
+++ b/src/storage/organize-job-store.ts
@@ -13,6 +13,8 @@ import type {
   Tag,
 } from '@/types';
 import {
+  createOrganizeTagPolicySnapshot,
+  reconcileOrganizeTagCoverage,
   validateProviderAttemptReservation,
   validateRunBudgetUsage,
   type RunBudget,
@@ -68,6 +70,7 @@ export type CreateOrganizeJobInput = Readonly<{
   proposalId?: string;
   frozenScope: OrganizeFrozenScopeSnapshot;
   taskInstruction: string;
+  tagPolicy?: unknown;
   taxonomy: Readonly<{ fingerprint: string; snapshot: unknown }>;
   budget: unknown;
   usage: unknown;
@@ -164,6 +167,7 @@ export async function createOrganizeJob(
     proposalId: input.proposalId ?? `proposal:v1:${jobId}`,
     frozenScope: { ...input.frozenScope, repositoryIds },
     taskInstruction: input.taskInstruction,
+    tagPolicy: createOrganizeTagPolicySnapshot(input.tagPolicy),
     budget: input.budget,
     usage: input.usage,
     nextFrozenIndex: input.nextFrozenIndex ?? 0,
@@ -250,6 +254,7 @@ export async function createOrganizePreflight(
     proposalId: input.proposalId ?? `proposal:v1:${jobId}`,
     frozenScope: { ...input.frozenScope, repositoryIds },
     taskInstruction: input.taskInstruction,
+    tagPolicy: createOrganizeTagPolicySnapshot(input.tagPolicy),
     budget: input.budget,
     usage: input.usage,
     nextFrozenIndex: 0,
@@ -772,16 +777,27 @@ export async function checkpointOrganizeAnalysisPage(input: Readonly<{
     if (outcomes.size !== claimed.length || claimed.some((row) => !outcomes.has(row.position))) {
       throw new TypeError('Analysis checkpoint must cover the exact leased page.');
     }
-    const settled = claimed.map((row) => settleAnalysisRow(row, outcomes.get(row.position)!, now));
+    const tagPolicy = createOrganizeTagPolicySnapshot(job.tagPolicy);
+    const settled = claimed.map((row) => settleAnalysisRow(
+      row,
+      outcomes.get(row.position)!,
+      now,
+      tagPolicy.maxTagsPerRepo,
+    ));
     await db.organizeItems.bulkPut(settled);
-    const coverage = await coverageForJob(input.jobId);
+    let coverage = await coverageForJob(input.jobId);
     const firstFailed = settled.find((row) => row.analysisState === 'failed')?.position ?? null;
     const complete = coverage.complete && end === job.itemCount;
     if (coverage.complete && end !== job.itemCount) {
       throw new TypeError('Organize coverage cannot complete before the frozen cursor reaches the end.');
     }
+    if (complete) {
+      await reconcileStoredOrganizeTagCoverage(input.jobId, tagPolicy);
+      coverage = await coverageForJob(input.jobId);
+    }
     const next: OrganizeJobRecord = {
       ...job,
+      tagPolicy,
       usage: input.usage,
       providerBinding: input.providerBinding ?? job.providerBinding,
       nextFrozenIndex: end,
@@ -1063,19 +1079,28 @@ export async function settleOrganizeAnalysisBatch(input: Readonly<{
     if (outcomes.size !== claimed.length || claimed.some((row) => !outcomes.has(row.position))) {
       throw new TypeError('Analysis settlement must cover the exact claimed batch.');
     }
-    const settled = claimed.map((row) => settleAnalysisRow(row, outcomes.get(row.position)!, now));
+    const tagPolicy = createOrganizeTagPolicySnapshot(job.tagPolicy);
+    const settled = claimed.map((row) => settleAnalysisRow(
+      row,
+      outcomes.get(row.position)!,
+      now,
+      tagPolicy.maxTagsPerRepo,
+    ));
     await db.organizeItems.bulkPut(settled);
     const unresolved = await firstUnresolvedPosition(input.jobId);
     const nextRevision = job.revision + 1;
     await db.organizeJobs.update(input.jobId, {
+      tagPolicy,
       usage: input.usage ?? job.usage,
       providerBinding: input.providerBinding ?? job.providerBinding,
       nextFrozenIndex: unresolved ?? job.itemCount,
       revision: nextRevision,
       updatedAt: now,
     });
-    const coverage = await coverageForJob(input.jobId);
+    let coverage = await coverageForJob(input.jobId);
     if (coverage.complete) {
+      await reconcileStoredOrganizeTagCoverage(input.jobId, tagPolicy);
+      coverage = await coverageForJob(input.jobId);
       await db.organizeJobs.update(input.jobId, {
         status: 'review',
         revision: nextRevision + 1,
@@ -2003,10 +2028,13 @@ async function firstUnresolvedPosition(jobId: string): Promise<number | null> {
 }
 
 async function finishAnalysisIfCovered(job: OrganizeJobRecord, now: number): Promise<void> {
+  const tagPolicy = createOrganizeTagPolicySnapshot(job.tagPolicy);
   const coverage = await coverageForJob(job.jobId);
   if (coverage.complete) {
+    await reconcileStoredOrganizeTagCoverage(job.jobId, tagPolicy);
     await db.organizeJobs.put({
       ...job,
+      tagPolicy,
       status: 'review',
       nextFrozenIndex: job.itemCount,
       revision: job.revision + 1,
@@ -2015,12 +2043,49 @@ async function finishAnalysisIfCovered(job: OrganizeJobRecord, now: number): Pro
   } else if (coverage.pending === 0 && coverage.leased === 0 && coverage.failed > 0) {
     await db.organizeJobs.put({
       ...job,
+      tagPolicy,
       status: 'analysis_blocked',
       nextFrozenIndex: job.itemCount,
       revision: job.revision + 1,
       updatedAt: now,
     });
   }
+}
+
+async function reconcileStoredOrganizeTagCoverage(
+  jobId: string,
+  tagPolicy: ReturnType<typeof createOrganizeTagPolicySnapshot>,
+): Promise<void> {
+  const actionable = await db.organizeItems
+    .where('[jobId+analysisState]')
+    .equals([jobId, 'actionable'])
+    .sortBy('position');
+  const retainedActions = reconcileOrganizeTagCoverage(
+    actionable.map((row) => ({ repositoryId: row.fullName, actions: row.proposedActions })),
+    tagPolicy,
+  );
+  const reconciled = actionable.flatMap((row, index): OrganizeItemRecord[] => {
+    const actions = retainedActions[index] ?? [];
+    if (actions.length === 0) {
+      return [{
+        ...row,
+        analysisState: 'insufficient_evidence',
+        proposedActions: [],
+        approvedActions: [],
+        proposedAdditions: [],
+        sourceFingerprint: null,
+        selected: false,
+      }];
+    }
+    if (actions.length === row.proposedActions.length) return [];
+    return [{
+      ...row,
+      proposedActions: actions.map((action) => ({ ...action })),
+      approvedActions: actions.map((action) => ({ ...action })),
+      proposedAdditions: actions.map((action) => action.tag),
+    }];
+  });
+  if (reconciled.length > 0) await db.organizeItems.bulkPut(reconciled);
 }
 
 async function recoverAnalysisLeases(jobId: string, now: number): Promise<void> {
@@ -2222,10 +2287,13 @@ function settleAnalysisRow(
   row: OrganizeItemRecord,
   outcome: OrganizeAnalysisOutcome,
   now: number,
+  maxTagsPerRepo = 5,
 ): OrganizeItemRecord {
   validateAnalysisOutcome(outcome);
   const retry = outcome.state === 'retry';
-  const proposedActions = retry ? [] : normalizeActions(outcome.proposedActions ?? []);
+  const proposedActions = retry
+    ? []
+    : normalizeActions(outcome.proposedActions ?? [], maxTagsPerRepo);
   const proposedAdditions = proposedActions.map((action) => action.tag);
   if (outcome.state === 'actionable' && proposedActions.length === 0) {
     throw new TypeError('Actionable organization outcomes require proposed actions.');
@@ -2321,8 +2389,14 @@ async function validateOrganizeLedger(
   return rows;
 }
 
-function normalizeActions(values: readonly OrganizeProposedAction[]): OrganizeProposedAction[] {
-  if (values.length > 5) throw new RangeError('At most 5 proposed actions are allowed per repository.');
+function normalizeActions(
+  values: readonly OrganizeProposedAction[],
+  maxTagsPerRepo = 5,
+): OrganizeProposedAction[] {
+  assertLimit(maxTagsPerRepo, 5, 'proposed actions');
+  if (values.length > maxTagsPerRepo) {
+    throw new RangeError(`At most ${maxTagsPerRepo} proposed actions are allowed per repository.`);
+  }
   const tags = addTagNames([], values.map((action) => action.tag));
   return tags.map((tag) => {
     const action = values.find((candidate) => canonicalTag(candidate.tag) === canonicalTag(tag));

--- a/src/storage/organize-job-store.ts
+++ b/src/storage/organize-job-store.ts
@@ -15,6 +15,7 @@ import type {
 import {
   createOrganizeTagPolicySnapshot,
   reconcileOrganizeTagCoverage,
+  TAG_ADDITIONS_PER_REPOSITORY_HARD_LIMIT,
   validateProviderAttemptReservation,
   validateRunBudgetUsage,
   type RunBudget,
@@ -2287,7 +2288,7 @@ function settleAnalysisRow(
   row: OrganizeItemRecord,
   outcome: OrganizeAnalysisOutcome,
   now: number,
-  maxTagsPerRepo = 5,
+  maxTagsPerRepo = TAG_ADDITIONS_PER_REPOSITORY_HARD_LIMIT,
 ): OrganizeItemRecord {
   validateAnalysisOutcome(outcome);
   const retry = outcome.state === 'retry';
@@ -2391,9 +2392,13 @@ async function validateOrganizeLedger(
 
 function normalizeActions(
   values: readonly OrganizeProposedAction[],
-  maxTagsPerRepo = 5,
+  maxTagsPerRepo = TAG_ADDITIONS_PER_REPOSITORY_HARD_LIMIT,
 ): OrganizeProposedAction[] {
-  assertLimit(maxTagsPerRepo, 5, 'proposed actions');
+  assertLimit(
+    maxTagsPerRepo,
+    TAG_ADDITIONS_PER_REPOSITORY_HARD_LIMIT,
+    'proposed actions',
+  );
   if (values.length > maxTagsPerRepo) {
     throw new RangeError(`At most ${maxTagsPerRepo} proposed actions are allowed per repository.`);
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -153,6 +153,12 @@ export interface OrganizeAnalysisRange {
   depth: number;
 }
 
+/** Preference snapshot that stays fixed for one whole-library organization job. */
+export interface OrganizeTagPolicySnapshot {
+  maxTagsPerRepo: number;
+  minTopicRepoCount: number;
+}
+
 /** Durable header for a resumable whole-library tag organization job. */
 export interface OrganizeJobRecord {
   jobId: string;
@@ -165,6 +171,8 @@ export interface OrganizeJobRecord {
   proposalId: string;
   frozenScope: OrganizeFrozenScopeSnapshot;
   taskInstruction: string;
+  /** Optional only for legacy v4 rows created before organization preferences were snapshotted. */
+  tagPolicy?: OrganizeTagPolicySnapshot;
   budget: unknown;
   usage: unknown;
   nextFrozenIndex: number;
@@ -339,9 +347,9 @@ export interface Config {
   autoTagAgentPromptSeen: boolean;
   /** Legacy max topic-derived tags per repo. Read as compatibility input only. */
   autoTagLimit: number;
-  /** Max topic-derived tags per repo for Auto Tags. */
+  /** Max topic-derived tags per repo for automated organization. */
   maxTagsPerRepo: number;
-  /** Minimum repos that must share a topic before bulk Auto Tags generates it. */
+  /** Minimum repos that must share a topic/tag before automated organization uses it. */
   minTopicRepoCount: number;
   /** Durable library view intent for filters and primary sort. */
   libraryView: LibraryViewPrefs;
@@ -354,6 +362,7 @@ export interface Config {
     order: string[];
     hidden: string[];
     widths?: Partial<Record<ColumnId, number>>;
+    showRepositoryOwner?: boolean;
   } | null;
   /** One-shot migration flag: clear auto-derived `language` tags (now that
    *  language is a first-class filter, not a tag). Set true after the migration

--- a/src/ui/ManagerPanel.tsx
+++ b/src/ui/ManagerPanel.tsx
@@ -153,6 +153,7 @@ export function ManagerPanel() {
     layoutEditReady,
     previewingCustomLayout,
     draftLayout,
+    showRepositoryOwner,
     visibleColumns,
     gridTemplateColumns,
     tableMinWidth,
@@ -182,6 +183,7 @@ export function ManagerPanel() {
     resetLayoutEdit,
     resetLayoutWidths,
     setColumnHidden,
+    setRepositoryOwnerVisible,
     beginColumnDrag,
     beginColumnResize,
     moveColumnByKeyboard,
@@ -419,6 +421,7 @@ export function ManagerPanel() {
       position={columnMenuPosition}
       draftLayout={draftLayout}
       onSetColumnHidden={setColumnHidden}
+      onSetRepositoryOwnerVisible={setRepositoryOwnerVisible}
     />
   );
 
@@ -582,6 +585,8 @@ export function ManagerPanel() {
             ) : (
               <StarsTable
                 rows={visibleRows}
+                searchQuery={f.query}
+                showRepositoryOwner={showRepositoryOwner}
                 loading={loading}
                 phase={phase}
                 tagsByFullName={tagsByFullName}

--- a/src/ui/column-layout.ts
+++ b/src/ui/column-layout.ts
@@ -24,6 +24,8 @@ export type ColumnLayout = {
   order: ColumnId[];
   hidden: ColumnId[];
   widths?: Partial<Record<ColumnId, number>>;
+  /** Omitted is the default: render repository names as owner/repo. */
+  showRepositoryOwner?: boolean;
 };
 
 export type ColumnLayoutMode = 'default' | 'custom';
@@ -178,7 +180,11 @@ export function normalizeColumnLayout(layout: ColumnLayout): ColumnLayout {
     seenHidden.add(id);
     return true;
   });
-  const normalized = { order: moveLockedColumnsToEnd(order), hidden };
+  const normalized: ColumnLayout = {
+    order: moveLockedColumnsToEnd(order),
+    hidden,
+    ...(layout.showRepositoryOwner === false ? { showRepositoryOwner: false } : {}),
+  };
   const widths = normalizeColumnWidths(layout.widths);
   return Object.keys(widths).length > 0 ? { ...normalized, widths } : normalized;
 }
@@ -189,12 +195,18 @@ export function normalizeColumnLayoutMode(value: unknown): ColumnLayoutMode {
 
 export function normalizeStoredColumnLayoutPreference(value: unknown): ColumnLayout | null {
   if (!value || typeof value !== 'object') return null;
-  const layout = value as { order?: unknown; hidden?: unknown; widths?: unknown };
+  const layout = value as {
+    order?: unknown;
+    hidden?: unknown;
+    widths?: unknown;
+    showRepositoryOwner?: unknown;
+  };
   if (!Array.isArray(layout.order) || !Array.isArray(layout.hidden)) return null;
   const normalized = normalizeColumnLayout({
     order: layout.order as ColumnId[],
     hidden: layout.hidden as ColumnId[],
     widths: layout.widths as Partial<Record<ColumnId, number>> | undefined,
+    showRepositoryOwner: layout.showRepositoryOwner === false ? false : undefined,
   });
   return layoutsEqual(normalized, DEFAULT_COLUMN_LAYOUT) ? null : normalized;
 }
@@ -204,6 +216,7 @@ export function cloneColumnLayout(layout: ColumnLayout): ColumnLayout {
     order: [...layout.order],
     hidden: [...layout.hidden],
     ...(layout.widths ? { widths: { ...layout.widths } } : {}),
+    ...(layout.showRepositoryOwner === false ? { showRepositoryOwner: false } : {}),
   };
 }
 
@@ -211,7 +224,8 @@ export function layoutsEqual(a: ColumnLayout, b: ColumnLayout): boolean {
   return (
     a.order.join('|') === b.order.join('|') &&
     a.hidden.join('|') === b.hidden.join('|') &&
-    widthSignature(a.widths) === widthSignature(b.widths)
+    widthSignature(a.widths) === widthSignature(b.widths) &&
+    (a.showRepositoryOwner !== false) === (b.showRepositoryOwner !== false)
   );
 }
 
@@ -249,6 +263,7 @@ export function restoreColumn(layout: ColumnLayout, id: ColumnId, insertIndex?: 
     order: mergeVisibleOrder(layout.order, withoutId),
     hidden,
     widths: layout.widths,
+    showRepositoryOwner: layout.showRepositoryOwner,
   });
 }
 

--- a/src/ui/components/AgentHost.tsx
+++ b/src/ui/components/AgentHost.tsx
@@ -79,6 +79,8 @@ export function AgentHost({
   const boundContextKey = agent.conversationBinding
     ? conversationCandidateContextKey(agent.conversationBinding.candidateContract)
     : null;
+  // Organize ownership implies !canSwitchSession; while a candidate is blocked,
+  // the effect cannot consume its pending switch before ownership releases and rerenders.
   const blockedConversationCandidate = organizeView.ownsSession
     && pendingContextKey !== null
     && pendingContextKey !== boundContextKey
@@ -91,8 +93,8 @@ export function AgentHost({
       pendingCandidateContextKeyRef.current = candidateContextKey;
     }
 
-    const pendingContextKey = pendingCandidateContextKeyRef.current;
-    if (!pendingContextKey) return;
+    const queuedCandidateContextKey = pendingCandidateContextKeyRef.current;
+    if (!queuedCandidateContextKey) return;
     if (!agent.conversationBinding) {
       if (uiPresentation.sessionPolicy.canSwitchSession) {
         pendingCandidateContextKeyRef.current = null;
@@ -100,7 +102,7 @@ export function AgentHost({
       return;
     }
     if (conversationCandidateContextKey(agent.conversationBinding.candidateContract)
-      === pendingContextKey) {
+      === queuedCandidateContextKey) {
       pendingCandidateContextKeyRef.current = null;
       return;
     }

--- a/src/ui/components/AgentHost.tsx
+++ b/src/ui/components/AgentHost.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import type { BgsmAgentConversationCandidate } from '@/bgsm-agent/conversation-binding';
 import type { LaunchCandidateContract } from '@/bgsm-agent/scope';
 import { useI18n } from '@/i18n';
@@ -43,29 +43,75 @@ export function AgentHost({
   const { m } = useI18n();
   const agent = useBgsmAgent(onDataChanged, chatCandidate);
   const workbench = useBgsmAgentWorkbench(onDataChanged, agent.sessionId);
-  const presentation = useMemo<AgentHostPresentation>(() => {
-    const organizeView = selectOrganizeWorkbenchView(
-      workbench.state,
-      workbench.displayedProcessed,
-    );
-    const ui = resolveAgentUiPresentation({
+  const organizeView = useMemo(() => selectOrganizeWorkbenchView(
+    workbench.state,
+    workbench.displayedProcessed,
+  ), [workbench.displayedProcessed, workbench.state]);
+  const uiPresentation = useMemo(() => {
+    return resolveAgentUiPresentation({
       phase: agent.phase,
       hasError: agent.error !== null,
       hasContextRecovery: agent.contextLimitRecovery !== null,
       unsafeReplayBlocked: false,
     }, organizeView);
-    return {
-      status: resolveToolbarStatus(ui, agent.status?.text ?? null, m.agentPanel),
-      active: ui.toolbar.active,
-    };
   }, [
     agent.contextLimitRecovery,
     agent.error,
     agent.phase,
+    organizeView,
+  ]);
+  const presentation = useMemo<AgentHostPresentation>(() => {
+    return {
+      status: resolveToolbarStatus(uiPresentation, agent.status?.text ?? null, m.agentPanel),
+      active: uiPresentation.toolbar.active,
+    };
+  }, [
     agent.status?.text,
     m.agentPanel,
-    workbench.displayedProcessed,
-    workbench.state,
+    uiPresentation,
+  ]);
+  const candidateContextKey = conversationCandidateContextKey(chatCandidate);
+  const previousCandidateContextKeyRef = useRef(candidateContextKey);
+  const pendingCandidateContextKeyRef = useRef<string | null>(null);
+  const pendingContextKey = candidateContextKey !== previousCandidateContextKeyRef.current
+    ? candidateContextKey
+    : pendingCandidateContextKeyRef.current;
+  const boundContextKey = agent.conversationBinding
+    ? conversationCandidateContextKey(agent.conversationBinding.candidateContract)
+    : null;
+  const blockedConversationCandidate = organizeView.ownsSession
+    && pendingContextKey !== null
+    && pendingContextKey !== boundContextKey
+    ? chatCandidate
+    : null;
+
+  useEffect(() => {
+    if (candidateContextKey !== previousCandidateContextKeyRef.current) {
+      previousCandidateContextKeyRef.current = candidateContextKey;
+      pendingCandidateContextKeyRef.current = candidateContextKey;
+    }
+
+    const pendingContextKey = pendingCandidateContextKeyRef.current;
+    if (!pendingContextKey) return;
+    if (!agent.conversationBinding) {
+      if (uiPresentation.sessionPolicy.canSwitchSession) {
+        pendingCandidateContextKeyRef.current = null;
+      }
+      return;
+    }
+    if (conversationCandidateContextKey(agent.conversationBinding.candidateContract)
+      === pendingContextKey) {
+      pendingCandidateContextKeyRef.current = null;
+      return;
+    }
+    if (!uiPresentation.sessionPolicy.canSwitchSession) return;
+    if (agent.createSession()) pendingCandidateContextKeyRef.current = null;
+  }, [
+    agent.activeSessionId,
+    agent.conversationBinding,
+    agent.createSession,
+    candidateContextKey,
+    uiPresentation.sessionPolicy.canSwitchSession,
   ]);
 
   useEffect(() => {
@@ -80,11 +126,18 @@ export function AgentHost({
       agent={agent}
       workbench={workbench}
       defaultCandidate={defaultCandidate}
+      blockedConversationCandidate={blockedConversationCandidate}
       scopeCount={scopeCount}
       handoff={handoff}
       onDismissHandoff={onDismissHandoff}
     />
   );
+}
+
+function conversationCandidateContextKey(candidate: BgsmAgentConversationCandidate): string {
+  return candidate.kind === 'selected_repository'
+    ? `selected_repository:${candidate.selectedRepositoryIdHint}`
+    : 'current_view';
 }
 
 function resolveToolbarStatus(

--- a/src/ui/components/AgentPanel.tsx
+++ b/src/ui/components/AgentPanel.tsx
@@ -21,6 +21,7 @@ import {
   X,
 } from 'lucide-react';
 import type { LaunchCandidateContract } from '@/bgsm-agent/scope';
+import type { BgsmAgentConversationCandidate } from '@/bgsm-agent/conversation-binding';
 import {
   BGSM_AGENT_TOOL_NAMES,
   getBgsmAgentToolDefinition,
@@ -63,6 +64,7 @@ export function AgentPanel({
   agent,
   workbench,
   defaultCandidate,
+  blockedConversationCandidate = null,
   scopeCount,
   handoff,
   onDismissHandoff,
@@ -73,6 +75,7 @@ export function AgentPanel({
   agent: ChatController;
   workbench: WorkbenchController;
   defaultCandidate: LaunchCandidateContract;
+  blockedConversationCandidate?: BgsmAgentConversationCandidate | null;
   scopeCount?: number;
   handoff?: { remainingUntagged: number; autoTagged: number } | null;
   onDismissHandoff?: () => void;
@@ -149,7 +152,8 @@ export function AgentPanel({
   const active = uiPresentation.active;
   const showStopbar = uiPresentation.stopbar !== null;
   const sessionTransitionBlocked = !uiPresentation.sessionPolicy.canSwitchSession;
-  const chatDisabled = uiPresentation.composer.disabled;
+  const conversationSwitchBlocked = blockedConversationCandidate !== null;
+  const chatDisabled = uiPresentation.composer.disabled || conversationSwitchBlocked;
   const mascotState = uiPresentation.mascot;
   const contextFailureReason = contextLimitRecovery?.reason ?? null;
   const contextNeedsProviderSettings = contextFailureReason === 'capability_unresolved'
@@ -327,7 +331,7 @@ export function AgentPanel({
   };
 
   const handleRetryContextLimitedPrompt = () => {
-    if (!contextLimitRecovery || active || !canRetryLastTurn) return;
+    if (!contextLimitRecovery || active || !canRetryLastTurn || conversationSwitchBlocked) return;
     const prompt = contextLimitRecovery.prompt;
     editContextLimitedPrompt();
     setInput('');
@@ -400,7 +404,14 @@ export function AgentPanel({
     organizeView,
     m,
   });
-  const composerNote = stateComposerNote
+  const blockedConversationLabel = blockedConversationCandidate?.kind === 'selected_repository'
+    ? blockedConversationCandidate.selectedRepositoryIdHint
+    : blockedConversationCandidate
+      ? m.agentPanel.askingAboutCurrentViewUnknown
+      : null;
+  const composerNote = blockedConversationLabel
+    ? m.agentPanel.conversationSwitchPending(blockedConversationLabel)
+    : stateComposerNote
     ?? (showHandoff
       ? m.agentPanel.handoffScopeNote(handoff!.remainingUntagged)
       : organize.snapshot
@@ -799,7 +810,7 @@ export function AgentPanel({
                           size="sm"
                           className="h-7 px-2 text-xs"
                           onClick={handleRetry}
-                          disabled={!retryPrompt || active || !canRetryLastTurn}
+                          disabled={!retryPrompt || active || !canRetryLastTurn || chatDisabled}
                         >
                           {isProviderSetupError ? m.agentPanel.providerAuthRetry : m.agentPanel.retry}
                         </Button>
@@ -834,7 +845,11 @@ export function AgentPanel({
                     </Button>
                   )}
                   {contextNeedsInternalRetry && (
-                    <Button size="sm" onClick={handleRetryContextLimitedPrompt} disabled={!canRetryLastTurn}>
+                    <Button
+                      size="sm"
+                      onClick={handleRetryContextLimitedPrompt}
+                      disabled={!canRetryLastTurn || conversationSwitchBlocked}
+                    >
                       {m.agentPanel.retry}
                     </Button>
                   )}

--- a/src/ui/components/LayoutEditChrome.tsx
+++ b/src/ui/components/LayoutEditChrome.tsx
@@ -63,6 +63,7 @@ export function LayoutColumnMenu({
   position,
   draftLayout,
   onSetColumnHidden,
+  onSetRepositoryOwnerVisible,
 }: {
   container: HTMLElement | null;
   editing: boolean;
@@ -70,6 +71,7 @@ export function LayoutColumnMenu({
   position: { left: number; top: number } | null;
   draftLayout: ColumnLayout;
   onSetColumnHidden: (id: ColumnId, hidden: boolean) => void;
+  onSetRepositoryOwnerVisible: (visible: boolean) => void;
 }) {
   const { m } = useI18n();
   if (!editing || !open || !position || !container) return null;
@@ -112,6 +114,22 @@ export function LayoutColumnMenu({
           </button>
         );
       })}
+      <div role="separator" className="my-1 border-t border-border" />
+      <button
+        type="button"
+        role="menuitemcheckbox"
+        aria-checked={draftLayout.showRepositoryOwner !== false}
+        onClick={() => onSetRepositoryOwnerVisible(draftLayout.showRepositoryOwner === false)}
+        className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs text-foreground hover:bg-accent"
+      >
+        <span className={cn(
+          'grid size-3.5 place-items-center rounded border border-border',
+          { 'bg-primary text-primary-foreground': draftLayout.showRepositoryOwner !== false },
+        )}>
+          {draftLayout.showRepositoryOwner !== false && <Check className="size-3" />}
+        </span>
+        <span className="flex-1 truncate">{m.toolbar.showRepositoryOwner}</span>
+      </button>
     </div>,
     container,
   );

--- a/src/ui/components/StarRow.tsx
+++ b/src/ui/components/StarRow.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { Archive, Star as StarIcon, StickyNote } from 'lucide-react';
 import type { Star } from '@/types';
 import { Badge } from '@/ui/shadcn/badge';
@@ -10,6 +10,10 @@ import { useI18n } from '@/i18n';
 import { getLockedRegionProps } from '@/ui/interaction-lock';
 import type { ColumnId } from '@/ui/column-layout';
 import { fitInlineTags } from '@/ui/inline-tag-fit';
+import {
+  createRepositorySearchMatcher,
+  type SearchTextRange,
+} from '@/search/repository-search';
 
 /**
  * virtualized-list row. Fixed h-16 (64px) MUST match the virtualizer
@@ -23,6 +27,8 @@ const useIsomorphicLayoutEffect =
 
 export const StarRow = memo(function StarRow({
   star,
+  searchQuery = '',
+  showRepositoryOwner = true,
   tags,
   hasNotes,
   favorite,
@@ -42,6 +48,8 @@ export const StarRow = memo(function StarRow({
   onUnstarPopoverOpenChange,
 }: {
   star: Star;
+  searchQuery?: string;
+  showRepositoryOwner?: boolean;
   tags: string[];
   hasNotes: boolean;
   favorite: boolean;
@@ -78,6 +86,10 @@ export const StarRow = memo(function StarRow({
   const visible = tags.slice(0, visibleCount);
   const hiddenCount = tags.length - visible.length;
   const overflow = hiddenCount > 0;
+  const repositoryNameMatch = useMemo(
+    () => createRepositorySearchMatcher(searchQuery).matchName(star.full_name),
+    [searchQuery, star.full_name],
+  );
   const { m } = useI18n();
 
   useIsomorphicLayoutEffect(() => {
@@ -148,7 +160,17 @@ export const StarRow = memo(function StarRow({
           case 'repository':
             return (
               <div key={column} data-row-col={column} className={cn('flex items-center gap-1 overflow-hidden rounded-sm', { 'gsm-flash-col': flashedColumn === column })}>
-                <span className="truncate text-primary">{star.full_name}</span>
+                <span
+                  className="truncate text-primary"
+                  title={showRepositoryOwner ? undefined : star.full_name}
+                  aria-label={showRepositoryOwner ? undefined : star.full_name}
+                >
+                  <HighlightedRepositoryName
+                    fullName={star.full_name}
+                    ranges={repositoryNameMatch.nameRanges}
+                    showOwner={showRepositoryOwner}
+                  />
+                </span>
                 {star.archived && <Archive className="size-3 shrink-0 text-warning" aria-label={m.starRow.archived} />}
               </div>
             );
@@ -363,6 +385,42 @@ export const StarRow = memo(function StarRow({
     </div>
   );
 });
+
+function HighlightedRepositoryName({
+  fullName,
+  ranges,
+  showOwner,
+}: {
+  fullName: string;
+  ranges: readonly SearchTextRange[];
+  showOwner: boolean;
+}) {
+  const sourceOffset = showOwner ? 0 : Math.max(0, fullName.lastIndexOf('/') + 1);
+  const label = fullName.slice(sourceOffset);
+  if (ranges.length === 0) return label;
+
+  const content: ReactNode[] = [];
+  let cursor = 0;
+  for (const range of ranges) {
+    const start = Math.max(cursor, Math.min(label.length, range.start - sourceOffset));
+    const end = Math.max(start, Math.min(label.length, range.end - sourceOffset));
+    if (start > cursor) content.push(label.slice(cursor, start));
+    if (end > start) {
+      content.push(
+        <mark
+          key={`${start}:${end}`}
+          data-search-match=""
+          className="rounded-[2px] bg-search-match/70 text-search-match-foreground"
+        >
+          {label.slice(start, end)}
+        </mark>,
+      );
+    }
+    cursor = end;
+  }
+  if (cursor < label.length) content.push(label.slice(cursor));
+  return <>{content}</>;
+}
 
 function fmt(n: number): string {
   if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;

--- a/src/ui/components/StarsTable.tsx
+++ b/src/ui/components/StarsTable.tsx
@@ -42,6 +42,8 @@ export interface StarsTableLayoutEdit {
 
 export function StarsTable({
   rows,
+  searchQuery = '',
+  showRepositoryOwner = true,
   loading,
   phase,
   tagsByFullName,
@@ -70,6 +72,8 @@ export function StarsTable({
   onAutoFitColumnWidth = () => {},
 }: {
   rows: Star[];
+  searchQuery?: string;
+  showRepositoryOwner?: boolean;
   loading: boolean;
   phase: StarsTablePhase;
   tagsByFullName: Map<string, Tag>;
@@ -384,6 +388,8 @@ export function StarsTable({
               >
                 <StarRow
                   star={star}
+                  searchQuery={searchQuery}
+                  showRepositoryOwner={showRepositoryOwner}
                   tags={visibleTagNames(tag)}
                   hasNotes={!!(tag?.notes && tag.notes.trim())}
                   favorite={favorite}

--- a/src/ui/hooks/use-column-layout-editor.ts
+++ b/src/ui/hooks/use-column-layout-editor.ts
@@ -147,6 +147,7 @@ export function useColumnLayoutEditor(
     ? customLayout
     : DEFAULT_COLUMN_LAYOUT;
   const activeLayout = editingLayout ? draftLayout : renderedBrowseLayout;
+  const showRepositoryOwner = activeLayout.showRepositoryOwner !== false;
   const displayLayout = layoutResize
     ? normalizeColumnLayout({ ...draftLayout, widths: { ...draftLayout.widths, ...layoutResize.liveWidths } })
     : activeLayout;
@@ -424,6 +425,14 @@ export function useColumnLayoutEditor(
   const setColumnHidden = (id: ColumnId, hidden: boolean) => {
     if (blockLayoutMutationDuringResize()) return;
     setDraftLayout((current) => (hidden ? hideColumn(current, id) : restoreColumnWithMeasuredWidth(current, id)));
+  };
+
+  const setRepositoryOwnerVisible = (visible: boolean) => {
+    if (blockLayoutMutationDuringResize()) return;
+    setDraftLayout((current) => normalizeColumnLayout({
+      ...current,
+      showRepositoryOwner: visible ? undefined : false,
+    }));
   };
 
   const flashColumn = (id: ColumnId) => {
@@ -820,6 +829,7 @@ export function useColumnLayoutEditor(
     layoutEditReady,
     previewingCustomLayout,
     draftLayout,
+    showRepositoryOwner,
     visibleColumns,
     gridTemplateColumns,
     tableMinWidth,
@@ -849,6 +859,7 @@ export function useColumnLayoutEditor(
     resetLayoutEdit,
     resetLayoutWidths,
     setColumnHidden,
+    setRepositoryOwnerVisible,
     beginColumnDrag,
     beginColumnResize,
     moveColumnByKeyboard,

--- a/src/ui/styles/theme.css
+++ b/src/ui/styles/theme.css
@@ -33,6 +33,8 @@
     --favorite-muted-hover: 352 96% 71%;
     --success: 142 71% 45%;
     --warning: 38 92% 50%;
+    --search-match: 48 96% 72%;
+    --search-match-foreground: 0 0% 9%;
     --border: 0 0% 90%;
     --input: 0 0% 90%;
     --ring: 0 0% 9%;
@@ -93,6 +95,8 @@
     --favorite-muted-hover: 352 96% 71%;
     --success: 142 71% 45%;
     --warning: 38 92% 50%;
+    --search-match: 45 80% 40%;
+    --search-match-foreground: 0 0% 4%;
     --border: 0 0% 20%;
     --input: 0 0% 20%;
     --ring: 0 0% 98%;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -57,6 +57,10 @@ export default {
         },
         success: 'hsl(var(--success))',
         warning: 'hsl(var(--warning))',
+        'search-match': {
+          DEFAULT: 'hsl(var(--search-match))',
+          foreground: 'hsl(var(--search-match-foreground))',
+        },
         favorite: {
           DEFAULT: 'hsl(var(--favorite))',
           hover: 'hsl(var(--favorite-hover))',

--- a/tests/integration/integration.test.ts
+++ b/tests/integration/integration.test.ts
@@ -272,6 +272,57 @@ describe('Integration (real query engine + Dexie)', () => {
     assert.deepEqual(r.rows.map((s) => s.full_name), ['b/rust']);
   });
 
+  it('ranks repository-name match tiers before metadata and keeps the selected sort within a tier', async () => {
+    await db.stars.bulkPut([
+      { ...base, full_name: 'rank/abc', starred_at: '2020-01-01' },
+      { ...base, full_name: 'rank/abc-old', starred_at: '2021-01-01' },
+      { ...base, full_name: 'rank/abc-new', starred_at: '2025-01-01' },
+      { ...base, full_name: 'rank/x-abc-tool', starred_at: '2026-01-01' },
+      { ...base, full_name: 'rank/a-big-catalog', starred_at: '2027-01-01' },
+      {
+        ...base,
+        full_name: 'rank/metadata-only',
+        description: 'Contains abc continuously',
+        starred_at: '2028-01-01',
+      },
+    ] as Star[]);
+    invalidateCache();
+
+    const r = await queryStars({
+      filter: { ...defaultFilter(), query: 'abc', sortKey: 'starred_at', sortDir: 'desc' },
+      offset: 0,
+      limit: 100,
+    });
+
+    assert.deepEqual(r.rows.map((s) => s.full_name), [
+      'rank/abc',
+      'rank/abc-new',
+      'rank/abc-old',
+      'rank/x-abc-tool',
+      'rank/a-big-catalog',
+      'rank/metadata-only',
+    ]);
+  });
+
+  it('ranks an owner-qualified path before an unrelated repository fuzzy match', async () => {
+    await db.stars.bulkPut([
+      { ...base, full_name: 'foo/bar-utils' },
+      { ...base, full_name: 'other/foobar-utils' },
+    ] as Star[]);
+    invalidateCache();
+
+    const r = await queryStars({
+      filter: { ...defaultFilter(), query: 'foo/bar', sortKey: 'name', sortDir: 'asc' },
+      offset: 0,
+      limit: 100,
+    });
+
+    assert.deepEqual(r.rows.map((s) => s.full_name), [
+      'foo/bar-utils',
+      'other/foobar-utils',
+    ]);
+  });
+
   it('filter by tag', async () => {
     const r = await queryStars({
       filter: { ...defaultFilter(), tags: ['rust'] },

--- a/tests/regressions/fuzz/query-fuzz.test.ts
+++ b/tests/regressions/fuzz/query-fuzz.test.ts
@@ -123,7 +123,18 @@ function generateQueryCase(rng: SeededRng, options: { forceStars?: number } = {}
       mtime: iso(index + 400),
       excluded: rng.bool(0.2) ? true : undefined,
     } satisfies TagMeta));
-  const queryTerm = rng.pick(['', '', 'repo', 'agent', 'sync', 'note', 'cache', rng.pick(words)]);
+  const queryTerm = rng.pick([
+    '',
+    '',
+    'repo',
+    'rpo',
+    'owner1/repo',
+    'agent',
+    'sync',
+    'note',
+    'cache',
+    rng.pick(words),
+  ]);
   const params: QueryParams = {
     filter: {
       query: rng.bool(0.2) ? `  ${queryTerm.toUpperCase()}  ` : queryTerm,
@@ -194,7 +205,8 @@ function referenceQuery(input: GeneratedQueryCase): QueryResult {
     }))
     .sort((a, b) => a.full_name.localeCompare(b.full_name));
   const tagMap = new Map(indexedTags.map((tag) => [tag.full_name, tag]));
-  const q = input.params.filter.query.trim().toLowerCase();
+  const q = normalizeReferenceSearchText(input.params.filter.query.trim());
+  const relevanceByFullName = new Map<string, number>();
   const langSet = input.params.filter.languages.length ? new Set(input.params.filter.languages) : null;
   const tagSet = input.params.filter.tags.length
     ? new Set(input.params.filter.tags.map((tag) => referenceTagKey(tag)))
@@ -216,12 +228,18 @@ function referenceQuery(input: GeneratedQueryCase): QueryResult {
       }
     }
     if (q) {
-      const haystack = `${star.full_name} ${star.description} ${star.topics.join(' ')} ${tagRecord?.notes ?? ''}`.toLowerCase();
-      if (!haystack.includes(q)) return false;
+      const relevance = referenceSearchRelevance(star, tagRecord?.notes ?? '', q);
+      if (relevance === 0) return false;
+      relevanceByFullName.set(star.full_name, relevance);
     }
     return true;
   });
-  const sorted = sortReferenceRows(filtered, input.params.filter.sortKey, input.params.filter.sortDir);
+  const sorted = sortReferenceRows(
+    filtered,
+    input.params.filter.sortKey,
+    input.params.filter.sortDir,
+    q ? relevanceByFullName : undefined,
+  );
   const rows = sorted.slice(input.params.offset, input.params.offset + input.params.limit);
   const languagesFacet = [...countLanguages(indexedStars).entries()].sort((a, b) => b[1] - a[1]).slice(0, 40);
   const tagCounts = countTags(indexedTags, excluded);
@@ -239,9 +257,18 @@ function referenceQuery(input: GeneratedQueryCase): QueryResult {
   };
 }
 
-function sortReferenceRows(rows: Star[], key: SortKey, dir: 'asc' | 'desc'): Star[] {
+function sortReferenceRows(
+  rows: Star[],
+  key: SortKey,
+  dir: 'asc' | 'desc',
+  relevance?: ReadonlyMap<string, number>,
+): Star[] {
   const mul = dir === 'asc' ? 1 : -1;
   return [...rows].sort((a, b) => {
+    if (relevance) {
+      const difference = (relevance.get(b.full_name) ?? 0) - (relevance.get(a.full_name) ?? 0);
+      if (difference !== 0) return difference;
+    }
     switch (key) {
       case 'pushed_at':
         return compareNullableDate(a.pushed_at, b.pushed_at, a.full_name, b.full_name, dir);
@@ -255,6 +282,47 @@ function sortReferenceRows(rows: Star[], key: SortKey, dir: 'asc' | 'desc'): Sta
         return a.full_name.localeCompare(b.full_name) * mul;
     }
   });
+}
+
+function referenceSearchRelevance(star: Star, notes: string, query: string): number {
+  const fullName = normalizeReferenceSearchText(star.full_name);
+  const slash = star.full_name.lastIndexOf('/');
+  const repositoryName = normalizeReferenceSearchText(star.full_name.slice(slash + 1));
+
+  if (fullName === query) return 900;
+  const fuzzyQuery = compactReferenceFuzzyQuery(query);
+  if (!query.includes('/')) {
+    if (repositoryName === query) return 800;
+    if (repositoryName.startsWith(query)) return 700;
+    if (repositoryName.includes(query)) return 600;
+    if (referenceSequenceMatch(repositoryName, fuzzyQuery)) return 500;
+  }
+  if (fullName.startsWith(query)) return 400;
+  if (fullName.includes(query)) return 300;
+  if (referenceSequenceMatch(fullName, fuzzyQuery)) return 200;
+
+  const metadata = normalizeReferenceSearchText(
+    `${star.description} ${star.topics.join(' ')} ${notes}`,
+  );
+  return metadata.includes(query) ? 100 : 0;
+}
+
+function referenceSequenceMatch(candidate: string, query: string): boolean {
+  let searchFrom = 0;
+  for (const character of query) {
+    const index = candidate.indexOf(character, searchFrom);
+    if (index < 0) return false;
+    searchFrom = index + character.length;
+  }
+  return query.length > 0;
+}
+
+function normalizeReferenceSearchText(value: string): string {
+  return value.normalize('NFKC').toLocaleLowerCase('en-US');
+}
+
+function compactReferenceFuzzyQuery(value: string): string {
+  return value.replace(/[-_./\s]+/gu, '');
 }
 
 function countLanguages(stars: Star[]): Map<string, number> {

--- a/tests/unit/agent-host-repository-selection.test.tsx
+++ b/tests/unit/agent-host-repository-selection.test.tsx
@@ -1,0 +1,377 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, useState } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  BgsmAgentConversationBinding,
+  BgsmAgentConversationCandidate,
+} from '@/bgsm-agent/conversation-binding';
+import { parseScopeFingerprintV1 } from '@/bgsm-agent/scope';
+import type { BgsmAgentTurnInput } from '@/bgsm-agent/session';
+import { AgentHost } from '@/ui/components/AgentHost';
+import type { BgsmAgentTurnHandlers } from '@/utils/messaging';
+import {
+  cleanupMountedRootsAndBody,
+  click,
+  mountReact,
+  type MountedRoot,
+} from './test-utils';
+
+const messagingMocks = vi.hoisted(() => ({
+  startBgsmAgentTurn: vi.fn(),
+}));
+const presentationMocks = vi.hoisted(() => ({
+  ownsWorkbench: false,
+}));
+
+vi.mock('@/utils/messaging', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/messaging')>();
+  return {
+    ...actual,
+    startBgsmAgentTurn: messagingMocks.startBgsmAgentTurn,
+  };
+});
+
+vi.mock('@/ui/agent-ui-presentation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/ui/agent-ui-presentation')>();
+  return {
+    ...actual,
+    selectOrganizeWorkbenchView: (...args: Parameters<typeof actual.selectOrganizeWorkbenchView>) => {
+      const view = actual.selectOrganizeWorkbenchView(...args);
+      if (!presentationMocks.ownsWorkbench) return view;
+      return {
+        ...view,
+        ownsSession: true,
+        capabilities: {
+          ...view.capabilities,
+          canSwitchSession: false,
+          canChat: true,
+        },
+      };
+    },
+  };
+});
+
+type CapturedTurn = Readonly<{
+  input: BgsmAgentTurnInput;
+  handlers: BgsmAgentTurnHandlers;
+}>;
+
+const mountedRoots: MountedRoot[] = [];
+let turns: CapturedTurn[];
+
+beforeEach(() => {
+  turns = [];
+  presentationMocks.ownsWorkbench = false;
+  messagingMocks.startBgsmAgentTurn.mockReset();
+  messagingMocks.startBgsmAgentTurn.mockImplementation((
+    input: BgsmAgentTurnInput,
+    handlers: BgsmAgentTurnHandlers,
+  ) => {
+    turns.push({ input, handlers });
+    return { stop: vi.fn(), acknowledge: vi.fn() };
+  });
+  vi.stubGlobal('chrome', { runtime: {} });
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  cleanupMountedRootsAndBody(mountedRoots);
+  vi.unstubAllGlobals();
+});
+
+describe('AgentHost repository selection', () => {
+  it('uses the latest repository in an unbound session without creating another conversation', async () => {
+    const container = await mountHarness(selectedRepository('owner/repo-a'));
+
+    await click(actionButton(container, 'select-repo-b'));
+    await click(actionButton(container, 'select-repo-c'));
+
+    await expectSessionCount(container, 1);
+    expect(composerText(container)).toContain('owner/repo-c');
+    const turn = await sendPrompt(container, 'Inspect this repository');
+    expect(turn.input.candidateContract).toEqual(selectedRepository('owner/repo-c'));
+    expect(turn.input.binding).toBeUndefined();
+    expect(turn.input.baseRevision).toBe(0);
+    expect(turn.input.history).toEqual([]);
+  });
+
+  it('starts a fresh conversation when an idle bound repository changes', async () => {
+    const repositoryA = selectedRepository('owner/repo-a');
+    const container = await mountHarness(repositoryA);
+    const first = await sendPrompt(container, 'Inspect repository A');
+    await bindAndComplete(first, conversationBinding(repositoryA, 'a'));
+
+    await click(actionButton(container, 'select-repo-b'));
+    await flushEffects();
+
+    await expectSessionCount(container, 2);
+    expect(composerText(container)).toContain('owner/repo-b');
+    const second = await sendPrompt(container, 'Inspect repository B');
+    expect(second.input.sessionId).not.toBe(first.input.sessionId);
+    expect(second.input.baseRevision).toBe(0);
+    expect(second.input.history).toEqual([]);
+    expect(second.input.candidateContract).toEqual(selectedRepository('owner/repo-b'));
+    expect(second.input.binding).toBeUndefined();
+  });
+
+  it('keeps the latest busy-time selection and rotates after the turn settles', async () => {
+    const repositoryA = selectedRepository('owner/repo-a');
+    const container = await mountHarness(repositoryA);
+    const first = await sendPrompt(container, 'Inspect repository A');
+    await bindTurn(first, conversationBinding(repositoryA, 'b'));
+
+    await click(actionButton(container, 'select-repo-b'));
+    await click(actionButton(container, 'select-repo-c'));
+    expect(turns).toHaveLength(1);
+    expect(composerText(container)).toContain('owner/repo-a');
+
+    await completeTurn(first);
+    await flushEffects();
+
+    expect(composerText(container)).toContain('owner/repo-c');
+    const second = await sendPrompt(container, 'Inspect the latest selection');
+    expect(second.input.sessionId).not.toBe(first.input.sessionId);
+    expect(second.input.candidateContract).toEqual(selectedRepository('owner/repo-c'));
+    expect(second.input.binding).toBeUndefined();
+  });
+
+  it('blocks stale-scope chat while the workbench owns the bound session', async () => {
+    presentationMocks.ownsWorkbench = true;
+    const repositoryA = selectedRepository('owner/repo-a');
+    const container = await mountHarness(repositoryA);
+    const first = await sendPrompt(container, 'Inspect repository A');
+    await bindAndComplete(first, conversationBinding(repositoryA, 'd'));
+
+    await click(actionButton(container, 'select-repo-b'));
+    await flushEffects();
+
+    expect(container.querySelector<HTMLTextAreaElement>('textarea')?.disabled).toBe(true);
+    expect(container.textContent).toContain(
+      'Selected owner/repo-b · finish or discard the current Organize run to switch conversations',
+    );
+    expect(turns).toHaveLength(1);
+  });
+
+  it('does not rotate a bound current-view conversation when its filters change', async () => {
+    const initialView = currentView('alpha');
+    const container = await mountHarness(initialView);
+    const first = await sendPrompt(container, 'Inspect this view');
+    const binding = conversationBinding(initialView, 'c');
+    await bindAndComplete(first, binding);
+
+    await click(actionButton(container, 'update-current-view'));
+    await flushEffects();
+
+    await expectSessionCount(container, 1);
+    const second = await sendPrompt(container, 'Continue inspecting this view');
+    expect(second.input.sessionId).toBe(first.input.sessionId);
+    expect(second.input.baseRevision).toBe(1);
+    expect(second.input.candidateContract).toBeUndefined();
+    expect(second.input.binding).toEqual(binding);
+  });
+});
+
+function Harness({ initialCandidate }: { initialCandidate: BgsmAgentConversationCandidate }) {
+  const [candidate, setCandidate] = useState(initialCandidate);
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="select-repo-b"
+        onClick={() => setCandidate(selectedRepository('owner/repo-b'))}
+      >
+        Select B
+      </button>
+      <button
+        type="button"
+        data-testid="select-repo-c"
+        onClick={() => setCandidate(selectedRepository('owner/repo-c'))}
+      >
+        Select C
+      </button>
+      <button
+        type="button"
+        data-testid="update-current-view"
+        onClick={() => setCandidate(currentView('beta'))}
+      >
+        Update view
+      </button>
+      <AgentHost
+        open
+        onHide={() => {}}
+        onPresentationChange={() => {}}
+        defaultCandidate={candidate}
+        chatCandidate={candidate}
+        scopeCount={candidate.kind === 'selected_repository' ? 1 : 2}
+      />
+    </>
+  );
+}
+
+async function mountHarness(initialCandidate: BgsmAgentConversationCandidate) {
+  const container = mountReact(<Harness initialCandidate={initialCandidate} />, mountedRoots);
+  await flushEffects();
+  return container;
+}
+
+async function sendPrompt(container: HTMLElement, prompt: string): Promise<CapturedTurn> {
+  const textarea = container.querySelector<HTMLTextAreaElement>('textarea');
+  if (!textarea) throw new Error('Agent composer not found.');
+  await setTextareaValue(textarea, prompt);
+  await click(container.querySelector<HTMLButtonElement>('button[aria-label="Send"]')!);
+  const turn = turns.at(-1);
+  if (!turn) throw new Error('Agent turn did not start.');
+  return turn;
+}
+
+async function bindAndComplete(
+  turn: CapturedTurn,
+  binding: BgsmAgentConversationBinding,
+): Promise<void> {
+  await act(async () => {
+    turn.handlers.onEvent?.({
+      ...deliveryIdentity(turn.input),
+      type: 'conversation_bound',
+      binding,
+    });
+    deliverTurnResult(turn);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function bindTurn(
+  turn: CapturedTurn,
+  binding: BgsmAgentConversationBinding,
+): Promise<void> {
+  await act(async () => {
+    turn.handlers.onEvent?.({
+      ...deliveryIdentity(turn.input),
+      type: 'conversation_bound',
+      binding,
+    });
+    await Promise.resolve();
+  });
+}
+
+async function completeTurn(turn: CapturedTurn): Promise<void> {
+  await act(async () => {
+    deliverTurnResult(turn);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function deliverTurnResult(turn: CapturedTurn): void {
+  turn.handlers.onResult?.({
+    ...deliveryIdentity(turn.input),
+    reason: 'final_answer',
+    changed: false,
+    changedCount: 0,
+    newMessages: [
+      {
+        id: `${turn.input.turnAttemptId}:user`,
+        role: 'user',
+        content: turn.input.prompt,
+        createdAt: 1,
+      },
+      {
+        id: `${turn.input.turnAttemptId}:assistant`,
+        role: 'agent',
+        content: 'Done.',
+        createdAt: 2,
+      },
+    ],
+  });
+}
+
+function deliveryIdentity(input: BgsmAgentTurnInput) {
+  return {
+    turnAttemptId: input.turnAttemptId,
+    sessionId: input.sessionId,
+    baseRevision: input.baseRevision,
+  };
+}
+
+function conversationBinding(
+  candidateContract: BgsmAgentConversationCandidate,
+  fingerprintCharacter: string,
+): BgsmAgentConversationBinding {
+  return {
+    version: 1,
+    candidateContract,
+    scopeFingerprint: parseScopeFingerprintV1(
+      `fs:v1:${fingerprintCharacter.repeat(43)}`,
+    ),
+    label: candidateContract.kind === 'selected_repository'
+      ? candidateContract.selectedRepositoryIdHint
+      : 'Current view',
+    count: candidateContract.kind === 'selected_repository' ? 1 : 2,
+    providerFingerprint: `pcf:v1:${'p'.repeat(43)}`,
+  };
+}
+
+function selectedRepository(selectedRepositoryIdHint: string): BgsmAgentConversationCandidate {
+  return { kind: 'selected_repository', selectedRepositoryIdHint };
+}
+
+function currentView(query: string): BgsmAgentConversationCandidate {
+  return {
+    kind: 'current_view',
+    filter: {
+      query,
+      languages: [],
+      tags: [],
+      tagMode: 'any',
+      showTombstone: false,
+      onlyFavorite: false,
+      onlyUntagged: false,
+      onlyArchived: false,
+      sortKey: 'starred_at',
+      sortDir: 'desc',
+    },
+  };
+}
+
+function actionButton(container: HTMLElement, testId: string): HTMLButtonElement {
+  const button = container.querySelector<HTMLButtonElement>(`[data-testid="${testId}"]`);
+  if (!button) throw new Error(`Action button not found: ${testId}`);
+  return button;
+}
+
+async function expectSessionCount(container: HTMLElement, count: number): Promise<void> {
+  const toggle = container.querySelector<HTMLButtonElement>('[data-testid="agent-session-toggle"]');
+  if (!toggle) throw new Error('Session menu toggle not found.');
+  await click(toggle);
+  expect(container.querySelectorAll('[data-testid="agent-session-item"]')).toHaveLength(count);
+  await click(toggle);
+}
+
+function composerText(container: HTMLElement): string {
+  return container.querySelector('textarea')?.closest('form')?.textContent ?? '';
+}
+
+async function setTextareaValue(textarea: HTMLTextAreaElement, value: string): Promise<void> {
+  await act(async () => {
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      'value',
+    )?.set;
+    valueSetter?.call(textarea, value);
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    textarea.dispatchEvent(new Event('change', { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}

--- a/tests/unit/agent-host-repository-selection.test.tsx
+++ b/tests/unit/agent-host-repository-selection.test.tsx
@@ -24,6 +24,9 @@ const messagingMocks = vi.hoisted(() => ({
 const presentationMocks = vi.hoisted(() => ({
   ownsWorkbench: false,
 }));
+const workbenchMocks = vi.hoisted(() => ({
+  releaseOwnership: null as (() => void) | null,
+}));
 
 vi.mock('@/utils/messaging', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/utils/messaging')>();
@@ -53,6 +56,18 @@ vi.mock('@/ui/agent-ui-presentation', async (importOriginal) => {
   };
 });
 
+vi.mock('@/ui/hooks/use-bgsm-agent-workbench', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/ui/hooks/use-bgsm-agent-workbench')>();
+  return {
+    ...actual,
+    useBgsmAgentWorkbench: (...args: Parameters<typeof actual.useBgsmAgentWorkbench>) => {
+      const workbench = actual.useBgsmAgentWorkbench(...args);
+      workbenchMocks.releaseOwnership = workbench.clearTerminal;
+      return workbench;
+    },
+  };
+});
+
 type CapturedTurn = Readonly<{
   input: BgsmAgentTurnInput;
   handlers: BgsmAgentTurnHandlers;
@@ -64,6 +79,7 @@ let turns: CapturedTurn[];
 beforeEach(() => {
   turns = [];
   presentationMocks.ownsWorkbench = false;
+  workbenchMocks.releaseOwnership = null;
   messagingMocks.startBgsmAgentTurn.mockReset();
   messagingMocks.startBgsmAgentTurn.mockImplementation((
     input: BgsmAgentTurnInput,
@@ -155,6 +171,13 @@ describe('AgentHost repository selection', () => {
       'Selected owner/repo-b · finish or discard the current Organize run to switch conversations',
     );
     expect(turns).toHaveLength(1);
+
+    await releaseWorkbenchOwnership();
+    await flushEffects();
+
+    await expectSessionCount(container, 2);
+    expect(composerText(container)).toContain('owner/repo-b');
+    expect(container.querySelector<HTMLTextAreaElement>('textarea')?.disabled).toBe(false);
   });
 
   it('does not rotate a bound current-view conversation when its filters change', async () => {
@@ -217,6 +240,16 @@ async function mountHarness(initialCandidate: BgsmAgentConversationCandidate) {
   const container = mountReact(<Harness initialCandidate={initialCandidate} />, mountedRoots);
   await flushEffects();
   return container;
+}
+
+async function releaseWorkbenchOwnership(): Promise<void> {
+  const releaseOwnership = workbenchMocks.releaseOwnership;
+  if (!releaseOwnership) throw new Error('Workbench release callback not found.');
+  await act(async () => {
+    presentationMocks.ownsWorkbench = false;
+    releaseOwnership();
+    await Promise.resolve();
+  });
 }
 
 async function sendPrompt(container: HTMLElement, prompt: string): Promise<CapturedTurn> {

--- a/tests/unit/agent-panel.test.tsx
+++ b/tests/unit/agent-panel.test.tsx
@@ -11,6 +11,7 @@ import { createAgentWorkbenchState, type AgentWorkbenchState } from '@/ui/agent-
 import { cleanupMountedRootsAndBody, click, mountReact, type MountedRoot } from './test-utils';
 import type { BgsmAgentTurnHandlers, BgsmOrganizeJobPresentation } from '@/utils/messaging';
 import type { BgsmAgentTurnInput } from '@/bgsm-agent/session';
+import type { BgsmAgentConversationCandidate } from '@/bgsm-agent/conversation-binding';
 import {
   createFrozenScope,
   parseScopeFingerprintV1,
@@ -57,6 +58,7 @@ function AgentPanel({
   handoff = null,
   onDismissHandoff,
   defaultCandidate = { kind: 'all_live_stars' },
+  blockedConversationCandidate = null,
   scopeCount,
   workbenchState,
   onClearTerminal,
@@ -69,6 +71,7 @@ function AgentPanel({
   handoff?: { remainingUntagged: number; autoTagged: number } | null;
   onDismissHandoff?: () => void;
   defaultCandidate?: LaunchCandidateContract;
+  blockedConversationCandidate?: BgsmAgentConversationCandidate | null;
   scopeCount?: number;
   workbenchState?: AgentWorkbenchState;
   onClearTerminal?: () => void;
@@ -113,6 +116,7 @@ function AgentPanel({
       agent={agent}
       workbench={workbench}
       defaultCandidate={defaultCandidate}
+      blockedConversationCandidate={blockedConversationCandidate}
       scopeCount={scopeCount}
       handoff={handoff}
       onDismissHandoff={onDismissHandoff}
@@ -136,6 +140,30 @@ afterEach(() => {
 });
 
 describe('AgentPanel', () => {
+  it('blocks chat from using the old scope while an Organize-owned session waits to switch', async () => {
+    const container = await mountAgentPanel(
+      <AgentPanel
+        open
+        onClose={vi.fn()}
+        defaultCandidate={{
+          kind: 'selected_repository',
+          selectedRepositoryIdHint: 'owner/repo-b',
+        }}
+        blockedConversationCandidate={{
+          kind: 'selected_repository',
+          selectedRepositoryIdHint: 'owner/repo-b',
+        }}
+      />,
+    );
+
+    const textarea = container.querySelector<HTMLTextAreaElement>('textarea');
+    expect(textarea?.disabled).toBe(true);
+    expect(container.textContent).toContain(
+      'Selected owner/repo-b · finish or discard the current Organize run to switch conversations',
+    );
+    expect(messagingMocks.startBgsmAgentTurn).not.toHaveBeenCalled();
+  });
+
   it('opens the single Cubby settings surface without starting a request', async () => {
     const onOpenOptions = vi.fn();
     const container = await mountAgentPanel(
@@ -2902,6 +2930,53 @@ describe('AgentPanel', () => {
       }
     },
   );
+
+  it('blocks an internal context retry after repository context changes', async () => {
+    const turns: Array<{ input: BgsmAgentTurnInput; handlers: BgsmAgentTurnHandlers }> = [];
+    messagingMocks.startBgsmAgentTurn.mockImplementation((input, handlers) => {
+      turns.push({ input, handlers });
+      return { stop: vi.fn(), acknowledge: vi.fn() };
+    });
+    const initial = (
+      <AgentPanel open onClose={vi.fn()} />
+    );
+    const container = await mountAgentPanel(initial);
+    const prompt = 'Continue inspecting repository A';
+    await setTextareaValue(container.querySelector<HTMLTextAreaElement>('textarea')!, prompt);
+    await click(container.querySelector<HTMLButtonElement>('button[aria-label="Send"]')!);
+    await act(async () => {
+      turns[0].handlers.onResult?.({
+        ...deliveryIdentity(turns[0].input),
+        reason: 'context_limit',
+        contextFailureReason: 'tool_result_memory_limit',
+        changed: false,
+        changedCount: 0,
+        newMessages: [],
+      });
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      mountedRoots.at(-1)?.render(
+        <AgentPanel
+          open
+          onClose={vi.fn()}
+          blockedConversationCandidate={{
+            kind: 'selected_repository',
+            selectedRepositoryIdHint: 'owner/repo-b',
+          }}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    const retry = [...container.querySelectorAll<HTMLButtonElement>('button')]
+      .find((button) => button.textContent?.trim() === 'Retry');
+    expect(retry?.disabled).toBe(true);
+    expect(container.textContent).toContain('Selected owner/repo-b');
+    await click(retry!);
+    expect(turns).toHaveLength(1);
+  });
 
   it('unlocks prompt editing after an internal memory terminal with a committed write', async () => {
     const turns: Array<{ input: BgsmAgentTurnInput; handlers: BgsmAgentTurnHandlers }> = [];

--- a/tests/unit/background-agent-turn-contract.test.ts
+++ b/tests/unit/background-agent-turn-contract.test.ts
@@ -31,6 +31,9 @@ describe('background agent turn contract', () => {
     assert.match(backgroundSource, /createBgsmAgentToolRegistry\(\{[\s\S]*?repositoryScope,/);
     assert.match(backgroundSource, /const scopeFingerprint = conversation\.binding\.scopeFingerprint/);
     assert.match(backgroundSource, /createBgsmAgentToolRegistry\(\{[\s\S]*?scopeFingerprint,/);
+    assert.match(backgroundSource, /createBgsmAgentTagAssignmentPolicy\(agentConfig, async \(\) =>/);
+    assert.match(backgroundSource, /storedTags\.map\(\(tag\) => normalizeStoredTag\(tag as LegacyTagRow\)\)/);
+    assert.match(backgroundSource, /createBgsmAgentToolRegistry\(\{[\s\S]*?tagAssignmentPolicy,/);
     assert.match(backgroundSource, /scopeLabel,/);
     assert.match(backgroundSource, /repositoryCodeRefAuthorityFor\(/);
     assert.match(backgroundSource, /repositoryCodeRefAuthority,/);

--- a/tests/unit/bgsm-agent-organize-job.test.ts
+++ b/tests/unit/bgsm-agent-organize-job.test.ts
@@ -37,11 +37,14 @@ import { parseProposalId, parseRunId } from '@/bgsm-agent/identity';
 import {
   createEmptyRunBudgetUsage,
   createLowerTestRunBudget,
+  createOrganizeTagPolicySnapshot,
   createProductionRunBudget,
+  reconcileOrganizeTagCoverage,
 } from '@/bgsm-agent/policy';
 import {
   parseSourceFingerprintV1,
   parseTaxonomyFingerprintV1,
+  type AnalyzerBatchProposalRow,
 } from '@/bgsm-agent/proposal';
 import {
   createFrozenScope,
@@ -371,7 +374,10 @@ describe('OrganizeProposalAnalyzer', () => {
   });
 
   it('binds the proposal schema to the immutable batch and its exact row count', () => {
-    const batch = analyzerBatch(['a/a', 'b/b']);
+    const batch = analyzerBatch(['a/a', 'b/b'], {
+      maxTagsPerRepo: 2,
+      minTopicRepoCount: 3,
+    });
     const prepared = new OrganizeProposalAnalyzer({ provider: preparedProvider([]) })
       .prepareAttempt(batch);
     const request = JSON.parse(prepared.serializedRequestBody) as {
@@ -411,7 +417,7 @@ describe('OrganizeProposalAnalyzer', () => {
     expect(properties.rows.items.properties.classifications.oneOf).toMatchObject([
       {
         minItems: 1,
-        maxItems: 5,
+        maxItems: 2,
         items: { properties: { kind: { enum: ['add_existing_tag', 'propose_new_tag'] } } },
       },
       {
@@ -420,6 +426,39 @@ describe('OrganizeProposalAnalyzer', () => {
         items: { properties: { kind: { enum: ['unchanged', 'insufficient_evidence'] } } },
       },
     ]);
+  });
+
+  it('rejects provider output above the snapshotted per-repository tag limit', async () => {
+    const batch = analyzerBatch(['a/a'], {
+      maxTagsPerRepo: 2,
+      minTopicRepoCount: 3,
+    });
+    const row = {
+      ...analyzerRow(0, 'a/a'),
+      classifications: ['infra', 'backend', 'tooling'].map((tag) => ({
+        kind: 'propose_new_tag' as const,
+        tag,
+        evidence: `${tag} evidence.`,
+      })),
+    };
+    const response: ModelResponse = {
+      finishReason: 'tool_calls',
+      toolCalls: [{
+        id: 'call-over-limit',
+        name: 'submit_semantic_tag_batch_proposal',
+        arguments: analyzerProposal([row]),
+      }],
+    };
+    const prepared = new OrganizeProposalAnalyzer({ provider: preparedProvider([response]) })
+      .prepareAttempt(batch);
+
+    await expect(prepared.execute()).rejects.toMatchObject({
+      failureKind: 'output_contract',
+      diagnostic: {
+        rejectionCode: 'classification',
+        schemaViolation: 'Proposal classifications exceeded the snapshotted per-repository tag limit.',
+      },
+    });
   });
 
   it('uses a silent Responses prepared request for one validated proposal tool call', async () => {
@@ -1412,6 +1451,81 @@ describe('OrganizeJobRun scheduler and row universes', () => {
     expect(result.nextFrozenIndex).toBe(4);
   });
 
+  it('reconciles canonical tag coverage across all analyzer pages before review', () => {
+    const ids = ['a/a', 'b/b', 'c/c', 'd/d'];
+    const tagPolicy = { maxTagsPerRepo: 2, minTopicRepoCount: 3 };
+    const taxonomy = buildSemanticTaxonomyDto([]);
+    const action = (tag: string) => ({
+      kind: 'propose_new_tag' as const,
+      tag,
+      evidence: `${tag} evidence.`,
+    });
+    let state = plannedState(analysisState(ids, createProductionRunBudget(), tagPolicy), 2);
+    state = finalizeAnalyzerBatch({
+      state,
+      positions: [livePosition(0, ids[0]), livePosition(1, ids[1])],
+      proposal: analyzerProposal([
+        { ...analyzerRow(0, ids[0]), classifications: [action('Shared'), action('Rare')] },
+        { ...analyzerRow(1, ids[1]), classifications: [action('shared')] },
+      ]),
+      taxonomy,
+      taxonomyFingerprint: TAXONOMY_FINGERPRINT,
+    }).state;
+    expect(state.status).toBe('analyzing');
+
+    state = plannedState(state, 2);
+    state = finalizeAnalyzerBatch({
+      state,
+      positions: [livePosition(2, ids[2]), livePosition(3, ids[3])],
+      proposal: analyzerProposal([
+        { ...analyzerRow(2, ids[2]), classifications: [action('SHARED')] },
+        { ...analyzerRow(3, ids[3]), classifications: [action('rare')] },
+      ]),
+      taxonomy,
+      taxonomyFingerprint: TAXONOMY_FINGERPRINT,
+    }).state;
+
+    expect(state.status).toBe('review');
+    expect(state.actionableProposalRows.map((row) => ({
+      frozenIndex: row.frozenIndex,
+      tags: row.actions.map((entry) => entry.tag),
+    }))).toEqual([
+      { frozenIndex: 0, tags: ['Shared'] },
+      { frozenIndex: 1, tags: ['shared'] },
+      { frozenIndex: 2, tags: ['SHARED'] },
+    ]);
+    expect(state.nonActionableAnalysisOutcomes).toEqual([
+      { frozenIndex: 3, repositoryId: 'd/d', kind: 'insufficient_evidence' },
+    ]);
+    expect(state.analyzedFrozenPositions[3]?.classification).toBe('non_actionable');
+    expect(JSON.stringify(createOrganizeProposal(state))).not.toContain('Rare');
+  });
+
+  it('counts canonical tag coverage at most once per repository', () => {
+    const action = (tag: string) => ({
+      kind: 'propose_new_tag' as const,
+      tag,
+      evidence: 'Evidence.',
+    });
+    const reconciled = reconcileOrganizeTagCoverage([
+      { repositoryId: 'a/a', actions: [action('Shared'), action('shared')] },
+      { repositoryId: 'b/b', actions: [action('SHARED')] },
+    ], createOrganizeTagPolicySnapshot({ minTopicRepoCount: 3 }));
+
+    expect(reconciled).toEqual([[], []]);
+    expect(createOrganizeTagPolicySnapshot(undefined)).toEqual({
+      maxTagsPerRepo: 5,
+      minTopicRepoCount: 3,
+    });
+    expect(createOrganizeTagPolicySnapshot({
+      maxTagsPerRepo: 50,
+      minTopicRepoCount: '4',
+    })).toEqual({
+      maxTagsPerRepo: 5,
+      minTopicRepoCount: 4,
+    });
+  });
+
   it('analyzes all actionable rows beyond 100 before entering review', () => {
     const ids = Array.from({ length: 102 }, (_, index) => `owner/repo-${index}`);
     let state = analysisState(ids);
@@ -1475,12 +1589,14 @@ describe('OrganizeJobRun scheduler and row universes', () => {
 function analysisState(
   ids: readonly string[],
   budget = createProductionRunBudget(),
+  tagPolicy = { maxTagsPerRepo: 5, minTopicRepoCount: 1 },
 ): OrganizeJobRunAnalysisState {
   return createOrganizeJobRunAnalysisState({
     runId: RUN_ID,
     generation: 1,
     proposalId: PROPOSAL_ID,
     frozenScope: frozenScope(ids),
+    tagPolicy,
     budget,
   });
 }
@@ -1531,13 +1647,17 @@ function livePosition(frozenIndex: number, repositoryId: string): OrganizeJobRun
   };
 }
 
-function analyzerBatch(ids: readonly string[]): SemanticAnalyzerBatch {
+function analyzerBatch(
+  ids: readonly string[],
+  tagPolicy = { maxTagsPerRepo: 5, minTopicRepoCount: 1 },
+): SemanticAnalyzerBatch {
   return {
     version: 1,
     runId: RUN_ID,
     generation: 1,
     scopeFingerprint: SCOPE_FINGERPRINT,
     taskInstruction: 'Classify repositories.',
+    tagPolicy,
     repositories: ids.map((id, index) =>
       (livePosition(index, id) as Extract<OrganizeJobRunPagePosition, { kind: 'live' }>).repository),
     taxonomy: buildSemanticTaxonomyDto([
@@ -1555,7 +1675,7 @@ function analyzerRow(frozenIndex: number, repositoryId: string) {
   };
 }
 
-function analyzerProposal(rows: ReturnType<typeof analyzerRow>[]) {
+function analyzerProposal(rows: readonly AnalyzerBatchProposalRow[]) {
   return {
     version: 1 as const,
     runId: RUN_ID,
@@ -1565,7 +1685,7 @@ function analyzerProposal(rows: ReturnType<typeof analyzerRow>[]) {
   };
 }
 
-function analyzerResponse(rows: ReturnType<typeof analyzerRow>[]): ModelResponse {
+function analyzerResponse(rows: readonly AnalyzerBatchProposalRow[]): ModelResponse {
   return {
     finishReason: 'tool_calls',
     toolCalls: [{

--- a/tests/unit/bgsm-agent-tag-assignment-policy.test.ts
+++ b/tests/unit/bgsm-agent-tag-assignment-policy.test.ts
@@ -1,0 +1,349 @@
+import 'fake-indexeddb/auto';
+import assert from 'node:assert/strict';
+import { describe, it } from 'vitest';
+import { createBgsmAgentTools } from '@/bgsm-agent/tools';
+import {
+  buildBgsmAgentTagCoverageSnapshot,
+  createBgsmAgentTagAssignmentPolicy,
+  prospectiveBgsmAgentTagCoverage,
+} from '@/bgsm-agent/tag-assignment-policy';
+import type { Star, Tag, TagMeta } from '@/types';
+
+const timestamp = '2026-08-01T00:00:00.000Z';
+
+function star(
+  fullName: string,
+  topics: string[] = [],
+  tombstone = false,
+): Star {
+  return {
+    full_name: fullName,
+    html_url: `https://github.com/${fullName}`,
+    description: '',
+    language: null,
+    stargazers_count: 1,
+    topics,
+    pushed_at: timestamp,
+    created_at: timestamp,
+    fork: false,
+    archived: false,
+    starred_at: timestamp,
+    tombstone,
+    synced_at: timestamp,
+  };
+}
+
+function tag(
+  fullName: string,
+  layers: Readonly<{
+    manual?: string[];
+    auto?: string[];
+    dismissed?: string[];
+  }> = {},
+): Tag {
+  return {
+    full_name: fullName,
+    manualTags: layers.manual ?? [],
+    autoTags: layers.auto ?? [],
+    dismissedAutoTags: layers.dismissed ?? [],
+    manualTagsMtime: timestamp,
+    autoTagsMtime: timestamp,
+    dismissedAutoTagsMtime: timestamp,
+    notes: '',
+    favorite: false,
+    mtime: timestamp,
+  };
+}
+
+function tagMeta(name: string, excluded: boolean): TagMeta {
+  return {
+    name,
+    dimension: null,
+    color: null,
+    excluded,
+    mtime: timestamp,
+  };
+}
+
+function assignmentTool(options: Parameters<typeof createBgsmAgentTools>[0]) {
+  const tool = createBgsmAgentTools(options)
+    .find((candidate) => candidate.name === 'assign_repo_tags');
+  assert.ok(tool);
+  return tool;
+}
+
+describe('Cubby Chat tag assignment policy', () => {
+  it('snapshots normalized preferences and loads library coverage lazily', async () => {
+    let loads = 0;
+    const policy = createBgsmAgentTagAssignmentPolicy(
+      { maxTagsPerRepo: '8', minTopicRepoCount: '3' },
+      () => {
+        loads += 1;
+        return { stars: [], tags: [], tagMeta: [] };
+      },
+    );
+
+    assert.equal(policy.maxTagsPerRepo, 8);
+    assert.equal(policy.minRepoCount, 3);
+    assert.equal(loads, 0);
+    const [first, second] = await Promise.all([
+      policy.loadCoverage(),
+      policy.loadCoverage(),
+    ]);
+    assert.strictEqual(first, second);
+    assert.equal(loads, 1);
+
+    policy.invalidateCoverage();
+    assert.notStrictEqual(await policy.loadCoverage(), first);
+    assert.equal(loads, 2);
+  });
+
+  it('unions topics and visible tags by canonical live-repository coverage', () => {
+    const coverage = buildBgsmAgentTagCoverageSnapshot({
+      stars: [
+        star('one/repo', ['React', 'third', 'build']),
+        star('two/repo'),
+        star('target/repo'),
+        star('dismissed/repo'),
+        star('dead/repo', ['third'], true),
+      ],
+      tags: [
+        tag('one/repo', { manual: ['Ｒｅａｃｔ'], auto: ['BUILD'] }),
+        tag('two/repo', { manual: ['ＴＨＩＲＤ'], auto: ['react'] }),
+        tag('dismissed/repo', { dismissed: ['third'] }),
+        tag('dead/repo', { manual: ['third'] }),
+        tag('missing/repo', { manual: ['third'] }),
+      ],
+      tagMeta: [tagMeta('ＢＵＩＬＤ', true)],
+    });
+
+    assert.deepEqual([...coverage.repositoriesByTag.get('react') ?? []].sort(), [
+      'one/repo',
+      'two/repo',
+    ]);
+    assert.deepEqual([...coverage.repositoriesByTag.get('third') ?? []].sort(), [
+      'one/repo',
+      'two/repo',
+    ]);
+    assert.equal(coverage.repositoriesByTag.has('build'), false);
+    assert.equal(coverage.visibleTagsByRepository.get('dismissed/repo')?.has('third'), false);
+    assert.equal(coverage.visibleTagsByRepository.has('missing/repo'), false);
+    assert.equal(prospectiveBgsmAgentTagCoverage(coverage, 'target/repo', 'ＴＨＩＲＤ'), 3);
+    assert.equal(prospectiveBgsmAgentTagCoverage(coverage, 'one/repo', 'third'), 2);
+    assert.equal(prospectiveBgsmAgentTagCoverage(coverage, 'target/repo', 'build'), 0);
+  });
+
+  it('enforces dynamic schema and cumulative per-turn limits above and below five', async () => {
+    const writes: string[][] = [];
+    const lowPolicy = createBgsmAgentTagAssignmentPolicy(
+      { maxTagsPerRepo: 2, minTopicRepoCount: 1 },
+      () => ({ stars: [], tags: [], tagMeta: [] }),
+    );
+    const low = assignmentTool({
+      repositoryScope: ['owner/repo'],
+      tagAssignmentPolicy: lowPolicy,
+      assignManualTags: async (_fullName, tags) => {
+        writes.push([...tags]);
+        return { manualTags: [...tags], changed: true, reason: null };
+      },
+    });
+
+    assert.throws(() => low.validate?.({
+      full_name: 'owner/repo',
+      tags: ['one', 'two', 'three'],
+    }), /at most 2 tags/u);
+    const calls = ['one', 'two', 'three'].map((name, index) => low.execute(
+      low.validate?.({ full_name: 'owner/repo', tags: [name] }),
+      { sessionId: 'limit', callId: `limit-${index}` },
+    ));
+    const results = await Promise.allSettled(calls);
+    assert.deepEqual(results.map((result) => result.status), [
+      'fulfilled',
+      'fulfilled',
+      'rejected',
+    ]);
+    assert.match(String((results[2] as PromiseRejectedResult).reason), /at most 2 tags/u);
+    assert.deepEqual(writes, [['one'], ['two']]);
+
+    const high = assignmentTool({
+      repositoryScope: ['owner/repo'],
+      tagAssignmentPolicy: createBgsmAgentTagAssignmentPolicy(
+        { maxTagsPerRepo: 8, minTopicRepoCount: 1 },
+        () => ({ stars: [], tags: [], tagMeta: [] }),
+      ),
+    });
+    const parameters = high.parameters as {
+      properties: { tags: { maxItems: number } };
+    };
+    assert.equal(parameters.properties.tags.maxItems, 8);
+    const validated = high.validate?.({
+      full_name: 'owner/repo',
+      tags: ['one', 'two', 'three', 'four', 'five', 'six'],
+    }) as { tags: string[] };
+    assert.equal(validated.tags.length, 6);
+  });
+
+  it('does not consume the turn limit when the writer rejects the repository', async () => {
+    let attempts = 0;
+    const assign = assignmentTool({
+      repositoryScope: ['owner/repo'],
+      tagAssignmentPolicy: createBgsmAgentTagAssignmentPolicy(
+        { maxTagsPerRepo: 1, minTopicRepoCount: 1 },
+        () => ({ stars: [], tags: [], tagMeta: [] }),
+      ),
+      assignManualTags: async (_fullName, tags) => {
+        attempts += 1;
+        if (attempts === 1) {
+          return { manualTags: [], changed: false, reason: 'missing' };
+        }
+        return { manualTags: [...tags], changed: true, reason: null };
+      },
+    });
+
+    const first = await assign.execute(
+      assign.validate?.({ full_name: 'owner/repo', tags: ['first'] }),
+      { sessionId: 'failed-write', callId: 'failed-write-1' },
+    ) as { reason: string | null };
+    assert.equal(first.reason, 'missing');
+    await assign.execute(
+      assign.validate?.({ full_name: 'owner/repo', tags: ['second'] }),
+      { sessionId: 'failed-write', callId: 'failed-write-2' },
+    );
+    await assert.rejects(
+      () => assign.execute(
+        assign.validate?.({ full_name: 'owner/repo', tags: ['third'] }),
+        { sessionId: 'failed-write', callId: 'failed-write-3' },
+      ),
+      /at most 1 tags/u,
+    );
+    assert.equal(attempts, 2);
+  });
+
+  it('checks only new effects and rejects a mixed ineligible batch before writing', async () => {
+    const library = {
+      stars: [star('one/repo'), star('two/repo'), star('target/repo')],
+      tags: [
+        tag('one/repo', { manual: ['shared'] }),
+        tag('two/repo', { auto: ['ＳＨＡＲＥＤ'] }),
+        tag('target/repo', { manual: ['rare'] }),
+      ],
+      tagMeta: [],
+    };
+    const writes: string[][] = [];
+    const assign = assignmentTool({
+      repositoryScope: ['target/repo'],
+      tagAssignmentPolicy: createBgsmAgentTagAssignmentPolicy(
+        { maxTagsPerRepo: 5, minTopicRepoCount: 3 },
+        () => library,
+      ),
+      assignManualTags: async (_fullName, tags) => {
+        writes.push([...tags]);
+        return { manualTags: [...tags], changed: true, reason: null };
+      },
+    });
+
+    await assign.execute(
+      assign.validate?.({ full_name: 'target/repo', tags: ['rare', 'shared'] }),
+      { sessionId: 'coverage', callId: 'coverage-1' },
+    );
+    await assert.rejects(
+      () => assign.execute(
+        assign.validate?.({ full_name: 'target/repo', tags: ['shared', 'novel'] }),
+        { sessionId: 'coverage', callId: 'coverage-2' },
+      ),
+      /minimum live-repository coverage of 3.*novel/u,
+    );
+    assert.deepEqual(writes, [['rare', 'shared']]);
+
+    let minOneWrites = 0;
+    const minOne = assignmentTool({
+      repositoryScope: ['target/repo'],
+      tagAssignmentPolicy: createBgsmAgentTagAssignmentPolicy(
+        { maxTagsPerRepo: 5, minTopicRepoCount: 1 },
+        () => ({ stars: [], tags: [], tagMeta: [] }),
+      ),
+      assignManualTags: async (_fullName, tags) => {
+        minOneWrites += 1;
+        return { manualTags: [...tags], changed: true, reason: null };
+      },
+    });
+    await minOne.execute(
+      minOne.validate?.({ full_name: 'target/repo', tags: ['novel'] }),
+      { sessionId: 'min-one', callId: 'min-one-1' },
+    );
+    assert.equal(minOneWrites, 1);
+  });
+
+  it('reloads coverage after repository removals and global deletions', async () => {
+    const stars = [
+      star('one/repo'),
+      star('two/repo'),
+      star('three/repo'),
+      star('target/repo'),
+    ];
+    let tags = [
+      tag('one/repo', { manual: ['shared'] }),
+      tag('two/repo', { manual: ['shared'] }),
+      tag('three/repo', { manual: ['shared'] }),
+    ];
+    let tagMetaRows: TagMeta[] = [];
+    let loads = 0;
+    let assignmentWrites = 0;
+    const policy = createBgsmAgentTagAssignmentPolicy(
+      { maxTagsPerRepo: 5, minTopicRepoCount: 3 },
+      () => {
+        loads += 1;
+        return { stars, tags, tagMeta: tagMetaRows };
+      },
+    );
+    const tools = createBgsmAgentTools({
+      repositoryScope: stars.map((item) => item.full_name),
+      tagAssignmentPolicy: policy,
+      assignManualTags: async (_fullName, submitted) => {
+        assignmentWrites += 1;
+        return { manualTags: [...submitted], changed: true, reason: null };
+      },
+      removeVisibleTags: async (changes) => {
+        const removedRepositories = new Set(changes.map((change) => change.full_name));
+        tags = tags.filter((row) => !removedRepositories.has(row.full_name));
+        return { requested: 2, changed: 2, skipped: 0, repositoriesChanged: 2 };
+      },
+      deleteTagsEverywhere: async (submitted) => {
+        tagMetaRows = submitted.map((name) => tagMeta(name, true));
+        return { requestedTags: submitted.length, assignmentsRemoved: 1, repositoriesChanged: 1 };
+      },
+    });
+    const remove = tools.find((tool) => tool.name === 'remove_repo_tags');
+    const assign = tools.find((tool) => tool.name === 'assign_repo_tags');
+    const del = tools.find((tool) => tool.name === 'delete_tags_everywhere');
+    assert.ok(remove);
+    assert.ok(assign);
+    assert.ok(del);
+
+    await policy.loadCoverage();
+    assert.equal(loads, 1);
+    await remove.execute(remove.validate?.({
+      changes: [
+        { full_name: 'two/repo', tags: ['shared'] },
+        { full_name: 'three/repo', tags: ['shared'] },
+      ],
+    }), { sessionId: 'invalidate', callId: 'remove' });
+    await assert.rejects(
+      () => assign.execute(
+        assign.validate?.({ full_name: 'target/repo', tags: ['shared'] }),
+        { sessionId: 'invalidate', callId: 'assign' },
+      ),
+      /minimum live-repository coverage of 3/u,
+    );
+    assert.equal(loads, 2);
+    assert.equal(assignmentWrites, 0);
+
+    await del.execute(
+      del.validate?.({ tags: ['shared'] }),
+      { sessionId: 'invalidate', callId: 'delete' },
+    );
+    const afterDelete = await policy.loadCoverage();
+    assert.equal(loads, 3);
+    assert.equal(afterDelete.excludedTagKeys.has('shared'), true);
+  });
+});

--- a/tests/unit/bgsm-agent-tag-assignment-policy.test.ts
+++ b/tests/unit/bgsm-agent-tag-assignment-policy.test.ts
@@ -274,6 +274,49 @@ describe('Cubby Chat tag assignment policy', () => {
     assert.equal(minOneWrites, 1);
   });
 
+  it('reuses cached coverage safely across sequential successful assignments', async () => {
+    const stars = [
+      star('a/repo'),
+      star('b/repo'),
+      star('c/repo'),
+      star('d/repo'),
+    ];
+    let tags = [
+      tag('a/repo', { manual: ['shared'] }),
+      tag('b/repo', { manual: ['shared'] }),
+    ];
+    let loads = 0;
+    const writes: string[] = [];
+    const assign = assignmentTool({
+      repositoryScope: stars.map((item) => item.full_name),
+      tagAssignmentPolicy: createBgsmAgentTagAssignmentPolicy(
+        { maxTagsPerRepo: 5, minTopicRepoCount: 3 },
+        () => {
+          loads += 1;
+          return { stars, tags, tagMeta: [] };
+        },
+      ),
+      assignManualTags: async (fullName, submitted) => {
+        writes.push(fullName);
+        tags = [...tags, tag(fullName, { manual: [...submitted] })];
+        return { manualTags: [...submitted], changed: true, reason: null };
+      },
+    });
+
+    await assign.execute(
+      assign.validate?.({ full_name: 'c/repo', tags: ['shared'] }),
+      { sessionId: 'monotonic-coverage', callId: 'assign-c' },
+    );
+    await assign.execute(
+      assign.validate?.({ full_name: 'd/repo', tags: ['shared'] }),
+      { sessionId: 'monotonic-coverage', callId: 'assign-d' },
+    );
+
+    assert.deepEqual(writes, ['c/repo', 'd/repo']);
+    assert.equal(tags.length, 4);
+    assert.equal(loads, 1);
+  });
+
   it('reloads coverage after repository removals and global deletions', async () => {
     const stars = [
       star('one/repo'),

--- a/tests/unit/column-layout.test.ts
+++ b/tests/unit/column-layout.test.ts
@@ -174,6 +174,24 @@ describe('column layout editing', () => {
     expect(normalizeStoredColumnLayoutPreference(DEFAULT_COLUMN_LAYOUT)).toBeNull();
   });
 
+  it('defaults legacy layouts to owner/repo and preserves hiding the owner', () => {
+    expect(normalizeStoredColumnLayoutPreference({
+      ...DEFAULT_COLUMN_LAYOUT,
+      showRepositoryOwner: true,
+    })).toBeNull();
+
+    const ownerHidden = normalizeStoredColumnLayoutPreference({
+      ...DEFAULT_COLUMN_LAYOUT,
+      showRepositoryOwner: false,
+    });
+
+    expect(ownerHidden).toEqual({
+      ...DEFAULT_COLUMN_LAYOUT,
+      showRepositoryOwner: false,
+    });
+    expect(layoutsEqual(ownerHidden!, DEFAULT_COLUMN_LAYOUT)).toBe(false);
+  });
+
   it('keeps default order and hidden as custom when explicit widths exist', () => {
     expect(normalizeStoredColumnLayoutPreference({
       ...DEFAULT_COLUMN_LAYOUT,

--- a/tests/unit/layout-edit-chrome.test.ts
+++ b/tests/unit/layout-edit-chrome.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/i18n', () => ({
         columnFavorite: 'Favorite',
         columnNotes: 'Notes',
         lockedColumn: 'Locked',
+        showRepositoryOwner: 'Show repository owner',
       },
     },
   }),
@@ -42,6 +43,7 @@ describe('layout edit chrome interactions', () => {
   it('keeps the column menu open after internal item clicks', async () => {
     const { LayoutColumnMenu } = await import('@/ui/components/LayoutEditChrome');
     const onSetColumnHidden = vi.fn();
+    const onSetRepositoryOwnerVisible = vi.fn();
 
     const menu = LayoutColumnMenu({
       container: {} as HTMLElement,
@@ -50,6 +52,7 @@ describe('layout edit chrome interactions', () => {
       position: { left: 0, top: 0 },
       draftLayout: DEFAULT_COLUMN_LAYOUT,
       onSetColumnHidden,
+      onSetRepositoryOwnerVisible,
     });
     const buttons = elementChildren(menu);
 
@@ -58,6 +61,9 @@ describe('layout edit chrome interactions', () => {
     expect(onSetColumnHidden).toHaveBeenCalledTimes(1);
     expect(onSetColumnHidden).toHaveBeenCalledWith('description', true);
     expect(Object.keys(buttons[1].props)).not.toContain('onClose');
+
+    buttons.at(-1)?.props.onClick();
+    expect(onSetRepositoryOwnerVisible).toHaveBeenCalledWith(false);
   });
 
   it('keeps outside-click detection scoped to layout column menu islands', () => {

--- a/tests/unit/layout-editor-config-sync.test.tsx
+++ b/tests/unit/layout-editor-config-sync.test.tsx
@@ -690,6 +690,33 @@ describe('layout editor config sync', () => {
     expect(editor.current.layoutMode).toBe('default');
   });
 
+  it('previews and saves the repository owner visibility with the custom layout', async () => {
+    authMocks.getConfig.mockResolvedValue(defaultConfig());
+    const editor = mountLayoutEditor();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      editor.current.beginCustomLayoutEdit();
+      editor.current.setRepositoryOwnerVisible(false);
+    });
+
+    expect(editor.current.showRepositoryOwner).toBe(false);
+    expect(editor.current.draftLayout.showRepositoryOwner).toBe(false);
+
+    await act(async () => {
+      await editor.current.saveLayoutEdit();
+    });
+
+    expect(authMocks.update).toHaveBeenCalledWith({
+      columnLayoutMode: 'custom',
+      customColumnLayout: expect.objectContaining({ showRepositoryOwner: false }),
+    });
+    expect(editor.current.showRepositoryOwner).toBe(false);
+  });
+
   it('refreshes cancel target when config changes while layout edit is open', async () => {
     authMocks.getConfig.mockResolvedValue(configFor('default'));
     const editor = mountLayoutEditor();

--- a/tests/unit/organize-job-store.test.ts
+++ b/tests/unit/organize-job-store.test.ts
@@ -255,6 +255,152 @@ describe('durable whole-library organize job store', () => {
     }), /actively analyzing/u);
   });
 
+  it('snapshots organization preferences and reconciles tag coverage across persisted pages', async () => {
+    const repositoryIds = ['owner/a', 'owner/b', 'owner/c', 'owner/d'];
+    const requestedPolicy = { maxTagsPerRepo: 2, minTopicRepoCount: 3 };
+    const preflight = await createOrganizePreflight(preflightInput(repositoryIds, {
+      tagPolicy: requestedPolicy,
+    }));
+    requestedPolicy.maxTagsPerRepo = 5;
+    requestedPolicy.minTopicRepoCount = 1;
+    const activated = await activateOrganizePreflight({
+      preflightToken: preflight.preflight!.token,
+      controllerId: preflight.controllerId,
+      sessionId: preflight.sessionId,
+      taskInstruction: preflight.taskInstruction,
+      now: 10,
+    });
+    assert.deepEqual(activated.job.tagPolicy, {
+      maxTagsPerRepo: 2,
+      minTopicRepoCount: 3,
+    });
+
+    const action = (tag: string) => ({
+      kind: 'propose_new_tag' as const,
+      tag,
+      evidence: `${tag} evidence.`,
+    });
+    const first = await claimOrganizeAnalysisBatch(preflight.jobId, 2, {
+      ownerId: 'coverage-worker',
+      now: 20,
+    });
+    await settleOrganizeAnalysisBatch({
+      jobId: preflight.jobId,
+      leaseToken: first!.leaseToken,
+      now: 30,
+      outcomes: [
+        {
+          position: 0,
+          state: 'actionable',
+          sourceFingerprint: 'source:a',
+          proposedActions: [action('Shared'), action('Rare')],
+        },
+        {
+          position: 1,
+          state: 'actionable',
+          sourceFingerprint: 'source:b',
+          proposedActions: [action('shared')],
+        },
+      ],
+    });
+    assert.equal((await getOrganizeJob(preflight.jobId))?.status, 'analyzing');
+
+    const second = await claimOrganizeAnalysisBatch(preflight.jobId, 2, {
+      ownerId: 'coverage-worker',
+      now: 40,
+    });
+    const coverage = await settleOrganizeAnalysisBatch({
+      jobId: preflight.jobId,
+      leaseToken: second!.leaseToken,
+      now: 50,
+      outcomes: [
+        {
+          position: 2,
+          state: 'actionable',
+          sourceFingerprint: 'source:c',
+          proposedActions: [action('SHARED')],
+        },
+        {
+          position: 3,
+          state: 'actionable',
+          sourceFingerprint: 'source:d',
+          proposedActions: [action('rare')],
+        },
+      ],
+    });
+
+    assert.deepEqual(coverage, {
+      total: 4,
+      pending: 0,
+      leased: 0,
+      actionable: 3,
+      unchanged: 0,
+      insufficientEvidence: 1,
+      missing: 0,
+      tombstoned: 0,
+      failed: 0,
+      analyzed: 4,
+      complete: true,
+    });
+    const restored = await restoreOrganizeAnalysisCheckpoint(preflight.jobId);
+    assert.deepEqual(restored.job.tagPolicy, {
+      maxTagsPerRepo: 2,
+      minTopicRepoCount: 3,
+    });
+    assert.deepEqual(restored.items.map((row) => ({
+      position: row.position,
+      state: row.analysisState,
+      tags: row.proposedActions.map((entry) => entry.tag),
+    })), [
+      { position: 0, state: 'actionable', tags: ['Shared'] },
+      { position: 1, state: 'actionable', tags: ['shared'] },
+      { position: 2, state: 'actionable', tags: ['SHARED'] },
+      { position: 3, state: 'insufficient_evidence', tags: [] },
+    ]);
+
+    const reviewJob = (await getOrganizeJob(preflight.jobId))!;
+    const apply = await sealOrganizeApply(preflight.jobId, reviewJob.revision, 60);
+    assert.equal(apply.rowCount, 3);
+    const applyRows = await db.organizeApplyRows.where('applyId').equals(apply.applyId).sortBy('position');
+    assert.deepEqual(applyRows.map((row) => row.approvedAdditions), [
+      ['Shared'],
+      ['shared'],
+      ['SHARED'],
+    ]);
+  });
+
+  it('normalizes a legacy job without a tag policy to the default shared coverage', async () => {
+    const job = await createOrganizeJob(jobInput(['owner/legacy-policy']));
+    await db.organizeJobs.update(job.jobId, { tagPolicy: undefined });
+    const batch = await claimOrganizeAnalysisBatch(job.jobId, 1, {
+      ownerId: 'legacy-policy-worker',
+      now: 20,
+    });
+
+    const coverage = await settleOrganizeAnalysisBatch({
+      jobId: job.jobId,
+      leaseToken: batch!.leaseToken,
+      now: 30,
+      outcomes: [{
+        position: 0,
+        state: 'actionable',
+        sourceFingerprint: 'source:legacy-policy',
+        proposedActions: [{
+          kind: 'propose_new_tag',
+          tag: 'single-use',
+          evidence: 'Only one repository proposed this tag.',
+        }],
+      }],
+    });
+
+    assert.equal(coverage.actionable, 0);
+    assert.equal(coverage.insufficientEvidence, 1);
+    assert.deepEqual((await getOrganizeJob(job.jobId))?.tagPolicy, {
+      maxTagsPerRepo: 5,
+      minTopicRepoCount: 3,
+    });
+  });
+
   it('recovers expired leases and rejects settlement from the stale claimant', async () => {
     const job = await createOrganizeJob(jobInput(['owner/missing', 'owner/tombstoned']));
     const stale = await claimOrganizeAnalysisBatch(job.jobId, 25, {
@@ -1495,6 +1641,7 @@ function jobInput(
       fingerprint: `scope:${repositoryIds.length}`,
     },
     taskInstruction: 'Organize all tags.',
+    tagPolicy: { maxTagsPerRepo: 5, minTopicRepoCount: 1 },
     taxonomy,
     budget: { maxBatches: 10 },
     usage: { batches: 0 },

--- a/tests/unit/repository-search.test.ts
+++ b/tests/unit/repository-search.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { createRepositorySearchMatcher } from '@/search/repository-search';
+
+const document = (overrides: Partial<{
+  fullName: string;
+  description: string;
+  topics: string[];
+  notes: string;
+}> = {}) => ({
+  fullName: 'owner/better-repo',
+  description: '',
+  topics: [],
+  notes: '',
+  ...overrides,
+});
+
+describe('repository search matcher', () => {
+  it('ranks repository exact, prefix, substring, and fuzzy matches in that order', () => {
+    const exact = createRepositorySearchMatcher('repo').matchName('owner/repo');
+    const prefix = createRepositorySearchMatcher('repo').matchName('owner/repository');
+    const substring = createRepositorySearchMatcher('repo').matchName('owner/my-repo-tool');
+    const fuzzy = createRepositorySearchMatcher('rpo').matchName('owner/repository');
+
+    expect(exact.kind).toBe('repository-exact');
+    expect(prefix.kind).toBe('repository-prefix');
+    expect(substring.kind).toBe('repository-substring');
+    expect(fuzzy.kind).toBe('repository-fuzzy');
+    expect(exact.relevance).toBeGreaterThan(prefix.relevance);
+    expect(prefix.relevance).toBeGreaterThan(substring.relevance);
+    expect(substring.relevance).toBeGreaterThan(fuzzy.relevance);
+  });
+
+  it('returns ranges in the original full-name string, including non-contiguous fuzzy ranges', () => {
+    const exact = createRepositorySearchMatcher('repo').matchName('owner/my-repo-tool');
+    expect(exact.nameRanges).toEqual([{ start: 9, end: 13 }]);
+
+    const fuzzy = createRepositorySearchMatcher('rpt').matchName('owner/repository-tool');
+    expect(fuzzy.kind).toBe('repository-fuzzy');
+    expect(fuzzy.nameRanges).toEqual([
+      { start: 6, end: 7 },
+      { start: 8, end: 9 },
+      { start: 12, end: 13 },
+    ]);
+  });
+
+  it('ignores common code-name separators during fuzzy matching', () => {
+    const result = createRepositorySearchMatcher('better repo')
+      .matchName('owner/better-repo');
+
+    expect(result.kind).toBe('repository-fuzzy');
+    expect(result.nameRanges).toEqual([
+      { start: 6, end: 12 },
+      { start: 13, end: 17 },
+    ]);
+  });
+
+  it('keeps full-name exact and owner matches distinct from repository-name ranking', () => {
+    const fullName = createRepositorySearchMatcher('owner/better-repo').matchName('owner/better-repo');
+    const owner = createRepositorySearchMatcher('owner').matchName('owner/better-repo');
+
+    expect(fullName.kind).toBe('full-name-exact');
+    expect(fullName.nameRanges).toEqual([{ start: 0, end: 17 }]);
+    expect(owner.kind).toBe('full-name-prefix');
+    expect(owner.nameRanges).toEqual([{ start: 0, end: 5 }]);
+  });
+
+  it('keeps an owner-qualified prefix ahead of an unrelated repository fuzzy match', () => {
+    const matcher = createRepositorySearchMatcher('foo/bar');
+    const qualified = matcher.matchName('foo/bar-utils');
+    const unrelated = matcher.matchName('other/foobar-utils');
+
+    expect(qualified.kind).toBe('full-name-prefix');
+    expect(unrelated.kind).toBe('full-name-fuzzy');
+    expect(qualified.relevance).toBeGreaterThan(unrelated.relevance);
+  });
+
+  it('retains continuous metadata matching after repository-name matching fails', () => {
+    const matcher = createRepositorySearchMatcher('needle');
+
+    expect(matcher.match(document({ description: 'A needle in the haystack' })).kind)
+      .toBe('metadata-substring');
+    expect(matcher.match(document({ topics: ['needle'] })).kind)
+      .toBe('metadata-substring');
+    expect(matcher.match(document({ notes: 'private needle' })).kind)
+      .toBe('metadata-substring');
+    expect(matcher.match(document({ description: 'unrelated' })).matched).toBe(false);
+  });
+
+  it('treats empty input as an unranked match without highlight ranges', () => {
+    const result = createRepositorySearchMatcher('   ').match(document());
+    expect(result).toEqual({
+      matched: true,
+      relevance: 0,
+      kind: 'empty',
+      nameRanges: [],
+    });
+  });
+});

--- a/tests/unit/star-row-columns.test.tsx
+++ b/tests/unit/star-row-columns.test.tsx
@@ -41,6 +41,28 @@ function renderCreatedColumn(createdAt: string | null): string {
   );
 }
 
+function renderRepositoryColumn(searchQuery: string, showRepositoryOwner = true): string {
+  return renderToStaticMarkup(
+    <StarRow
+      star={fakeStar('2020-01-02T12:00:00Z')}
+      searchQuery={searchQuery}
+      showRepositoryOwner={showRepositoryOwner}
+      tags={[]}
+      hasNotes={false}
+      favorite={false}
+      favoriteBusy={false}
+      selectedTags={[]}
+      onToggleTag={vi.fn()}
+      onToggleFavorite={vi.fn(async () => undefined)}
+      selected={false}
+      onSelect={vi.fn()}
+      columns={['repository']}
+      gridTemplateColumns="180px"
+      flashedColumn={null}
+    />,
+  );
+}
+
 describe('star row column rendering', () => {
   it('applies the shared table min width when provided', () => {
     const markup = renderToStaticMarkup(
@@ -77,6 +99,46 @@ describe('star row column rendering', () => {
 
     expect(markup).toContain('data-row-col="created"');
     expect(markup).toContain('—');
+  });
+
+  it('highlights a contiguous repository-name match with the semantic background token', () => {
+    const markup = renderRepositoryColumn('REPO');
+
+    expect(markup).toContain('data-search-match=""');
+    expect(markup).toContain('bg-search-match/70');
+    expect(markup).toContain('text-search-match-foreground');
+    expect(markup).toContain('>repo</mark>');
+    expect(markup).toContain('owner/');
+  });
+
+  it('highlights each original range for a fuzzy repository-name match', () => {
+    const markup = renderRepositoryColumn('rpo');
+
+    expect(markup.match(/data-search-match=""/g)).toHaveLength(2);
+    expect(markup).toContain('>r</mark>');
+    expect(markup).toContain('>po</mark>');
+  });
+
+  it('does not highlight the repository label when only metadata could match', () => {
+    const markup = renderRepositoryColumn('repository description');
+
+    expect(markup).not.toContain('data-search-match');
+    expect(markup).toContain('owner/repo');
+  });
+
+  it('hides the owner without shifting repository-name highlights', () => {
+    const markup = renderRepositoryColumn('repo', false);
+
+    expect(markup).toContain('>repo</mark>');
+    expect(markup).toContain('title="owner/repo"');
+    expect(markup).toContain('aria-label="owner/repo"');
+  });
+
+  it('does not render an owner-only highlight when the owner is hidden', () => {
+    const markup = renderRepositoryColumn('owner', false);
+
+    expect(markup).not.toContain('data-search-match');
+    expect(markup).toContain('aria-label="owner/repo">repo</span>');
   });
 
   it('uses the edit-layout star alignment in the default browse layout', () => {


### PR DESCRIPTION
## Summary

- rank repository-name matches ahead of owner paths and metadata, with exact, prefix, substring, and fuzzy matching plus theme-aware highlights
- add an Edit Layout preference that can hide repository owners while preserving the full name for accessibility
- apply Agent tag limits and minimum shared-tag coverage from Preferences to Chat and durable Organize jobs
- rotate repository-bound conversations when selection changes, preserve the latest busy-time selection, and block stale-scope sends while Organize owns the session

## Validation

- `pnpm typecheck`
- focused search and Agent tests: 350 passed
- `pnpm test:logic`: 131 files, 1600 passed
- `pnpm test:integration`: 19 passed
- `pnpm test:regressions`: 18 files, 696 passed
- `pnpm build`
- `pnpm test:runtime`
- `pnpm test:runtime:organize-job-host`: 8 scenarios, zero live traffic
- `git diff --check`

## Known develop baseline issues

- `pnpm test:smoke`: Watch detail loads, but the drawer remains 1px wide instead of at least 339px
- `pnpm test:runtime:agent-scenarios`: `verifyRawCaptureLifecycle` times out after 30 seconds

Both failures reproduce unchanged on clean `develop` at `85e9bbd`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 仓库搜索支持精确、前缀、模糊及描述/主题/备注匹配，并按相关性排序和高亮结果。
  * 可在列表布局中显示或隐藏仓库所有者。
  * Organize 标签分配遵循每仓库数量上限及跨仓库覆盖率规则。
  * 切换对话时如仍有未完成任务，将暂时禁用输入及重试操作。
* **改进**
  * 优化标签策略在任务恢复和分析过程中的一致性。
* **测试**
  * 补充搜索、标签策略、布局设置及对话切换场景测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->