### PR TITLE
Harden CI credentials and release publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,34 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
+      - name: Lint workflows with actionlint
+        shell: bash
+        run: |
+          set -euo pipefail
+          actionlint_dir="${RUNNER_TEMP}/actionlint-1.7.12"
+          archive="${actionlint_dir}/actionlint_1.7.12_linux_amd64.tar.gz"
+          checksum_file="${actionlint_dir}/actionlint_1.7.12_linux_amd64.tar.gz.sha256"
+          mkdir --parents "$actionlint_dir"
+          curl --fail --location --silent --show-error \
+            --output "$archive" \
+            "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz"
+          printf '%s  %s\n' \
+            '8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8' \
+            "$archive" > "$checksum_file"
+          sha256sum --check --status "$checksum_file"
+          tar --extract --gzip --file "$archive" --directory "$actionlint_dir" actionlint
+          "$actionlint_dir/actionlint" .github/workflows/*.yml
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.33.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: pnpm
@@ -47,7 +66,7 @@ jobs:
         run: pnpm test
 
       - name: Upload dist artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist-${{ github.sha }}
           path: dist

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,12 +2,15 @@ name: E2E Chrome Verification
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       scenario:
         description: Comma-separated verify-first-run scenarios
         required: false
-        default: no-token,invalid-token,valid-token
+        default: invalid-token,no-gists-token,valid-token
   schedule:
     - cron: '0 4 * * 1'
 
@@ -19,21 +22,23 @@ permissions:
   contents: read
 
 jobs:
-  verify-extension:
+  verify-extension-no-token:
     runs-on: ubuntu-latest
     timeout-minutes: 50
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.33.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: pnpm
@@ -53,19 +58,64 @@ jobs:
           PUPPETEER_HEADLESS: 'false'
         run: xvfb-run -a pnpm test:smoke
 
-      - name: Run first-run Chrome verification
+      - name: Run credential-free first-run Chrome verification
         env:
           CI: 'true'
           PUPPETEER_HEADLESS: 'false'
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          GH_TOKEN_NO_GISTS: ${{ secrets.GH_TOKEN_NO_GISTS }}
+        run: xvfb-run -a pnpm test:verify-first-run -- --scenario=no-token
+
+      - name: Rebuild release extension for packaged Agent verification
+        run: GSM_RELEASE=true GSM_DEV=false pnpm build
+
+      - name: Run credential-free packaged Agent session verification
+        env:
+          CI: 'true'
+          PUPPETEER_HEADLESS: 'false'
+        run: xvfb-run -a pnpm test:runtime:agent-session
+
+  verify-extension-authenticated:
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
+    environment: e2e-credentials
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 10.33.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Chrome for Testing
+        run: pnpm exec puppeteer browsers install chrome
+
+      - name: Build extension
+        run: pnpm build
+
+      - name: Run authenticated first-run Chrome verification
+        env:
+          CI: 'true'
+          PUPPETEER_HEADLESS: 'false'
+          GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
+          GH_TOKEN_NO_GISTS: ${{ secrets.E2E_GH_TOKEN_NO_GISTS }}
           GH_USER: ${{ vars.GH_USER }}
-          GSM_RESET_GIST: '1'
           GSM_SCENARIO: ${{ github.event.inputs.scenario }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            scenario="no-token"
-          else
-            scenario="${GSM_SCENARIO:-no-token,invalid-token,valid-token}"
-          fi
-          xvfb-run -a pnpm test:verify-first-run -- --scenario="$scenario"
+          scenario="${GSM_SCENARIO:-invalid-token,no-gists-token,valid-token}"
+          xvfb-run -a pnpm test:verify-first-run -- --scenario="$scenario" --require-selected

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,17 +29,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.33.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: pnpm
@@ -54,6 +55,9 @@ jobs:
         run: |
           package_version="$(node -p "require('./package.json').version")"
           test "$TAG_NAME" = "v$package_version"
+
+      - name: Install Chrome for Testing
+        run: pnpm exec puppeteer browsers install chrome
 
       - name: Run integrated Agent runtime verification
         run: pnpm verify:agent-runtime
@@ -73,14 +77,14 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Upload packaged artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-artifacts-${{ github.sha }}
           path: ${{ steps.release-artifacts.outputs.files }}
           if-no-files-found: error
           retention-days: 14
 
-      - name: Create or update GitHub release
+      - name: Create or verify immutable GitHub release
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         env:
           GH_TOKEN: ${{ github.token }}
@@ -89,7 +93,24 @@ jobs:
           mapfile -t release_files < "$RUNNER_TEMP/release-artifacts.txt"
           test "${#release_files[@]}" -gt 0
           if gh release view "$TAG_NAME" >/dev/null 2>&1; then
-            gh release upload "$TAG_NAME" "${release_files[@]}" --clobber
+            existing_release_dir="$(mktemp -d "$RUNNER_TEMP/existing-release.XXXXXX")"
+            expected_asset_names="$existing_release_dir/expected-asset-names.txt"
+            actual_asset_names="$existing_release_dir/actual-asset-names.txt"
+            printf '%s\n' "${release_files[@]##*/}" | LC_ALL=C sort > "$expected_asset_names"
+            gh release view "$TAG_NAME" --json assets --jq '.assets[].name' |
+              LC_ALL=C sort > "$actual_asset_names"
+            if ! cmp -s "$expected_asset_names" "$actual_asset_names"; then
+              echo "Existing GitHub Release asset inventory differs from the canonical release artifacts; refusing to mutate immutable assets." >&2
+              exit 1
+            fi
+            gh release download "$TAG_NAME" --dir "$existing_release_dir/downloaded"
+            for release_file in "${release_files[@]}"; do
+              asset_name="${release_file##*/}"
+              if ! cmp -s "$release_file" "$existing_release_dir/downloaded/$asset_name"; then
+                echo "Existing GitHub Release asset $asset_name differs from the canonical release artifact; refusing to mutate immutable assets." >&2
+                exit 1
+              fi
+            done
           else
             gh release create "$TAG_NAME" "${release_files[@]}" --generate-notes --title "$TAG_NAME"
           fi

