### PR TITLE
Add one-time E2E secret migration

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,6 +79,9 @@ jobs:
       (github.event_name == 'workflow_dispatch' &&
       github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     environment: e2e-credentials
+    concurrency:
+      group: e2e-credentials-${{ github.ref }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 50
 

--- a/.github/workflows/migrate-e2e-secrets.yml
+++ b/.github/workflows/migrate-e2e-secrets.yml
@@ -1,0 +1,34 @@
+name: Migrate E2E Secrets
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: migrate-e2e-secrets
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  migrate:
+    if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+    environment: e2e-credentials
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Copy repository secrets into the E2E Environment
+        env:
+          GH_TOKEN: ${{ secrets.E2E_SECRET_MIGRATOR_TOKEN }}
+          SOURCE_GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          SOURCE_GH_TOKEN_NO_GISTS: ${{ secrets.GH_TOKEN_NO_GISTS }}
+        run: |
+          set -euo pipefail
+          test -n "$GH_TOKEN"
+          test -n "$SOURCE_GH_TOKEN"
+          test -n "$SOURCE_GH_TOKEN_NO_GISTS"
+          printf '%s' "$SOURCE_GH_TOKEN" |
+            gh secret set E2E_GH_TOKEN --env e2e-credentials --repo "$GITHUB_REPOSITORY"
+          printf '%s' "$SOURCE_GH_TOKEN_NO_GISTS" |
+            gh secret set E2E_GH_TOKEN_NO_GISTS --env e2e-credentials --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/migrate-e2e-secrets.yml
+++ b/.github/workflows/migrate-e2e-secrets.yml
@@ -3,10 +3,6 @@ name: Migrate E2E Secrets
 on:
   workflow_dispatch:
 
-concurrency:
-  group: migrate-e2e-secrets
-  cancel-in-progress: false
-
 permissions:
   contents: read
 
@@ -14,6 +10,9 @@ jobs:
   migrate:
     if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     environment: e2e-credentials
+    concurrency:
+      group: e2e-credentials-${{ github.ref }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -32,3 +31,4 @@ jobs:
             gh secret set E2E_GH_TOKEN --env e2e-credentials --repo "$GITHUB_REPOSITORY"
           printf '%s' "$SOURCE_GH_TOKEN_NO_GISTS" |
             gh secret set E2E_GH_TOKEN_NO_GISTS --env e2e-credentials --repo "$GITHUB_REPOSITORY"
+          gh secret delete E2E_SECRET_MIGRATOR_TOKEN --repo "$GITHUB_REPOSITORY"

--- a/tests/unit/e2e-credential-isolation.test.ts
+++ b/tests/unit/e2e-credential-isolation.test.ts
@@ -40,6 +40,12 @@ describe('E2E credential isolation', () => {
     );
     expect(authenticatedJob).toMatch(/^[ \t]*environment:[ \t]*e2e-credentials[ \t]*$/m);
     expect(authenticatedJob).toMatch(
+      /^[ \t]*group:[ \t]*e2e-credentials-\$\{\{ github\.ref \}\}[ \t]*$/m,
+    );
+    expect(authenticatedJob).toMatch(
+      /^[ \t]*cancel-in-progress:[ \t]*false[ \t]*$/m,
+    );
+    expect(authenticatedJob).toMatch(
       /\$\{\{\s*secrets\.E2E_GH_TOKEN\s*\}\}/,
     );
     expect(authenticatedJob).toMatch(


### PR DESCRIPTION
## Purpose

One-time, non-exporting migration of the existing repository-level E2E tokens into the protected `e2e-credentials` Environment.

## Security properties

- manual dispatch only
- runs only from the default branch
- protected by the `e2e-credentials` Environment branch policy
- shares `e2e-credentials-${{ github.ref }}` concurrency with the authenticated consumer, so migration and use cannot overlap
- never prints either source token
- sends each source token through stdin to `gh secret set`, which encrypts it before GitHub storage
- uses the short-lived `E2E_SECRET_MIGRATOR_TOKEN`, deleted only after both Environment writes succeed

## Verification

- workflow YAML parsed
- actionlint v1.7.12 passed after SHA-256 verification
- focused workflow contract tests passed

After migration, authenticated E2E must pass before the repository-level `GH_TOKEN` and `GH_TOKEN_NO_GISTS` secrets are deleted. The migration workflow is removed only after that cleanup is verified.
