### PR TITLE
chore(bots): reduce automated PR churn

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,8 @@
 language: "zh-CN"
 
 reviews:
+  high_level_summary: true
+  high_level_summary_in_walkthrough: true
   auto_review:
     enabled: true
     drafts: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,7 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: quarterly
       time: '05:00'
       timezone: UTC
     open-pull-requests-limit: 10
@@ -17,8 +16,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: quarterly
       time: '05:30'
       timezone: UTC
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- Run grouped npm dependency version updates quarterly instead of weekly.
- Run grouped GitHub Actions version updates quarterly instead of weekly.
- Keep the existing 05:00 and 05:30 UTC execution times.
- Move CodeRabbit's high-level summary into its walkthrough comment so the human-authored PR body remains unchanged.

## Behavior

Dependabot's `quarterly` interval runs on the first day of January, April, July, and October. This controls scheduled version updates; Dependabot security updates remain independent and can still open when a fix is available.

The CodeRabbit review remains enabled. Only summary placement changes from the PR description to the walkthrough comment. An explicit `@coderabbitai summary` placeholder can still request body replacement; this PR does not include one.

The existing Dependabot PR #41 is unaffected and must be handled separately.

## Validation

- `coderabbit config validate`
- Parsed `.github/dependabot.yml` and `.coderabbit.yaml` successfully with Ruby YAML
- No product code changed; code tests were not run