--- a/scripts/publish-chrome-web-store.mjs
+++ b/scripts/publish-chrome-web-store.mjs
@@ -29,6 +29,7 @@ export async function publishChromeWebStore({
   fetchImpl = globalThis.fetch,
   log = console.log,
 } = {}) {
+  assertRequiredEnvironment(env);
   const publishType = env.CWS_PUBLISH_TYPE || 'DEFAULT_PUBLISH';
   if (!Object.hasOwn(SUCCESSFUL_PUBLISH_STATES_BY_TYPE, publishType)) {
     throw new Error(`unsupported Chrome Web Store publish type: ${publishType}`);
@@ -159,6 +160,12 @@ function assertSuccessfulPublish(publish, { extensionId, publishType, resourcePa
   }
   if (publish.name !== resourcePath) {
     throw new Error('publish failed: name does not match configured extension resource');
+  }
+}
+
+function assertRequiredEnvironment(env) {
+  for (const key of REQUIRED_ENV) {
+    if (!env?.[key]) throw new Error(`missing required env: ${key}`);
   }
 }
 

--- a/scripts/publish-chrome-web-store.mjs
+++ b/scripts/publish-chrome-web-store.mjs
@@ -10,6 +10,9 @@ const REQUIRED_ENV = Object.freeze([
   'CWS_EXTENSION_ID',
   'CWS_PUBLISHER_ID',
 ]);
+const DEFAULT_UPLOAD_POLL_INTERVAL_MS = 5_000;
+const DEFAULT_UPLOAD_POLL_TIMEOUT_MS = 5 * 60_000;
+const UPLOAD_STATE_IN_PROGRESS = 'IN_PROGRESS';
 const UPLOAD_STATE_SUCCEEDED = 'SUCCEEDED';
 const SUCCESSFUL_PUBLISH_STATES_BY_TYPE = Object.freeze({
   DEFAULT_PUBLISH: Object.freeze([
@@ -28,8 +31,12 @@ export async function publishChromeWebStore({
   env = process.env,
   fetchImpl = globalThis.fetch,
   log = console.log,
+  sleep = delay,
+  uploadPollIntervalMs = DEFAULT_UPLOAD_POLL_INTERVAL_MS,
+  uploadPollTimeoutMs = DEFAULT_UPLOAD_POLL_TIMEOUT_MS,
 } = {}) {
   assertRequiredEnvironment(env);
+  assertUploadPollingOptions({ uploadPollIntervalMs, uploadPollTimeoutMs });
   const publishType = env.CWS_PUBLISH_TYPE || 'DEFAULT_PUBLISH';
   if (!Object.hasOwn(SUCCESSFUL_PUBLISH_STATES_BY_TYPE, publishType)) {
     throw new Error(`unsupported Chrome Web Store publish type: ${publishType}`);
@@ -53,9 +60,15 @@ export async function publishChromeWebStore({
     fetchImpl,
   );
 
-  assertSuccessfulUpload(upload, {
+  const completedUpload = await awaitSuccessfulUpload({
+    upload,
+    accessToken,
     extensionId: env.CWS_EXTENSION_ID,
     resourcePath,
+    fetchImpl,
+    sleep,
+    uploadPollIntervalMs,
+    uploadPollTimeoutMs,
   });
 
   const publish = await apiFetch(
@@ -80,8 +93,8 @@ export async function publishChromeWebStore({
   });
 
   const output = {
-    uploadState: upload.uploadState,
-    itemId: upload.itemId,
+    uploadState: completedUpload.uploadState,
+    itemId: completedUpload.itemId,
     published: {
       name: publish.name,
       itemId: publish.itemId,
@@ -134,18 +147,68 @@ async function apiFetch(url, init, accessToken, fetchImpl) {
   return res.json();
 }
 
-function assertSuccessfulUpload(upload, { extensionId, resourcePath }) {
-  if (!isRecord(upload) || upload.uploadState !== UPLOAD_STATE_SUCCEEDED) {
-    const state = isRecord(upload) ? upload.uploadState ?? 'missing' : 'missing';
+async function awaitSuccessfulUpload({
+  upload,
+  accessToken,
+  extensionId,
+  resourcePath,
+  fetchImpl,
+  sleep,
+  uploadPollIntervalMs,
+  uploadPollTimeoutMs,
+}) {
+  let state = assertUploadResponse(upload, {
+    extensionId,
+    resourcePath,
+    stateKey: 'uploadState',
+  });
+  if (state === UPLOAD_STATE_SUCCEEDED) return upload;
+  if (state !== UPLOAD_STATE_IN_PROGRESS) {
     throw new Error(`upload failed with state ${state}`);
   }
 
-  if (upload.itemId !== extensionId) {
+  const maxPollAttempts = Math.floor(uploadPollTimeoutMs / uploadPollIntervalMs);
+  const statusUrl =
+    `https://chromewebstore.googleapis.com/v2/${resourcePath}:fetchStatus`;
+
+  for (let attempt = 0; attempt < maxPollAttempts; attempt += 1) {
+    await sleep(uploadPollIntervalMs);
+    const status = await apiFetch(
+      statusUrl,
+      { method: 'GET' },
+      accessToken,
+      fetchImpl,
+    );
+    state = assertUploadResponse(status, {
+      extensionId,
+      resourcePath,
+      stateKey: 'lastAsyncUploadState',
+    });
+    if (state === UPLOAD_STATE_SUCCEEDED) {
+      return {
+        name: status.name,
+        itemId: status.itemId,
+        uploadState: state,
+      };
+    }
+    if (state !== UPLOAD_STATE_IN_PROGRESS) {
+      throw new Error(`upload failed with state ${state}`);
+    }
+  }
+
+  throw new Error(`upload timed out after ${uploadPollTimeoutMs}ms`);
+}
+
+function assertUploadResponse(response, { extensionId, resourcePath, stateKey }) {
+  if (!isRecord(response)) throw new Error('upload failed with state missing');
+  if (response.itemId !== extensionId) {
     throw new Error('upload failed: itemId does not match configured extension ID');
   }
-  if (upload.name !== resourcePath) {
+  if (response.name !== resourcePath) {
     throw new Error('upload failed: name does not match configured extension resource');
   }
+
+  return response[stateKey] ?? 'missing';
 }
 
 function assertSuccessfulPublish(publish, { extensionId, publishType, resourcePath }) {
@@ -165,8 +228,27 @@ function assertSuccessfulPublish(publish, { extensionId, publishType, resourcePa
 
 function assertRequiredEnvironment(env) {
   for (const key of REQUIRED_ENV) {
-    if (!env?.[key]) throw new Error(`missing required env: ${key}`);
+    const value = env?.[key];
+    if (typeof value !== 'string' || value.trim() === '') {
+      throw new Error(`missing required env: ${key}`);
+    }
   }
+}
+
+function assertUploadPollingOptions({ uploadPollIntervalMs, uploadPollTimeoutMs }) {
+  if (!Number.isFinite(uploadPollIntervalMs) || uploadPollIntervalMs <= 0) {
+    throw new Error('upload poll interval must be a positive finite number');
+  }
+  if (
+    !Number.isFinite(uploadPollTimeoutMs)
+    || uploadPollTimeoutMs < uploadPollIntervalMs
+  ) {
+    throw new Error('upload poll timeout must be finite and at least one interval');
+  }
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 function isRecord(value) {

--- a/scripts/publish-chrome-web-store.mjs
+++ b/scripts/publish-chrome-web-store.mjs
@@ -1,83 +1,105 @@
 #!/usr/bin/env node
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const zipArg = process.argv[2];
-const zipPath = zipArg ? path.resolve(process.cwd(), zipArg) : null;
-
-if (!zipPath || !existsSync(zipPath)) {
-  console.error('❌ Usage: node scripts/publish-chrome-web-store.mjs <path-to-extension-zip>');
-  process.exit(1);
-}
-
-const required = [
+const REQUIRED_ENV = Object.freeze([
   'CWS_CLIENT_ID',
   'CWS_CLIENT_SECRET',
   'CWS_REFRESH_TOKEN',
   'CWS_EXTENSION_ID',
   'CWS_PUBLISHER_ID',
-];
+]);
+const UPLOAD_STATE_SUCCEEDED = 'SUCCEEDED';
+const SUCCESSFUL_PUBLISH_STATES_BY_TYPE = Object.freeze({
+  DEFAULT_PUBLISH: Object.freeze([
+    'PENDING_REVIEW',
+    'PUBLISHED',
+    'PUBLISHED_TO_TESTERS',
+  ]),
+  STAGED_PUBLISH: Object.freeze([
+    'PENDING_REVIEW',
+    'STAGED',
+  ]),
+});
 
-for (const key of required) {
-  if (!process.env[key]) {
-    console.error(`❌ Missing required env: ${key}`);
-    process.exit(1);
+export async function publishChromeWebStore({
+  zipPath,
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+  log = console.log,
+} = {}) {
+  const publishType = env.CWS_PUBLISH_TYPE || 'DEFAULT_PUBLISH';
+  if (!Object.hasOwn(SUCCESSFUL_PUBLISH_STATES_BY_TYPE, publishType)) {
+    throw new Error(`unsupported Chrome Web Store publish type: ${publishType}`);
   }
+  const skipReview = env.CWS_SKIP_REVIEW === '1';
+
+  const accessToken = await fetchAccessToken({ env, fetchImpl });
+  const resourcePath =
+    `publishers/${env.CWS_PUBLISHER_ID}/items/${env.CWS_EXTENSION_ID}`;
+
+  const upload = await apiFetch(
+    `https://chromewebstore.googleapis.com/upload/v2/${resourcePath}:upload`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/zip',
+      },
+      body: readFileSync(zipPath),
+    },
+    accessToken,
+    fetchImpl,
+  );
+
+  assertSuccessfulUpload(upload, {
+    extensionId: env.CWS_EXTENSION_ID,
+    resourcePath,
+  });
+
+  const publish = await apiFetch(
+    `https://chromewebstore.googleapis.com/v2/${resourcePath}:publish`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        publishType,
+        skipReview,
+      }),
+    },
+    accessToken,
+    fetchImpl,
+  );
+  assertSuccessfulPublish(publish, {
+    extensionId: env.CWS_EXTENSION_ID,
+    publishType,
+    resourcePath,
+  });
+
+  const output = {
+    uploadState: upload.uploadState,
+    itemId: upload.itemId,
+    published: {
+      name: publish.name,
+      itemId: publish.itemId,
+      state: publish.state,
+    },
+  };
+  log(JSON.stringify(output, null, 2));
+  return output;
 }
 
-const publishType = process.env.CWS_PUBLISH_TYPE || 'DEFAULT_PUBLISH';
-const skipReview = process.env.CWS_SKIP_REVIEW === '1';
-
-const accessToken = await fetchAccessToken();
-const resourcePath =
-  `publishers/${process.env.CWS_PUBLISHER_ID}/items/${process.env.CWS_EXTENSION_ID}`;
-
-const upload = await apiFetch(
-  `https://chromewebstore.googleapis.com/upload/v2/${resourcePath}:upload`,
-  {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/zip',
-    },
-    body: readFileSync(zipPath),
-  },
-  accessToken,
-);
-
-if (upload.uploadState && upload.uploadState !== 'UPLOAD_STATE_SUCCESS') {
-  throw new Error(`upload failed with state ${upload.uploadState}`);
-}
-
-const publish = await apiFetch(
-  `https://chromewebstore.googleapis.com/v2/${resourcePath}:publish`,
-  {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      publishType,
-      skipReview,
-    }),
-  },
-  accessToken,
-);
-
-console.log(JSON.stringify({
-  uploadState: upload.uploadState ?? null,
-  itemId: upload.itemId ?? process.env.CWS_EXTENSION_ID,
-  published: publish,
-}, null, 2));
-
-async function fetchAccessToken() {
+async function fetchAccessToken({ env, fetchImpl }) {
   const body = new URLSearchParams({
-    client_id: process.env.CWS_CLIENT_ID,
-    client_secret: process.env.CWS_CLIENT_SECRET,
-    refresh_token: process.env.CWS_REFRESH_TOKEN,
+    client_id: env.CWS_CLIENT_ID,
+    client_secret: env.CWS_CLIENT_SECRET,
+    refresh_token: env.CWS_REFRESH_TOKEN,
     grant_type: 'refresh_token',
   });
 
-  const res = await fetch('https://oauth2.googleapis.com/token', {
+  const res = await fetchImpl('https://oauth2.googleapis.com/token', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -94,8 +116,8 @@ async function fetchAccessToken() {
   return json.access_token;
 }
 
-async function apiFetch(url, init, accessToken) {
-  const res = await fetch(url, {
+async function apiFetch(url, init, accessToken, fetchImpl) {
+  const res = await fetchImpl(url, {
     ...init,
     headers: {
       ...(init.headers || {}),
@@ -110,3 +132,58 @@ async function apiFetch(url, init, accessToken) {
 
   return res.json();
 }
+
+function assertSuccessfulUpload(upload, { extensionId, resourcePath }) {
+  if (!isRecord(upload) || upload.uploadState !== UPLOAD_STATE_SUCCEEDED) {
+    const state = isRecord(upload) ? upload.uploadState ?? 'missing' : 'missing';
+    throw new Error(`upload failed with state ${state}`);
+  }
+
+  if (upload.itemId !== extensionId) {
+    throw new Error('upload failed: itemId does not match configured extension ID');
+  }
+  if (upload.name !== resourcePath) {
+    throw new Error('upload failed: name does not match configured extension resource');
+  }
+}
+
+function assertSuccessfulPublish(publish, { extensionId, publishType, resourcePath }) {
+  const successfulStates = SUCCESSFUL_PUBLISH_STATES_BY_TYPE[publishType];
+  if (!isRecord(publish) || !successfulStates.includes(publish.state)) {
+    const state = isRecord(publish) ? publish.state ?? 'missing' : 'missing';
+    throw new Error(`publish failed with state ${state}`);
+  }
+
+  if (publish.itemId !== extensionId) {
+    throw new Error('publish failed: itemId does not match configured extension ID');
+  }
+  if (publish.name !== resourcePath) {
+    throw new Error('publish failed: name does not match configured extension resource');
+  }
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+async function main() {
+  const zipArg = process.argv[2];
+  const zipPath = zipArg ? path.resolve(process.cwd(), zipArg) : null;
+
+  if (!zipPath || !existsSync(zipPath)) {
+    console.error('❌ Usage: node scripts/publish-chrome-web-store.mjs <path-to-extension-zip>');
+    process.exit(1);
+  }
+
+  for (const key of REQUIRED_ENV) {
+    if (!process.env[key]) {
+      console.error(`❌ Missing required env: ${key}`);
+      process.exit(1);
+    }
+  }
+
+  await publishChromeWebStore({ zipPath });
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) await main();

--- a/tests/manual/e2e/verify-first-run.mjs
+++ b/tests/manual/e2e/verify-first-run.mjs
@@ -14,6 +14,7 @@ const INVALID_TOKEN =
   'github_pat_invalid_test_value_for_first_run_matrix';
 
 const args = new Set(process.argv.slice(2));
+const requireSelected = args.has('--require-selected');
 const selectedArg = process.argv
   .slice(2)
   .find((arg) => arg.startsWith('--scenario='));
@@ -39,6 +40,7 @@ Optional env:
 
 Optional args:
   --scenario=no-token,invalid-token,valid-token
+  --require-selected     fail when a selected scenario skips for missing prerequisites
 `);
   process.exit(0);
 }
@@ -48,8 +50,6 @@ if (!existsSync(path.join(DIST, 'manifest.json'))) {
   process.exit(1);
 }
 
-const summaries = [];
-const starsUser = await resolveGitHubUser();
 
 const scenarios = [
   {
@@ -137,6 +137,22 @@ if (args.has('--list')) {
   }
   process.exit(0);
 }
+if (requireSelected && selectedNames) {
+  const scenarioNames = new Set(scenarios.map((scenario) => scenario.id));
+  const unknownNames = [...selectedNames].filter((name) => !scenarioNames.has(name));
+
+  if (selectedNames.size === 0) {
+    console.error('❌ --require-selected cannot be used with an empty --scenario selection.');
+    process.exit(1);
+  }
+  if (unknownNames.length > 0) {
+    console.error(`❌ Unknown --scenario selection: ${unknownNames.join(', ')}`);
+    process.exit(1);
+  }
+}
+
+const summaries = [];
+const starsUser = await resolveGitHubUser();
 
 for (const scenario of scenarios) {
   if (selectedNames && !selectedNames.has(scenario.id)) continue;
@@ -200,7 +216,13 @@ for (const item of summaries) {
 }
 
 const failed = summaries.filter((item) => item.status === 'failed');
-if (failed.length > 0) process.exit(1);
+const skipped = summaries.filter((item) => item.status === 'skipped');
+
+if (requireSelected && skipped.length > 0) {
+  console.error(`❌ --require-selected: selected scenario(s) skipped: ${skipped.map((item) => item.id).join(', ')}`);
+}
+
+if (failed.length > 0 || (requireSelected && skipped.length > 0)) process.exit(1);
 
 async function resolveGitHubUser() {
   if (process.env.GH_USER) return process.env.GH_USER;

--- a/tests/manual/e2e/verify-first-run.mjs
+++ b/tests/manual/e2e/verify-first-run.mjs
@@ -137,12 +137,12 @@ if (args.has('--list')) {
   }
   process.exit(0);
 }
-if (requireSelected && selectedNames) {
+if (selectedNames) {
   const scenarioNames = new Set(scenarios.map((scenario) => scenario.id));
   const unknownNames = [...selectedNames].filter((name) => !scenarioNames.has(name));
 
   if (selectedNames.size === 0) {
-    console.error('❌ --require-selected cannot be used with an empty --scenario selection.');
+    console.error('❌ empty --scenario selection is not allowed.');
     process.exit(1);
   }
   if (unknownNames.length > 0) {

--- a/tests/unit/agent-release-conformance.test.ts
+++ b/tests/unit/agent-release-conformance.test.ts
@@ -92,7 +92,7 @@ describe('Agent release conformance', () => {
   });
 
 
-  it('wires one behavior-named, approval-gated release flow without legacy aliases', () => {
+  it('wires one behavior-named, approval-gated, immutable release flow without legacy aliases', () => {
     const packageJson = JSON.parse(read('package.json')) as {
       scripts: Record<string, string>;
     };
@@ -105,22 +105,77 @@ describe('Agent release conformance', () => {
     expect(existsSync(path.join(root, 'scripts/run-agent-phase5-verification.mjs'))).toBe(false);
 
     const workflow = read('.github/workflows/release.yml');
+    const checkout = workflow.indexOf('uses: actions/checkout@');
+    const pnpmSetup = workflow.indexOf('uses: pnpm/action-setup@');
+    const nodeSetup = workflow.indexOf('uses: actions/setup-node@');
     const tagVersionCheck = workflow.indexOf('test "$TAG_NAME" = "v$package_version"');
+    const chromeInstallation = workflow.indexOf('pnpm exec puppeteer browsers install chrome');
     const runtimeVerification = workflow.indexOf('pnpm verify:agent-runtime');
     const gateFinalization = workflow.indexOf('pnpm verify:agent-release-gates');
     const canonicalEnumeration = workflow.indexOf('--list-release-artifacts');
-    const artifactUpload = workflow.indexOf('uses: actions/upload-artifact');
+    const artifactUpload = workflow.indexOf('uses: actions/upload-artifact@');
+    const existingReleaseCheck = workflow.indexOf('gh release view "$TAG_NAME"');
+    const existingAssetInventory = workflow.indexOf(
+      'gh release view "$TAG_NAME" --json assets --jq',
+    );
+    const assetSetVerification = workflow.indexOf(
+      'cmp -s "$expected_asset_names" "$actual_asset_names"',
+    );
+    const existingAssetDownload = workflow.indexOf('gh release download "$TAG_NAME"');
+    const assetByteVerification = workflow.indexOf(
+      'cmp -s "$release_file" "$existing_release_dir/downloaded/$asset_name"',
+    );
     const githubRelease = workflow.indexOf('gh release create');
     const chromeWebStore = workflow.indexOf('node scripts/publish-chrome-web-store.mjs');
 
     expect(workflow).toContain('GSM_VERSION_APPROVAL');
     expect(workflow).not.toContain('verify:agent-phase5');
+    expect(workflow).toContain(
+      'uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7',
+    );
+    expect(workflow).toContain(
+      'uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6',
+    );
+    expect(workflow).toContain(
+      'uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7',
+    );
+    expect(workflow).toContain(
+      'uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7',
+    );
+    expect(workflow).not.toContain('uses: actions/checkout@v7');
+    expect(workflow).not.toContain('uses: pnpm/action-setup@v6');
+    expect(workflow).not.toContain('uses: actions/setup-node@v7');
+    expect(workflow).not.toContain('uses: actions/upload-artifact@v7');
+
+    const checkoutStep = workflow.slice(checkout, pnpmSetup);
+    expect(checkoutStep).toContain('persist-credentials: false');
+    expect(checkoutStep).toContain('fetch-depth: 0');
+    expect(workflow.match(/uses: actions\/checkout@/gu) ?? []).toHaveLength(1);
+    expect(workflow.match(/uses: pnpm\/action-setup@/gu) ?? []).toHaveLength(1);
+    expect(workflow.match(/uses: actions\/setup-node@/gu) ?? []).toHaveLength(1);
+    expect(workflow.match(/uses: actions\/upload-artifact@/gu) ?? []).toHaveLength(1);
+    expect(workflow).toContain(
+      '      - name: Install Chrome for Testing\n' +
+        '        run: pnpm exec puppeteer browsers install chrome\n\n' +
+        '      - name: Run integrated Agent runtime verification\n' +
+        '        run: pnpm verify:agent-runtime',
+    );
+
+    expect(checkout).toBeGreaterThan(-1);
+    expect(checkout).toBeLessThan(pnpmSetup);
+    expect(pnpmSetup).toBeLessThan(nodeSetup);
     expect(tagVersionCheck).toBeGreaterThan(-1);
-    expect(tagVersionCheck).toBeLessThan(runtimeVerification);
+    expect(tagVersionCheck).toBeLessThan(chromeInstallation);
+    expect(chromeInstallation).toBeLessThan(runtimeVerification);
     expect(runtimeVerification).toBeLessThan(gateFinalization);
     expect(gateFinalization).toBeLessThan(canonicalEnumeration);
     expect(canonicalEnumeration).toBeLessThan(artifactUpload);
-    expect(artifactUpload).toBeLessThan(githubRelease);
+    expect(artifactUpload).toBeLessThan(existingReleaseCheck);
+    expect(existingReleaseCheck).toBeLessThan(existingAssetInventory);
+    expect(existingAssetInventory).toBeLessThan(assetSetVerification);
+    expect(assetSetVerification).toBeLessThan(existingAssetDownload);
+    expect(existingAssetDownload).toBeLessThan(assetByteVerification);
+    expect(assetByteVerification).toBeLessThan(githubRelease);
     expect(githubRelease).toBeLessThan(chromeWebStore);
 
     expect(workflow).toContain('scripts/verify-agent-release-gates.mjs --list-release-artifacts');
@@ -128,6 +183,20 @@ describe('Agent release conformance', () => {
     expect(workflow).toContain('mapfile -t release_files');
     expect(workflow).toContain('"${release_files[@]}"');
     expect(workflow).not.toContain('artifacts/*');
+
+    expect(workflow).toContain('Create or verify immutable GitHub release');
+    expect(workflow).toContain(
+      'printf \'%s\\n\' "${release_files[@]##*/}" | LC_ALL=C sort > "$expected_asset_names"',
+    );
+    expect(workflow).toContain('mktemp -d "$RUNNER_TEMP/existing-release.XXXXXX"');
+    expect(workflow).toContain('Existing GitHub Release asset inventory differs');
+    expect(workflow).toContain('Existing GitHub Release asset $asset_name differs');
+    expect(workflow.match(/gh release create/gu) ?? []).toHaveLength(1);
+    expect(workflow.match(/gh release download/gu) ?? []).toHaveLength(1);
+    expect(workflow.match(/cmp -s /gu) ?? []).toHaveLength(2);
+    expect(workflow).not.toMatch(/\bgh release (?:upload|edit|delete)\b/gu);
+    expect(workflow).not.toContain('--clobber');
+    expect(workflow).not.toContain('Create or update GitHub release');
 
     expect(workflow).toContain('publish_to_chrome_web_store:');
     expect(workflow).toContain(

--- a/tests/unit/e2e-credential-isolation.test.ts
+++ b/tests/unit/e2e-credential-isolation.test.ts
@@ -1,0 +1,247 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+
+const ACTION_PINS: Record<string, { sha: string; version: string }> = {
+  'actions/checkout': {
+    sha: '3d3c42e5aac5ba805825da76410c181273ba90b1',
+    version: 'v7',
+  },
+  'actions/setup-node': {
+    sha: '820762786026740c76f36085b0efc47a31fe5020',
+    version: 'v7',
+  },
+  'actions/upload-artifact': {
+    sha: '043fb46d1a93c77aae656e7c1c64a875d1fc6a0a',
+    version: 'v7',
+  },
+  'pnpm/action-setup': {
+    sha: '0977fd99725f1db4007ccb2928dbb4e90d06cc86',
+    version: 'v6',
+  },
+};
+
+describe('E2E credential isolation', () => {
+  it('keeps credential-free and authenticated browser verification isolated', () => {
+    const workflow = read('.github/workflows/e2e.yml');
+    expect(workflow).not.toContain('GSM_RESET_GIST');
+    const noTokenJob = jobBlock(workflow, 'verify-extension-no-token');
+    const authenticatedJob = jobBlock(workflow, 'verify-extension-authenticated');
+
+    expect(noTokenJob).not.toContain('secrets.');
+    expectCheckoutCredentialPersistenceDisabled(noTokenJob);
+    expectCheckoutCredentialPersistenceDisabled(authenticatedJob);
+
+    const authenticatedCondition = jobField(authenticatedJob, 'if').replace(/\s+/g, ' ');
+    expect(authenticatedCondition).toMatch(
+      /github\.event_name == 'schedule' \|\| \(github\.event_name == 'workflow_dispatch' && github\.ref == format\('refs\/heads\/\{0\}', github\.event\.repository\.default_branch\)\)/,
+    );
+    expect(authenticatedJob).toMatch(/^[ \t]*environment:[ \t]*e2e-credentials[ \t]*$/m);
+    expect(authenticatedJob).toMatch(
+      /\$\{\{\s*secrets\.E2E_GH_TOKEN\s*\}\}/,
+    );
+    expect(authenticatedJob).toMatch(
+      /\$\{\{\s*secrets\.E2E_GH_TOKEN_NO_GISTS\s*\}\}/,
+    );
+    expect(authenticatedJob).toMatch(
+      /\$\{GSM_SCENARIO:-[^}\r\n]*\bno-gists-token\b[^}\r\n]*\}/,
+    );
+    expect(authenticatedJob).toMatch(/--require-selected\b/);
+
+    expect(workflow).not.toMatch(/\bsecrets\.GH_TOKEN\b/);
+    expect(workflow).not.toMatch(/\bsecrets\.GH_TOKEN_NO_GISTS\b/);
+  });
+
+  it('keeps canonical workflow coverage representative', () => {
+    const ciWorkflow = read('.github/workflows/ci.yml');
+    const ciJob = jobBlock(ciWorkflow, 'verify');
+    expectCheckoutCredentialPersistenceDisabled(ciJob);
+    expectActionsPinned(ciWorkflow, [
+      'actions/checkout',
+      'pnpm/action-setup',
+      'actions/setup-node',
+      'actions/upload-artifact',
+    ]);
+    expectActionlintVerification(ciJob);
+
+    const e2eWorkflow = read('.github/workflows/e2e.yml');
+    expectActionsPinned(e2eWorkflow, [
+      'actions/checkout',
+      'pnpm/action-setup',
+      'actions/setup-node',
+    ]);
+    expect(e2eWorkflow).toMatch(
+      /^  push:\r?\n    branches:\r?\n      - master[ \t]*$/m,
+    );
+
+    const noTokenJob = jobBlock(e2eWorkflow, 'verify-extension-no-token');
+    const firstRun = noTokenJob.indexOf(
+      'pnpm test:verify-first-run -- --scenario=no-token',
+    );
+    const productionBuild = noTokenJob.indexOf(
+      'GSM_RELEASE=true GSM_DEV=false pnpm build',
+    );
+    const agentSession = noTokenJob.indexOf(
+      'pnpm test:runtime:agent-session',
+    );
+    expect(firstRun).toBeGreaterThan(-1);
+    expect(productionBuild).toBeGreaterThan(firstRun);
+    expect(agentSession).toBeGreaterThan(productionBuild);
+
+    const packagedHostCommands = noTokenJob.match(
+      /pnpm test:runtime:(?:agent-[A-Za-z0-9-]+|organize-job-[A-Za-z0-9-]+)/g,
+    ) ?? [];
+    expect(packagedHostCommands).toEqual(['pnpm test:runtime:agent-session']);
+  });
+});
+
+function read(relativePath: string): string {
+  return readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+function jobBlock(workflow: string, name: string): string {
+  const heading = new RegExp(
+    String.raw`^([ \t]+)${name}:[ \t]*\r?\n`,
+    'm',
+  ).exec(workflow);
+
+  if (!heading) {
+    throw new Error(`Missing workflow job: ${name}`);
+  }
+
+  const contentStart = heading.index + heading[0].length;
+  const remainder = workflow.slice(contentStart);
+  const followingJob = remainder.search(
+    new RegExp(String.raw`^${heading[1]}[A-Za-z0-9_-]+:[ \t]*\r?$`, 'm'),
+  );
+
+  return followingJob === -1 ? remainder : remainder.slice(0, followingJob);
+}
+
+function jobField(job: string, name: string): string {
+  const field = new RegExp(
+    String.raw`^([ \t]+)${name}:[ \t]*(.*)\r?$`,
+    'm',
+  ).exec(job);
+
+  if (!field) {
+    throw new Error(`Missing ${name} in E2E workflow job`);
+  }
+
+  const remainder = job.slice(field.index + field[0].length);
+  const followingField = remainder.search(
+    new RegExp(String.raw`^${field[1]}[A-Za-z0-9_-]+:[ \t]*`, 'm'),
+  );
+
+  return field[2] + (followingField === -1 ? remainder : remainder.slice(0, followingField));
+}
+
+function expectCheckoutCredentialPersistenceDisabled(job: string): void {
+  const checkoutSteps = job
+    .split(/(?=^[ \t]*-[ \t])/m)
+    .filter((step) => /^[ \t]*(?:-[ \t]+)?uses:[ \t]*actions\/checkout@/m.test(step));
+
+  if (checkoutSteps.length === 0) {
+    throw new Error('Missing actions/checkout step in workflow job');
+  }
+
+  for (const checkoutStep of checkoutSteps) {
+    expect(checkoutStep).toMatch(/^[ \t]*persist-credentials:[ \t]*false[ \t]*$/m);
+  }
+}
+
+function expectActionsPinned(
+  workflow: string,
+  expectedActions: readonly string[],
+): void {
+  const useLines = workflow.match(/^[ \t]*uses:[ \t]*[^\r\n]+\r?$/gm) ?? [];
+  const actionReferences = Array.from(
+    workflow.matchAll(
+      /^[ \t]*uses:[ \t]*([^@\s]+)@([^\s#]+)[ \t]+#[ \t]+([^\s]+)[ \t]*\r?$/gm,
+    ),
+  );
+
+  expect(actionReferences).toHaveLength(useLines.length);
+  expect(actionReferences.length).toBeGreaterThan(0);
+  expect(workflow).not.toMatch(/^[ \t]*uses:[^\r\n]*@v\d+\b/m);
+
+  const actions = actionReferences.map(([, action]) => action);
+  for (const action of expectedActions) {
+    expect(actions).toContain(action);
+  }
+
+  for (const [, action, ref, version] of actionReferences) {
+    const expectedPin = ACTION_PINS[action];
+    if (!expectedPin) {
+      throw new Error(`Unexpected workflow action: ${action}`);
+    }
+
+    expect(ref).toMatch(/^[0-9a-f]{40}$/);
+    expect(ref).toBe(expectedPin.sha);
+    expect(version).toBe(expectedPin.version);
+  }
+}
+
+function expectActionlintVerification(ciJob: string): void {
+  const stepNames = Array.from(
+    ciJob.matchAll(/^[ \t]*-[ \t]+name:[ \t]*(.+?)[ \t]*\r?$/gm),
+    ([, name]) => name,
+  );
+  const checkoutStep = stepNames.indexOf('Checkout');
+  expect(checkoutStep).toBeGreaterThanOrEqual(0);
+  expect(stepNames[checkoutStep + 1]).toBe('Lint workflows with actionlint');
+
+  const actionlintStep = stepBlock(ciJob, 'Lint workflows with actionlint');
+  const archiveUrl =
+    'https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz';
+  const checksum =
+    '8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8';
+  const download = actionlintStep.indexOf(
+    'curl --fail --location --silent --show-error',
+  );
+  const checksumVerification = actionlintStep.indexOf(
+    'sha256sum --check --status',
+  );
+  const extraction = actionlintStep.indexOf(
+    'tar --extract --gzip --file "$archive" --directory "$actionlint_dir" actionlint',
+  );
+  const execution = actionlintStep.indexOf(
+    '"$actionlint_dir/actionlint" .github/workflows/*.yml',
+  );
+
+  expect(actionlintStep).toMatch(/^[ \t]*shell:[ \t]*bash[ \t]*$/m);
+  expect(actionlintStep).toContain('set -euo pipefail');
+  expect(actionlintStep).toContain(
+    'actionlint_dir="${RUNNER_TEMP}/actionlint-1.7.12"',
+  );
+  expect(actionlintStep).toContain(archiveUrl);
+  expect(actionlintStep).toContain(checksum);
+  expect(actionlintStep).toContain('sha256sum --check --status');
+  expect(actionlintStep).toContain('.github/workflows/*.yml');
+
+  expect(download).toBeGreaterThan(-1);
+  expect(checksumVerification).toBeGreaterThan(download);
+  expect(extraction).toBeGreaterThan(checksumVerification);
+  expect(execution).toBeGreaterThan(extraction);
+}
+
+function stepBlock(job: string, name: string): string {
+  const heading = new RegExp(
+    String.raw`^([ \t]*)-[ \t]+name:[ \t]*${name}[ \t]*\r?\n`,
+    'm',
+  ).exec(job);
+
+  if (!heading) {
+    throw new Error(`Missing workflow step: ${name}`);
+  }
+
+  const contentStart = heading.index + heading[0].length;
+  const remainder = job.slice(contentStart);
+  const followingStep = remainder.search(
+    new RegExp(String.raw`^${heading[1]}-[ \t]+name:[ \t]*`, 'm'),
+  );
+
+  return followingStep === -1 ? remainder : remainder.slice(0, followingStep);
+}

--- a/tests/unit/publish-chrome-web-store.test.mjs
+++ b/tests/unit/publish-chrome-web-store.test.mjs
@@ -481,3 +481,30 @@ test('rejects an unsupported publish type before any network request', async () 
     assertLogsOmitCredentials(logs, env);
   });
 });
+
+test('rejects each missing required environment value before any network request', async () => {
+  await withTemporaryZip(async (zipPath) => {
+    for (const key of Object.keys(BASE_ENV)) {
+      const env = environment();
+      delete env[key];
+      const calls = [];
+
+      await assert.rejects(
+        publishChromeWebStore({
+          zipPath,
+          env,
+          fetchImpl: async (...args) => {
+            calls.push(args);
+            throw new Error('unexpected network request');
+          },
+          log: () => {
+            throw new Error('unexpected log output');
+          },
+        }),
+        new RegExp(`missing required env: ${key}`, 'u'),
+      );
+
+      assert.deepEqual(calls, []);
+    }
+  });
+});

--- a/tests/unit/publish-chrome-web-store.test.mjs
+++ b/tests/unit/publish-chrome-web-store.test.mjs
@@ -1,0 +1,483 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'vitest';
+
+import { publishChromeWebStore } from '../../scripts/publish-chrome-web-store.mjs';
+
+const ACCESS_TOKEN = 'returned-access-token';
+const BASE_ENV = Object.freeze({
+  CWS_CLIENT_ID: 'test-client-id',
+  CWS_CLIENT_SECRET: 'client-secret-must-not-be-logged',
+  CWS_REFRESH_TOKEN: 'refresh-token-must-not-be-logged',
+  CWS_EXTENSION_ID: 'test-extension-id',
+  CWS_PUBLISHER_ID: 'test-publisher-id',
+});
+const RESOURCE_PATH = `publishers/${BASE_ENV.CWS_PUBLISHER_ID}/items/${BASE_ENV.CWS_EXTENSION_ID}`;
+const OAUTH_URL = 'https://oauth2.googleapis.com/token';
+const UPLOAD_URL = `https://chromewebstore.googleapis.com/upload/v2/${RESOURCE_PATH}:upload`;
+const PUBLISH_URL = `https://chromewebstore.googleapis.com/v2/${RESOURCE_PATH}:publish`;
+const ZIP_BYTES = Buffer.from([
+  0x50, 0x4b, 0x05, 0x06,
+  0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00,
+]);
+
+function environment() {
+  return { ...BASE_ENV };
+}
+
+function resourcePath(env) {
+  return `publishers/${env.CWS_PUBLISHER_ID}/items/${env.CWS_EXTENSION_ID}`;
+}
+
+function successfulUpload(env, overrides = {}) {
+  return {
+    name: resourcePath(env),
+    itemId: env.CWS_EXTENSION_ID,
+    uploadState: 'SUCCEEDED',
+    ...overrides,
+  };
+}
+
+function successfulPublish(env, overrides = {}) {
+  return {
+    name: resourcePath(env),
+    itemId: env.CWS_EXTENSION_ID,
+    state: 'PENDING_REVIEW',
+    ...overrides,
+  };
+}
+
+function jsonResponse(value) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => value,
+    text: async () => JSON.stringify(value),
+  };
+}
+
+function failedResponse(status, text) {
+  return {
+    ok: false,
+    status,
+    text: async () => text,
+  };
+}
+
+function createFetchSequence(responses) {
+  const calls = [];
+  let responseIndex = 0;
+
+  return {
+    calls,
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      if (responseIndex === responses.length) {
+        throw new Error(`Unexpected fetch request: ${String(url)}`);
+      }
+      return responses[responseIndex++];
+    },
+  };
+}
+
+async function withTemporaryZip(run) {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'publish-chrome-web-store-'));
+  const zipPath = path.join(root, 'extension.zip');
+  writeFileSync(zipPath, ZIP_BYTES);
+
+  try {
+    return await run(zipPath);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function assertNoPublishRequest(calls) {
+  assert.deepEqual(calls.map(({ url }) => url), [OAUTH_URL, UPLOAD_URL]);
+  assert.equal(calls.filter(({ url }) => url === PUBLISH_URL).length, 0);
+}
+
+function assertLogsOmitCredentials(logs, env) {
+  const output = logs.join('\n');
+  for (const credential of [
+    env.CWS_CLIENT_SECRET,
+    env.CWS_REFRESH_TOKEN,
+    ACCESS_TOKEN,
+  ]) {
+    assert.equal(output.includes(credential), false);
+  }
+}
+
+test('publishes an exact successful upload after OAuth without logging credentials', async () => {
+  await withTemporaryZip(async (zipPath) => {
+    const env = environment();
+    const logs = [];
+    const publishResult = successfulPublish(env);
+    const { calls, fetchImpl } = createFetchSequence([
+      jsonResponse({ access_token: ACCESS_TOKEN }),
+      jsonResponse(successfulUpload(env)),
+      jsonResponse(publishResult),
+    ]);
+
+    const result = await publishChromeWebStore({
+      zipPath,
+      env,
+      fetchImpl,
+      log: (line) => logs.push(String(line)),
+    });
+
+    assert.deepEqual(calls.map(({ url }) => url), [OAUTH_URL, UPLOAD_URL, PUBLISH_URL]);
+
+    const [oauth, upload, publish] = calls;
+    assert.equal(oauth.init.method, 'POST');
+    assert.deepEqual(oauth.init.headers, {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    });
+    assert.deepEqual(
+      Object.fromEntries(new URLSearchParams(String(oauth.init.body))),
+      {
+        client_id: env.CWS_CLIENT_ID,
+        client_secret: env.CWS_CLIENT_SECRET,
+        refresh_token: env.CWS_REFRESH_TOKEN,
+        grant_type: 'refresh_token',
+      },
+    );
+    assert.deepEqual(upload.init.headers, {
+      'Content-Type': 'application/zip',
+      Authorization: `Bearer ${ACCESS_TOKEN}`,
+      Accept: 'application/json',
+    });
+    assert.deepEqual(upload.init.body, ZIP_BYTES);
+    assert.deepEqual(publish.init.headers, {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${ACCESS_TOKEN}`,
+      Accept: 'application/json',
+    });
+    assert.deepEqual(JSON.parse(publish.init.body), {
+      publishType: 'DEFAULT_PUBLISH',
+      skipReview: false,
+    });
+    assert.deepEqual(result, {
+      uploadState: 'SUCCEEDED',
+      itemId: env.CWS_EXTENSION_ID,
+      published: publishResult,
+    });
+    assert.equal(logs.length, 1);
+    assert.deepEqual(JSON.parse(logs[0]), result);
+    assertLogsOmitCredentials(logs, env);
+  });
+});
+
+test('accepts a staged response only for staged publishing', async () => {
+  await withTemporaryZip(async (zipPath) => {
+    const env = {
+      ...environment(),
+      CWS_PUBLISH_TYPE: 'STAGED_PUBLISH',
+    };
+    const logs = [];
+    const publishResult = successfulPublish(env, { state: 'STAGED' });
+    const { calls, fetchImpl } = createFetchSequence([
+      jsonResponse({ access_token: ACCESS_TOKEN }),
+      jsonResponse(successfulUpload(env)),
+      jsonResponse(publishResult),
+    ]);
+
+    const result = await publishChromeWebStore({
+      zipPath,
+      env,
+      fetchImpl,
+      log: (line) => logs.push(String(line)),
+    });
+
+    assert.deepEqual(JSON.parse(calls[2].init.body), {
+      publishType: 'STAGED_PUBLISH',
+      skipReview: false,
+    });
+    assert.deepEqual(result.published, publishResult);
+    assert.deepEqual(JSON.parse(logs[0]), result);
+    assertLogsOmitCredentials(logs, env);
+  });
+});
+
+test('rejects a missing upload state before publishing', async () => {
+  await withTemporaryZip(async (zipPath) => {
+    const env = environment();
+    const logs = [];
+    const { calls, fetchImpl } = createFetchSequence([
+      jsonResponse({ access_token: ACCESS_TOKEN }),
+      jsonResponse({
+        name: resourcePath(env),
+        itemId: env.CWS_EXTENSION_ID,
+      }),
+    ]);
+
+    await assert.rejects(
+      publishChromeWebStore({
+        zipPath,
+        env,
+        fetchImpl,
+        log: (line) => logs.push(String(line)),
+      }),
+      /upload failed with state missing/u,
+    );
+
+    assertNoPublishRequest(calls);
+    assert.deepEqual(logs, []);
+    assertLogsOmitCredentials(logs, env);
+  });
+});
+
+test('rejects a successful upload without an item ID before publishing', async () => {
+  await withTemporaryZip(async (zipPath) => {
+    const env = environment();
+    const logs = [];
+    const { calls, fetchImpl } = createFetchSequence([
+      jsonResponse({ access_token: ACCESS_TOKEN }),
+      jsonResponse({
+        name: resourcePath(env),
+        uploadState: 'SUCCEEDED',
+      }),
+    ]);
+
+    await assert.rejects(
+      publishChromeWebStore({
+        zipPath,
+        env,
+        fetchImpl,
+        log: (line) => logs.push(String(line)),
+      }),
+      /upload failed: itemId does not match configured extension ID/u,
+    );
+
+    assertNoPublishRequest(calls);
+    assert.deepEqual(logs, []);
+    assertLogsOmitCredentials(logs, env);
+  });
+});
+
+test('rejects a non-success upload state before publishing', async () => {
+  await withTemporaryZip(async (zipPath) => {
+    const env = environment();
+    const logs = [];
+    const { calls, fetchImpl } = createFetchSequence([
+      jsonResponse({ access_token: ACCESS_TOKEN }),
+      jsonResponse(successfulUpload(env, {
+        uploadState: 'IN_PROGRESS',
+      })),
+    ]);
+
+    await assert.rejects(
+      publishChromeWebStore({
+        zipPath,
+        env,
+        fetchImpl,
+        log: (line) => logs.push(String(line)),
+      }),
+      /upload failed with state IN_PROGRESS/u,
+    );
+
+    assertNoPublishRequest(calls);
+    assert.deepEqual(logs, []);
+    assertLogsOmitCredentials(logs, env);
+  });
+});
+
+test('rejects a successful upload for a different item before publishing', async () => {
+  await withTemporaryZip(async (zipPath) => {
+    const env = environment();
+    const logs = [];
+    const { calls, fetchImpl } = createFetchSequence([
+      jsonResponse({ access_token: ACCESS_TOKEN }),
+      jsonResponse(successfulUpload(env, {
+        itemId: 'different-extension-id',
+      })),
+    ]);
+
+    await assert.rejects(
+      publishChromeWebStore({
+        zipPath,
+        env,
+        fetchImpl,
+        log: (line) => logs.push(String(line)),
+      }),
+      /upload failed: itemId does not match configured extension ID/u,
+    );
+
+    assertNoPublishRequest(calls);
+    assert.deepEqual(logs, []);
+    assertLogsOmitCredentials(logs, env);
+  });
+});
+
+
+test('rejects a publish response without a state', async () => {
+  await withTemporaryZip(async (zipPath) => {
+    const env = environment();
+    const logs = [];
+    const { calls, fetchImpl } = createFetchSequence([
+      jsonResponse({ access_token: ACCESS_TOKEN }),
+      jsonResponse(successfulUpload(env)),
+      jsonResponse({
+        name: resourcePath(env),
+        itemId: env.CWS_EXTENSION_ID,
+      }),
+    ]);
+
+    await assert.rejects(
+      publishChromeWebStore({
+        zipPath,
+        env,
+        fetchImpl,
+        log: (line) => logs.push(String(line)),
+      }),
+      /publish failed with state missing/u,
+    );
+
+    assert.deepEqual(calls.map(({ url }) => url), [OAUTH_URL, UPLOAD_URL, PUBLISH_URL]);
+    assert.deepEqual(logs, []);
+    assertLogsOmitCredentials(logs, env);
+  });
+});
+
+test('rejects a publish response with a terminal failure state', async () => {
+  await withTemporaryZip(async (zipPath) => {
+    const env = environment();
+    const logs = [];
+    const { calls, fetchImpl } = createFetchSequence([
+      jsonResponse({ access_token: ACCESS_TOKEN }),
+      jsonResponse(successfulUpload(env)),
+      jsonResponse(successfulPublish(env, { state: 'REJECTED' })),
+    ]);
+
+    await assert.rejects(
+      publishChromeWebStore({
+        zipPath,
+        env,
+        fetchImpl,
+        log: (line) => logs.push(String(line)),
+      }),
+      /publish failed with state REJECTED/u,
+    );
+
+    assert.deepEqual(calls.map(({ url }) => url), [OAUTH_URL, UPLOAD_URL, PUBLISH_URL]);
+    assert.deepEqual(logs, []);
+    assertLogsOmitCredentials(logs, env);
+  });
+});
+
+test('rejects a staged response for default publishing', async () => {
+  await withTemporaryZip(async (zipPath) => {
+    const env = environment();
+    const logs = [];
+    const { calls, fetchImpl } = createFetchSequence([
+      jsonResponse({ access_token: ACCESS_TOKEN }),
+      jsonResponse(successfulUpload(env)),
+      jsonResponse(successfulPublish(env, { state: 'STAGED' })),
+    ]);
+
+    await assert.rejects(
+      publishChromeWebStore({
+        zipPath,
+        env,
+        fetchImpl,
+        log: (line) => logs.push(String(line)),
+      }),
+      /publish failed with state STAGED/u,
+    );
+
+    assert.deepEqual(calls.map(({ url }) => url), [OAUTH_URL, UPLOAD_URL, PUBLISH_URL]);
+    assert.deepEqual(logs, []);
+    assertLogsOmitCredentials(logs, env);
+  });
+});
+
+test('rejects a successful publish response without an item ID', async () => {
+  await withTemporaryZip(async (zipPath) => {
+    const env = environment();
+    const logs = [];
+    const { calls, fetchImpl } = createFetchSequence([
+      jsonResponse({ access_token: ACCESS_TOKEN }),
+      jsonResponse(successfulUpload(env)),
+      jsonResponse({
+        name: resourcePath(env),
+        state: 'PENDING_REVIEW',
+      }),
+    ]);
+
+    await assert.rejects(
+      publishChromeWebStore({
+        zipPath,
+        env,
+        fetchImpl,
+        log: (line) => logs.push(String(line)),
+      }),
+      /publish failed: itemId does not match configured extension ID/u,
+    );
+
+    assert.deepEqual(calls.map(({ url }) => url), [OAUTH_URL, UPLOAD_URL, PUBLISH_URL]);
+    assert.deepEqual(logs, []);
+    assertLogsOmitCredentials(logs, env);
+  });
+});
+
+test('propagates a publish HTTP failure after one proven upload', async () => {
+  await withTemporaryZip(async (zipPath) => {
+    const env = environment();
+    const logs = [];
+    const { calls, fetchImpl } = createFetchSequence([
+      jsonResponse({ access_token: ACCESS_TOKEN }),
+      jsonResponse(successfulUpload(env)),
+      failedResponse(503, 'publisher unavailable'),
+    ]);
+
+    await assert.rejects(
+      publishChromeWebStore({
+        zipPath,
+        env,
+        fetchImpl,
+        log: (line) => logs.push(String(line)),
+      }),
+      /Chrome Web Store API failed: 503 publisher unavailable/u,
+    );
+
+    assert.deepEqual(calls.map(({ url }) => url), [OAUTH_URL, UPLOAD_URL, PUBLISH_URL]);
+    assert.equal(calls.filter(({ url }) => url === UPLOAD_URL).length, 1);
+    assert.equal(calls.filter(({ url }) => url === PUBLISH_URL).length, 1);
+    assert.deepEqual(logs, []);
+    assertLogsOmitCredentials(logs, env);
+  });
+});
+
+test('rejects an unsupported publish type before any network request', async () => {
+  await withTemporaryZip(async (zipPath) => {
+    const env = {
+      ...environment(),
+      CWS_PUBLISH_TYPE: 'UNSUPPORTED_PUBLISH',
+    };
+    const logs = [];
+    const calls = [];
+
+    await assert.rejects(
+      publishChromeWebStore({
+        zipPath,
+        env,
+        fetchImpl: async (...args) => {
+          calls.push(args);
+          throw new Error('unexpected network request');
+        },
+        log: (line) => logs.push(String(line)),
+      }),
+      /unsupported Chrome Web Store publish type: UNSUPPORTED_PUBLISH/u,
+    );
+
+    assert.deepEqual(calls, []);
+    assert.deepEqual(logs, []);
+    assertLogsOmitCredentials(logs, env);
+  });
+});

--- a/tests/unit/publish-chrome-web-store.test.mjs
+++ b/tests/unit/publish-chrome-web-store.test.mjs
@@ -18,6 +18,7 @@ const RESOURCE_PATH = `publishers/${BASE_ENV.CWS_PUBLISHER_ID}/items/${BASE_ENV.
 const OAUTH_URL = 'https://oauth2.googleapis.com/token';
 const UPLOAD_URL = `https://chromewebstore.googleapis.com/upload/v2/${RESOURCE_PATH}:upload`;
 const PUBLISH_URL = `https://chromewebstore.googleapis.com/v2/${RESOURCE_PATH}:publish`;
+const FETCH_STATUS_URL = `https://chromewebstore.googleapis.com/v2/${RESOURCE_PATH}:fetchStatus`;
 const ZIP_BYTES = Buffer.from([
   0x50, 0x4b, 0x05, 0x06,
   0x00, 0x00, 0x00, 0x00,
@@ -40,6 +41,15 @@ function successfulUpload(env, overrides = {}) {
     name: resourcePath(env),
     itemId: env.CWS_EXTENSION_ID,
     uploadState: 'SUCCEEDED',
+    ...overrides,
+  };
+}
+
+function uploadStatus(env, state, overrides = {}) {
+  return {
+    name: resourcePath(env),
+    itemId: env.CWS_EXTENSION_ID,
+    lastAsyncUploadState: state,
     ...overrides,
   };
 }
@@ -261,14 +271,131 @@ test('rejects a successful upload without an item ID before publishing', async (
   });
 });
 
-test('rejects a non-success upload state before publishing', async () => {
+test('polls an asynchronous upload to success before publishing', async () => {
+  await withTemporaryZip(async (zipPath) => {
+    const env = environment();
+    const logs = [];
+    const sleeps = [];
+    const publishResult = successfulPublish(env);
+    const { calls, fetchImpl } = createFetchSequence([
+      jsonResponse({ access_token: ACCESS_TOKEN }),
+      jsonResponse(successfulUpload(env, { uploadState: 'IN_PROGRESS' })),
+      jsonResponse(uploadStatus(env, 'IN_PROGRESS')),
+      jsonResponse(uploadStatus(env, 'SUCCEEDED')),
+      jsonResponse(publishResult),
+    ]);
+
+    const result = await publishChromeWebStore({
+      zipPath,
+      env,
+      fetchImpl,
+      log: (line) => logs.push(String(line)),
+      sleep: async (milliseconds) => sleeps.push(milliseconds),
+      uploadPollIntervalMs: 10,
+      uploadPollTimeoutMs: 30,
+    });
+
+    assert.deepEqual(calls.map(({ url }) => url), [
+      OAUTH_URL,
+      UPLOAD_URL,
+      FETCH_STATUS_URL,
+      FETCH_STATUS_URL,
+      PUBLISH_URL,
+    ]);
+    assert.deepEqual(sleeps, [10, 10]);
+    assert.equal(calls[2].init.method, 'GET');
+    assert.equal(calls[2].init.body, undefined);
+    assert.deepEqual(result, {
+      uploadState: 'SUCCEEDED',
+      itemId: env.CWS_EXTENSION_ID,
+      published: publishResult,
+    });
+    assert.deepEqual(JSON.parse(logs[0]), result);
+    assertLogsOmitCredentials(logs, env);
+  });
+});
+
+test('rejects an asynchronous upload that reaches a failed state', async () => {
+  await withTemporaryZip(async (zipPath) => {
+    const env = environment();
+    const logs = [];
+    const sleeps = [];
+    const { calls, fetchImpl } = createFetchSequence([
+      jsonResponse({ access_token: ACCESS_TOKEN }),
+      jsonResponse(successfulUpload(env, { uploadState: 'IN_PROGRESS' })),
+      jsonResponse(uploadStatus(env, 'FAILED')),
+    ]);
+
+    await assert.rejects(
+      publishChromeWebStore({
+        zipPath,
+        env,
+        fetchImpl,
+        log: (line) => logs.push(String(line)),
+        sleep: async (milliseconds) => sleeps.push(milliseconds),
+        uploadPollIntervalMs: 10,
+        uploadPollTimeoutMs: 30,
+      }),
+      /upload failed with state FAILED/u,
+    );
+
+    assert.deepEqual(calls.map(({ url }) => url), [
+      OAUTH_URL,
+      UPLOAD_URL,
+      FETCH_STATUS_URL,
+    ]);
+    assert.deepEqual(sleeps, [10]);
+    assert.deepEqual(logs, []);
+    assertLogsOmitCredentials(logs, env);
+  });
+});
+
+test('rejects an asynchronous upload after the bounded polling timeout', async () => {
+  await withTemporaryZip(async (zipPath) => {
+    const env = environment();
+    const logs = [];
+    const sleeps = [];
+    const { calls, fetchImpl } = createFetchSequence([
+      jsonResponse({ access_token: ACCESS_TOKEN }),
+      jsonResponse(successfulUpload(env, { uploadState: 'IN_PROGRESS' })),
+      jsonResponse(uploadStatus(env, 'IN_PROGRESS')),
+      jsonResponse(uploadStatus(env, 'IN_PROGRESS')),
+    ]);
+
+    await assert.rejects(
+      publishChromeWebStore({
+        zipPath,
+        env,
+        fetchImpl,
+        log: (line) => logs.push(String(line)),
+        sleep: async (milliseconds) => sleeps.push(milliseconds),
+        uploadPollIntervalMs: 10,
+        uploadPollTimeoutMs: 20,
+      }),
+      /upload timed out after 20ms/u,
+    );
+
+    assert.deepEqual(calls.map(({ url }) => url), [
+      OAUTH_URL,
+      UPLOAD_URL,
+      FETCH_STATUS_URL,
+      FETCH_STATUS_URL,
+    ]);
+    assert.deepEqual(sleeps, [10, 10]);
+    assert.deepEqual(logs, []);
+    assertLogsOmitCredentials(logs, env);
+  });
+});
+
+test('rejects an asynchronous upload status for a different item', async () => {
   await withTemporaryZip(async (zipPath) => {
     const env = environment();
     const logs = [];
     const { calls, fetchImpl } = createFetchSequence([
       jsonResponse({ access_token: ACCESS_TOKEN }),
-      jsonResponse(successfulUpload(env, {
-        uploadState: 'IN_PROGRESS',
+      jsonResponse(successfulUpload(env, { uploadState: 'IN_PROGRESS' })),
+      jsonResponse(uploadStatus(env, 'SUCCEEDED', {
+        itemId: 'different-extension-id',
       })),
     ]);
 
@@ -278,11 +405,18 @@ test('rejects a non-success upload state before publishing', async () => {
         env,
         fetchImpl,
         log: (line) => logs.push(String(line)),
+        sleep: async () => {},
+        uploadPollIntervalMs: 10,
+        uploadPollTimeoutMs: 10,
       }),
-      /upload failed with state IN_PROGRESS/u,
+      /upload failed: itemId does not match configured extension ID/u,
     );
 
-    assertNoPublishRequest(calls);
+    assert.deepEqual(calls.map(({ url }) => url), [
+      OAUTH_URL,
+      UPLOAD_URL,
+      FETCH_STATUS_URL,
+    ]);
     assert.deepEqual(logs, []);
     assertLogsOmitCredentials(logs, env);
   });
@@ -487,6 +621,35 @@ test('rejects each missing required environment value before any network request
     for (const key of Object.keys(BASE_ENV)) {
       const env = environment();
       delete env[key];
+      const calls = [];
+
+      await assert.rejects(
+        publishChromeWebStore({
+          zipPath,
+          env,
+          fetchImpl: async (...args) => {
+            calls.push(args);
+            throw new Error('unexpected network request');
+          },
+          log: () => {
+            throw new Error('unexpected log output');
+          },
+        }),
+        new RegExp(`missing required env: ${key}`, 'u'),
+      );
+
+      assert.deepEqual(calls, []);
+    }
+  });
+});
+
+test('rejects whitespace-only required environment values before any network request', async () => {
+  await withTemporaryZip(async (zipPath) => {
+    for (const key of Object.keys(BASE_ENV)) {
+      const env = {
+        ...environment(),
+        [key]: ' \t\n ',
+      };
       const calls = [];
 
       await assert.rejects(

--- a/tests/unit/verify-first-run-strict-selection.test.mjs
+++ b/tests/unit/verify-first-run-strict-selection.test.mjs
@@ -34,7 +34,7 @@ function outputOf(result) {
   return `${result.stdout}\n${result.stderr}`;
 }
 
-test('selected valid-token skips without Chrome and strict mode fails closed', () => {
+test('valid selections preserve skip behavior while invalid selections fail before Chrome', () => {
   const root = mkdtempSync(path.join(os.tmpdir(), 'verify-first-run-strict-'));
 
   try {
@@ -64,13 +64,13 @@ test('selected valid-token skips without Chrome and strict mode fails closed', (
     assert.match(missingToken.stderr, /selected scenario\(s\) skipped: valid-token/u);
     assert.doesNotMatch(missingToken.stdout, /Profile:/u);
 
-    const unknown = runVerifyFirstRun(root, ['--scenario=unknown', '--require-selected']);
+    const unknown = runVerifyFirstRun(root, ['--scenario=unknown']);
     assert.equal(unknown.error, undefined, unknown.error?.message);
     assert.equal(unknown.status, 1, outputOf(unknown));
     assert.match(unknown.stderr, /Unknown --scenario selection: unknown/u);
     assert.doesNotMatch(unknown.stdout, /Summary:/u);
 
-    const empty = runVerifyFirstRun(root, ['--scenario=', '--require-selected']);
+    const empty = runVerifyFirstRun(root, ['--scenario=']);
     assert.equal(empty.error, undefined, empty.error?.message);
     assert.equal(empty.status, 1, outputOf(empty));
     assert.match(empty.stderr, /empty --scenario selection/u);

--- a/tests/unit/verify-first-run-strict-selection.test.mjs
+++ b/tests/unit/verify-first-run-strict-selection.test.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'vitest';
+
+const VERIFY_FIRST_RUN = path.resolve('tests/manual/e2e/verify-first-run.mjs');
+const SCENARIO_ENV_KEYS = [
+  'GH_TOKEN',
+  'GH_TOKEN_NO_GISTS',
+  'GH_USER',
+  'GH_TOKEN_INVALID',
+  'GSM_RESET_GIST',
+];
+
+function runVerifyFirstRun(root, args, environment = {}) {
+  const env = {
+    ...process.env,
+    // Any browser launch makes the ordinary skipped invocation fail deterministically.
+    PUPPETEER_EXECUTABLE_PATH: path.join(root, 'chrome-must-not-launch'),
+  };
+  for (const key of SCENARIO_ENV_KEYS) delete env[key];
+  Object.assign(env, environment);
+
+  return spawnSync(process.execPath, [VERIFY_FIRST_RUN, ...args], {
+    cwd: root,
+    encoding: 'utf8',
+    env,
+  });
+}
+
+function outputOf(result) {
+  return `${result.stdout}\n${result.stderr}`;
+}
+
+test('selected valid-token skips without Chrome and strict mode fails closed', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'verify-first-run-strict-'));
+
+  try {
+    mkdirSync(path.join(root, 'dist'));
+    writeFileSync(path.join(root, 'dist', 'manifest.json'), '{}\n');
+
+    const ordinary = runVerifyFirstRun(root, ['--scenario=valid-token']);
+    assert.equal(ordinary.error, undefined, ordinary.error?.message);
+    assert.equal(ordinary.status, 0, outputOf(ordinary));
+    assert.match(ordinary.stdout, /Summary:\n - valid-token: skipped/u);
+
+    const strict = runVerifyFirstRun(root, ['--scenario=valid-token', '--require-selected']);
+    assert.equal(strict.error, undefined, strict.error?.message);
+    assert.equal(strict.status, 1, outputOf(strict));
+    assert.match(strict.stdout, /Summary:\n - valid-token: skipped/u);
+    assert.match(strict.stderr, /--require-selected: selected scenario\(s\) skipped: valid-token/u);
+    assert.doesNotMatch(strict.stdout, /Profile:/u);
+
+    const missingToken = runVerifyFirstRun(
+      root,
+      ['--scenario=valid-token', '--require-selected'],
+      { GH_USER: 'fixture-user' },
+    );
+    assert.equal(missingToken.error, undefined, missingToken.error?.message);
+    assert.equal(missingToken.status, 1, outputOf(missingToken));
+    assert.match(missingToken.stdout, /valid-token: skipped — Missing required env/u);
+    assert.match(missingToken.stderr, /selected scenario\(s\) skipped: valid-token/u);
+    assert.doesNotMatch(missingToken.stdout, /Profile:/u);
+
+    const unknown = runVerifyFirstRun(root, ['--scenario=unknown', '--require-selected']);
+    assert.equal(unknown.error, undefined, unknown.error?.message);
+    assert.equal(unknown.status, 1, outputOf(unknown));
+    assert.match(unknown.stderr, /Unknown --scenario selection: unknown/u);
+    assert.doesNotMatch(unknown.stdout, /Summary:/u);
+
+    const empty = runVerifyFirstRun(root, ['--scenario=', '--require-selected']);
+    assert.equal(empty.error, undefined, empty.error?.message);
+    assert.equal(empty.status, 1, outputOf(empty));
+    assert.match(empty.stderr, /empty --scenario selection/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- keep pull-request E2E credential-free and move authenticated first-run checks to scheduled/manual runs through the `e2e-credentials` Environment
- pin every GitHub Action to a reviewed full commit SHA and install `actionlint` through a checksum-verified permanent CI step
- make tagged Release reruns immutable: existing assets must have the exact canonical name set and byte content before Chrome Web Store retry can continue
- validate Chrome Web Store v2 upload/publish identities and documented states fail-closed; never publish after a missing or mismatched result

## Security boundaries

- neither CI workflow sets `GSM_RESET_GIST`; automated jobs cannot reach the bulk Gist deletion path
- checkout credentials are not persisted
- pull-request events cannot access the authenticated Environment job
- tag movement/deletion is separately blocked by the active `immutable release tags` ruleset

## Verification

- `pnpm build`
- `pnpm test` — 188 test files / 2,896 tests passed; Puppeteer resolved a concrete Chrome executable
- `pnpm typecheck`
- `actionlint .github/workflows/*.yml`
- parsed every workflow as YAML
- exercised Release shell against absent, byte-identical, inventory-mismatch, and byte-mismatch GitHub Release scenarios

## Operational follow-up

- after merge, manually dispatch authenticated E2E on `master`; only after that succeeds, remove the duplicate repository-level `GH_TOKEN` and `GH_TOKEN_NO_GISTS` secrets
- after merge, make the CI and E2E checks required on `master`; the existing legacy ruleset intentionally excludes `master` today to avoid blocking this repair PR
- Chrome Web Store secrets and deployment variables remain unconfigured; no live store submission was attempted
