### PR TITLE
fix: harden cross-cutting correctness contracts

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -94,6 +94,10 @@ Watch retrieves notifications from your GitHub inbox and organizes them in one w
 - Fetch an Issue or Pull Request body, state, author, labels, assignees, and milestone on demand
 - Mark one notification or an entire repository group as read or done
 
+<div align="center">
+  <img src="store-assets/chrome-web-store/03-watch-activity-1280x800.png" alt="Watch workspace showing notifications grouped by repository" width="960" />
+</div>
+
 Watch Inbox requires the optional `notifications` scope on your Classic Personal Access Token (PAT). See [How Watch works](docs/en/watch-strategy.md) for its full behavior.
 
 ### Discover projects worth following

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Watch 工作区用于获取 GitHub 信箱的通知并整理给你:
 - 按需读取 Issue 或 Pull Request 的正文、状态、作者、labels、assignees 和 milestone
 - 将一条通知或整个仓库组标记为已读或完成
 
+<div align="center">
+  <img src="store-assets/chrome-web-store/03-watch-activity-1280x800.png" alt="Watch 工作区按仓库分组查看通知" width="960" />
+</div>
+
 Watch Inbox 需要 Classic Personal Access Token (PAT) 的可选 `notifications` scope。完整行为见 [Watch 的工作方式](docs/zh/watch-strategy.md)。
 
 ### 发现你所爱

--- a/src/api/github-radar-source.ts
+++ b/src/api/github-radar-source.ts
@@ -56,6 +56,7 @@ type ActivityPageTarget = Readonly<{
 type ActivityBatch = GraphqlRateLimit & {
   activities: RadarActivityRecord[];
   continuations: ActivityPageTarget[];
+  skippedTargets: ActivityPageTarget[];
   privateActivityOmitted: boolean;
 };
 
@@ -103,17 +104,19 @@ function parseResetAt(value: unknown): string | null {
   return Number.isFinite(millis) ? new Date(millis).toISOString() : null;
 }
 
-function classifyGraphqlErrors(errors: unknown): GitHubRadarError {
-  if (!Array.isArray(errors) || errors.length === 0) {
-    return new GitHubRadarError('invalid_response');
-  }
+function graphqlErrorTypes(error: Record<string, unknown>): string[] {
+  const extensions = record(error.extensions);
+  return [nonEmptyString(error.type), nonEmptyString(extensions?.type)].filter(
+    (value): value is string => value !== null,
+  );
+}
+
+function classifyGraphqlErrors(errors: readonly unknown[]): GitHubRadarError {
+  if (errors.length === 0) return new GitHubRadarError('invalid_response');
 
   const types = errors.flatMap((item) => {
     const error = record(item);
-    const extensions = record(error?.extensions);
-    return [nonEmptyString(error?.type), nonEmptyString(extensions?.type)].filter(
-      (value): value is string => value !== null,
-    );
+    return error ? graphqlErrorTypes(error) : [];
   });
 
   if (types.some((type) => /RATE_LIMIT/iu.test(type))) {
@@ -123,6 +126,33 @@ function classifyGraphqlErrors(errors: unknown): GitHubRadarError {
     return new GitHubRadarError('permission_denied');
   }
   return new GitHubRadarError('invalid_response');
+}
+
+function recoverableMissingActivityIndexes(
+  errors: readonly unknown[],
+  targetCount: number,
+): Set<number> | null {
+  const indexes = new Set<number>();
+  for (const item of errors) {
+    const error = record(item);
+    const types = error ? graphqlErrorTypes(error) : [];
+    const path = error?.path;
+    if (
+      types.length === 0
+      || types.some((type) => type.toUpperCase() !== 'NOT_FOUND')
+      || !Array.isArray(path)
+      || path.length === 0
+      || path.some((segment) => typeof segment !== 'string'
+        && !(typeof segment === 'number' && Number.isSafeInteger(segment) && segment >= 0))
+    ) return null;
+
+    const alias = path[0];
+    const match = typeof alias === 'string' ? /^follower(0|[1-9]\d*)$/u.exec(alias) : null;
+    const index = match ? Number(match[1]) : -1;
+    if (!Number.isSafeInteger(index) || index < 0 || index >= targetCount) return null;
+    indexes.add(index);
+  }
+  return indexes.size > 0 ? indexes : null;
 }
 
 function headerRateLimit(response: Response): GraphqlRateLimit {
@@ -166,7 +196,11 @@ async function fetchGraphql(
   query: string,
   variables: Record<string, unknown>,
   options: { signal?: AbortSignal; timeoutMs: number },
-): Promise<{ data: Record<string, unknown>; rateLimit: GraphqlRateLimit }> {
+): Promise<{
+  data: Record<string, unknown>;
+  errors: readonly unknown[];
+  rateLimit: GraphqlRateLimit;
+}> {
   if (options.signal?.aborted) throw new GitHubRadarError('request_aborted');
   const controller = new AbortController();
   let requestTimedOut = false;
@@ -215,12 +249,13 @@ async function fetchGraphql(
     throw new GitHubRadarError('invalid_response');
   }
 
-  if (Array.isArray(envelope.errors) && envelope.errors.length > 0) {
-    throw classifyGraphqlErrors(envelope.errors);
-  }
+  const errors = Array.isArray(envelope.errors) ? envelope.errors : [];
   const data = record(envelope.data);
-  if (!data) throw new GitHubRadarError('invalid_response');
-  return { data, rateLimit: headerRateLimit(response) };
+  if (!data) {
+    if (errors.length > 0) throw classifyGraphqlErrors(errors);
+    throw new GitHubRadarError('invalid_response');
+  }
+  return { data, errors, rateLimit: headerRateLimit(response) };
 }
 
 function parseRateLimit(
@@ -241,6 +276,7 @@ async function fetchFollowingPage(
   options: { signal?: AbortSignal; timeoutMs: number },
 ): Promise<FollowingPage> {
   const result = await fetchGraphql(fetchImpl, token, FOLLOWING_QUERY, { cursor }, options);
+  if (result.errors.length > 0) throw classifyGraphqlErrors(result.errors);
   const viewer = record(result.data.viewer);
   const accountLogin = nonEmptyString(viewer?.login);
   const following = record(viewer?.following);
@@ -309,12 +345,14 @@ function parseActivityBatch(
   accountLogin: string,
   targets: readonly ActivityPageTarget[],
   cutoffMillis: number,
+  skippedIndexes: ReadonlySet<number>,
 ): ActivityBatch {
   const activities: RadarActivityRecord[] = [];
   const continuations: ActivityPageTarget[] = [];
   let privateActivityOmitted = false;
 
   for (let index = 0; index < targets.length; index += 1) {
+    if (skippedIndexes.has(index)) continue;
     const userValue = data[`follower${index}`];
     if (userValue === null) continue;
     const user = record(userValue);
@@ -402,6 +440,7 @@ function parseActivityBatch(
   return {
     activities,
     continuations,
+    skippedTargets: targets.filter((_, index) => skippedIndexes.has(index)),
     privateActivityOmitted,
     ...parseRateLimit(data, fallbackRateLimit),
   };
@@ -427,12 +466,17 @@ async function fetchActivityBatch(
     variables,
     options,
   );
+  const skippedIndexes = result.errors.length === 0
+    ? new Set<number>()
+    : recoverableMissingActivityIndexes(result.errors, targets.length);
+  if (skippedIndexes === null) throw classifyGraphqlErrors(result.errors);
   return parseActivityBatch(
     result.data,
     result.rateLimit,
     accountLogin,
     targets,
     cutoffMillis,
+    skippedIndexes,
   );
 }
 
@@ -562,10 +606,13 @@ export async function fetchGitHubRadar(
     offset += targets.length;
     activities.push(...batch.activities);
     batchCount += 1;
-    scannedFollowingCount += targets.filter((target) => target.cursor === null).length;
+    scannedFollowingCount += targets.filter((target) => (
+      target.cursor === null && !batch.skippedTargets.includes(target)
+    )).length;
     rateLimitRemaining = minNullable(rateLimitRemaining, batch.remaining);
     rateLimitResetAt = batch.resetAt ?? rateLimitResetAt;
     if (batch.privateActivityOmitted) partialReasons.add('private_activity_omitted');
+    addPendingActivityReasons(batch.skippedTargets, partialReasons);
 
     for (const continuation of batch.continuations) {
       const identity = JSON.stringify([

--- a/src/background/bgsm-agent-conversation.ts
+++ b/src/background/bgsm-agent-conversation.ts
@@ -36,7 +36,8 @@ export async function resolveBgsmAgentConversation(
       dependencies.providerFingerprint,
     );
     if (
-      recomputed.scopeFingerprint !== input.binding.scopeFingerprint
+      scopeFingerprintDigest(recomputed.scopeFingerprint)
+        !== scopeFingerprintDigest(input.binding.scopeFingerprint)
       || recomputed.label !== input.binding.label
       || recomputed.count !== input.binding.count
     ) {
@@ -65,6 +66,12 @@ export async function resolveBgsmAgentConversation(
     binding,
     repositoryIds: Object.freeze([...candidate.repositoryIds]),
   });
+}
+
+function scopeFingerprintDigest(
+  fingerprint: BgsmAgentConversationBinding['scopeFingerprint'],
+): string {
+  return fingerprint.slice(fingerprint.lastIndexOf(':') + 1);
 }
 
 async function bindingFor(

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -69,7 +69,11 @@ import {
   type ScheduledRefreshKind,
 } from './scheduled-refresh';
 import { GitHubWatchError, canonicalRepositoryFullName } from '@/watch/watch-model';
-import { parseWatchThreadId, parseWatchThreadIds } from '@/watch/watch-contract';
+import {
+  parseWatchAccountLogin,
+  parseWatchThreadId,
+  parseWatchThreadIds,
+} from '@/watch/watch-contract';
 import { RADAR_MAX_FOLLOWING } from '@/radar/radar-model';
 import {
   createOrganizeApplyPump,
@@ -257,8 +261,8 @@ type Req = BgsmAgentSessionRequest
   | { type: "getWatchSubjectDetail"; threadId?: unknown }
   | { type: "getWatchRepositoryDetail"; fullName?: unknown }
   | { type: "refreshWatchInbox" }
-  | { type: "markWatchThreadsRead"; threadIds?: unknown }
-  | { type: "markWatchThreadsDone"; threadIds?: unknown }
+  | { type: "markWatchThreadsRead"; accountLogin?: unknown; threadIds?: unknown }
+  | { type: "markWatchThreadsDone"; accountLogin?: unknown; threadIds?: unknown }
   | { type: "disconnectWatchInbox" }
   | { type: "clearWatchData" }
   | { type: 'getRecommendationStatus' }
@@ -1795,14 +1799,18 @@ async function handle(req: Req): Promise<Res> {
       case 'markWatchThreadsRead':
       case 'markWatchThreadsDone': {
         const m = await getLocaleMessages();
+        const accountLogin = parseWatchAccountLogin(req.accountLogin);
         const threadIds = parseWatchThreadIds(req.threadIds);
-        if (!threadIds) return { ok: false, error: m.background.watchThreadActionInvalid };
+        if (!accountLogin || !threadIds) {
+          return { ok: false, error: m.background.watchThreadActionInvalid };
+        }
+        const mutation = { accountLogin, threadIds };
         try {
           return {
             ok: true,
             data: req.type === 'markWatchThreadsRead'
-              ? await watchRefreshCoordinator.markThreadsRead(threadIds)
-              : await watchRefreshCoordinator.markThreadsDone(threadIds),
+              ? await watchRefreshCoordinator.markThreadsRead(mutation)
+              : await watchRefreshCoordinator.markThreadsDone(mutation),
           };
         } catch {
           return { ok: false, error: m.background.watchThreadActionFailed };

--- a/src/background/watch-refresh.ts
+++ b/src/background/watch-refresh.ts
@@ -32,11 +32,13 @@ import {
   type WatchSubjectIdentity,
 } from '@/watch/watch-model';
 import {
+  parseWatchAccountLogin,
   parseWatchThreadIds,
   type WatchInboxQueryResponse,
   type WatchRefreshResult,
   type WatchStatus,
   type WatchThreadAction,
+  type WatchThreadMutationInput,
   type WatchThreadMutationResult,
 } from '@/watch/watch-contract';
 
@@ -79,8 +81,8 @@ export interface WatchRefreshCoordinator {
   refresh(): Promise<WatchRefreshResult>;
   getSubjectDetail(threadId: string): Promise<WatchSubjectDetail>;
   refreshInbox(): Promise<WatchRefreshResult>;
-  markThreadsRead(threadIds: readonly string[]): Promise<WatchThreadMutationResult>;
-  markThreadsDone(threadIds: readonly string[]): Promise<WatchThreadMutationResult>;
+  markThreadsRead(input: WatchThreadMutationInput): Promise<WatchThreadMutationResult>;
+  markThreadsDone(input: WatchThreadMutationInput): Promise<WatchThreadMutationResult>;
   disconnectInbox(): Promise<WatchStatus>;
   clearData(): Promise<WatchStatus>;
   reconcileAccount(options?: {
@@ -570,12 +572,14 @@ export function createWatchRefreshCoordinator(
   async function performThreadMutation(
     auth: AuthSnapshot,
     action: WatchThreadAction,
-    requestedIds: readonly string[],
+    input: WatchThreadMutationInput,
   ): Promise<WatchThreadMutationResult> {
-    const threadIds = parseWatchThreadIds(requestedIds);
+    const accountLogin = parseWatchAccountLogin(input.accountLogin);
+    const threadIds = parseWatchThreadIds(input.threadIds);
     if (!threadIds) throw new GitHubWatchError('invalid_thread');
     if (
-      !auth.accountLogin ||
+      !accountLogin ||
+      auth.accountLogin !== accountLogin ||
       !auth.mainToken ||
       !auth.notificationsToken ||
       !await sameCredentials(auth, true)
@@ -636,11 +640,11 @@ export function createWatchRefreshCoordinator(
 
   async function mutateThreads(
     action: WatchThreadAction,
-    threadIds: readonly string[],
+    input: WatchThreadMutationInput,
   ): Promise<WatchThreadMutationResult> {
     await reconcileAccount();
     const auth = await readAuth();
-    return dependencies.runSerialized(() => performThreadMutation(auth, action, threadIds));
+    return dependencies.runSerialized(() => performThreadMutation(auth, action, input));
   }
 
   async function disconnectInboxCommand(): Promise<WatchStatus> {
@@ -704,8 +708,8 @@ export function createWatchRefreshCoordinator(
     getSubjectDetail,
     refresh,
     refreshInbox,
-    markThreadsRead: (threadIds) => mutateThreads('read', threadIds),
-    markThreadsDone: (threadIds) => mutateThreads('done', threadIds),
+    markThreadsRead: (input) => mutateThreads('read', input),
+    markThreadsDone: (input) => mutateThreads('done', input),
     disconnectInbox: disconnectInboxCommand,
     clearData: clearDataCommand,
     reconcileAccount,

--- a/src/bgsm-agent/conversation-binding.ts
+++ b/src/bgsm-agent/conversation-binding.ts
@@ -1,6 +1,7 @@
 import { canonicalJson, sha256Base64Url } from '@/agent-harness/canonical-json';
 import {
   parseScopeFingerprint,
+  isScopeFingerprint,
   validateLaunchCandidateContract,
   type LaunchCandidateContract,
   type ScopeFingerprint,
@@ -59,8 +60,7 @@ export function validateBgsmAgentConversationBinding(
   ]);
   if (value.version !== 1) throw new TypeError('Conversation binding version must be 1.');
   validateBgsmAgentConversationCandidate(value.candidateContract);
-  if (typeof value.scopeFingerprint !== 'string'
-    || !parseScopeFingerprint(value.scopeFingerprint)) {
+  if (!isScopeFingerprint(value.scopeFingerprint)) {
     throw new TypeError('Conversation scope fingerprint is malformed.');
   }
   assertTrimmedNonempty(value.label, 'Conversation scope label');

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -111,6 +111,7 @@ export function Options() {
   const [tokenBusy, setTokenBusy] = useState(false);
   const [syncStatus, setSyncStatus] = useState<SyncStatus | null>(null);
   const [msg, setMsg] = useState<OptionsMessage | null>(null);
+  const [storeRatingMessage, setStoreRatingMessage] = useState<OptionsMessage | null>(null);
   const { locale, setLocale, m } = useI18n();
   const tokenInput = useImeBufferedInput("");
   const refreshGeneration = useRef(0);
@@ -245,21 +246,23 @@ export function Options() {
   };
 
   const setStoreRatingReminderEnabled = async (enabled: boolean) => {
+    setStoreRatingMessage(null);
     try {
       const config = enabled
         ? await authStore.reenableStoreRatingPrompt()
         : await authStore.disableStoreRatingPrompt();
       setStoreRatingPrompt(config.storeRatingPrompt);
     } catch (error) {
-      setMsg({ kind: "err", text: translateError(error, m) });
+      setStoreRatingMessage({ kind: "err", text: translateError(error, m) });
     }
   };
 
   const markStoreRatingOpened = () => {
+    setStoreRatingMessage(null);
     void authStore.recordStoreRatingNavigation()
       .then((config) => setStoreRatingPrompt(config.storeRatingPrompt))
       .catch((error) => {
-        setMsg({ kind: "err", text: translateError(error, m) });
+        setStoreRatingMessage({ kind: "err", text: translateError(error, m) });
       });
   };
 
@@ -701,6 +704,12 @@ export function Options() {
                   </span>
                 </label>
               </div>
+              {storeRatingMessage && (
+                <StatusNotice
+                  message={storeRatingMessage}
+                  testId="store-rating-status"
+                />
+              )}
             </div>
           )}
         </div>

--- a/src/ui/hooks/use-watch-inbox.ts
+++ b/src/ui/hooks/use-watch-inbox.ts
@@ -5,11 +5,12 @@ import {
   GITHUB_CREDENTIALS_STORAGE_KEY,
 } from '@/auth/auth-store';
 import { bgCall } from '@/utils/messaging';
-import type {
-  WatchInboxQueryResponse,
-  WatchRefreshResult,
-  WatchThreadAction,
-  WatchThreadMutationResult,
+import {
+  WATCH_MAX_THREAD_ACTIONS,
+  type WatchInboxQueryResponse,
+  type WatchRefreshResult,
+  type WatchThreadAction,
+  type WatchThreadMutationResult,
 } from '@/watch/watch-contract';
 import { normalizeWatchCollapsedRepositories } from '@/preferences';
 import type { WatchCollapsedRepositorySignatures } from '@/types';
@@ -197,10 +198,12 @@ export function useWatchInbox({
     setActionPending({ action, threadIds });
     setActionError(null);
     try {
-      await bgCall<WatchThreadMutationResult>(
-        action === 'read' ? 'markWatchThreadsRead' : 'markWatchThreadsDone',
-        { threadIds },
-      );
+      const requestType = action === 'read' ? 'markWatchThreadsRead' : 'markWatchThreadsDone';
+      for (let offset = 0; offset < threadIds.length; offset += WATCH_MAX_THREAD_ACTIONS) {
+        await bgCall<WatchThreadMutationResult>(requestType, {
+          threadIds: threadIds.slice(offset, offset + WATCH_MAX_THREAD_ACTIONS),
+        });
+      }
       onMeaningfulAction?.();
       await load(true);
     } catch {

--- a/src/ui/hooks/use-watch-inbox.ts
+++ b/src/ui/hooks/use-watch-inbox.ts
@@ -186,12 +186,13 @@ export function useWatchInbox({
       if (mountedRef.current) setRefreshing(false);
     }
   }, [load]);
+  const actionAccountLogin = result?.status.accountLogin ?? null;
 
   const mutateThreads = useCallback(async (
     action: WatchThreadAction,
     requestedIds: readonly string[],
   ) => {
-    if (!mountedRef.current || actionPendingRef.current) return;
+    if (!mountedRef.current || actionPendingRef.current || !actionAccountLogin) return;
     const threadIds = [...new Set(requestedIds)];
     if (threadIds.length === 0) return;
     actionPendingRef.current = true;
@@ -201,6 +202,7 @@ export function useWatchInbox({
       const requestType = action === 'read' ? 'markWatchThreadsRead' : 'markWatchThreadsDone';
       for (let offset = 0; offset < threadIds.length; offset += WATCH_MAX_THREAD_ACTIONS) {
         await bgCall<WatchThreadMutationResult>(requestType, {
+          accountLogin: actionAccountLogin,
           threadIds: threadIds.slice(offset, offset + WATCH_MAX_THREAD_ACTIONS),
         });
       }
@@ -213,7 +215,7 @@ export function useWatchInbox({
       actionPendingRef.current = false;
       if (mountedRef.current) setActionPending(null);
     }
-  }, [load, onMeaningfulAction]);
+  }, [actionAccountLogin, load, onMeaningfulAction]);
 
   const markThreadsRead = useCallback((threadIds: readonly string[]) => (
     mutateThreads('read', threadIds)

--- a/src/ui/watch-inbox-presentation.ts
+++ b/src/ui/watch-inbox-presentation.ts
@@ -202,7 +202,11 @@ export function hasNewWatchGroupContent(
   let previousMarkers: Set<string>;
   try {
     const parsed = JSON.parse(previousSignature) as unknown;
-    if (!Array.isArray(parsed)) return true;
+    if (!Array.isArray(parsed) || !parsed.every(
+      (marker: unknown): marker is [string, string] => Array.isArray(marker)
+        && marker.length === 2
+        && marker.every((value) => typeof value === 'string'),
+    )) return true;
     previousMarkers = new Set(parsed.map((marker) => JSON.stringify(marker)));
   } catch {
     return true;

--- a/src/watch/watch-contract.ts
+++ b/src/watch/watch-contract.ts
@@ -4,6 +4,17 @@ import type {
 } from '@/watch/watch-model';
 export type WatchThreadAction = 'read' | 'done';
 
+export interface WatchThreadMutationInput {
+  accountLogin: string;
+  threadIds: readonly string[];
+}
+
+export function parseWatchAccountLogin(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const login = value.trim().toLocaleLowerCase('en-US');
+  return login.length > 0 && login.length <= 39 ? login : null;
+}
+
 export const WATCH_MAX_THREAD_ACTIONS = 500;
 
 export interface WatchThreadMutationResult {

--- a/tests/regressions/storage/watch-store-regression.test.ts
+++ b/tests/regressions/storage/watch-store-regression.test.ts
@@ -449,6 +449,18 @@ describe('Watch snapshot storage', () => {
     assert.equal(stored.state?.inbox.matchedCount, 2);
 
     assert.equal(await applyWatchThreadMutation({
+      accountLogin: 'another-user',
+      threadIds: ['1'],
+      action: 'done',
+    }), 0);
+    stored = await queryStoredWatchInbox({ accountLogin: ACCOUNT, unreadOnly: false });
+    assert.deepEqual(stored.threads.map((row) => [row.id, row.unread]), [
+      ['1', false],
+      ['2', true],
+    ]);
+    assert.equal(stored.state?.inbox.matchedCount, 2);
+
+    assert.equal(await applyWatchThreadMutation({
       accountLogin: ACCOUNT,
       threadIds: ['1', '2'],
       action: 'done',
@@ -457,11 +469,6 @@ describe('Watch snapshot storage', () => {
     assert.equal(stored.totalCount, 0);
     assert.equal(stored.state?.inbox.matchedCount, 0);
 
-    assert.equal(await applyWatchThreadMutation({
-      accountLogin: 'another-user',
-      threadIds: ['1'],
-      action: 'done',
-    }), 0);
   });
 
   it('counts unread Inbox rows only for the bound account', async () => {

--- a/tests/unit/background-bgsm-agent-scope.test.ts
+++ b/tests/unit/background-bgsm-agent-scope.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'vitest';
 import {
   createBgsmAgentConversationBinding,
   createBgsmAgentConversationScopeFingerprint,
+  validateBgsmAgentConversationBinding,
   type BgsmAgentConversationCandidate,
   type BgsmAgentTurnInput,
 } from '@/bgsm-agent';
@@ -147,19 +148,33 @@ describe('Cubby conversation scope binding', () => {
       providerFingerprint: PROVIDER,
     });
 
-    await assert.rejects(
-      resolveBgsmAgentConversation({
-        turnAttemptId: 'turn-attempt-legacy-scope',
-        sessionId: 'session-legacy-scope',
-        baseRevision: 1,
-        prompt: 'Follow up',
-        history: [{ id: 'old', role: 'user', content: 'old', createdAt: 1 }],
-        binding,
-      }, {
-        providerFingerprint: PROVIDER,
-        resolveCandidate: resolver(),
-      }),
-      /scope changed/i,
-    );
+    const resolved = await resolveBgsmAgentConversation({
+      turnAttemptId: 'turn-attempt-legacy-scope',
+      sessionId: 'session-legacy-scope',
+      baseRevision: 1,
+      prompt: 'Follow up',
+      history: [{ id: 'old', role: 'user', content: 'old', createdAt: 1 }],
+      binding,
+    }, {
+      providerFingerprint: PROVIDER,
+      resolveCandidate: resolver(),
+    });
+
+    assert.equal(resolved.binding, binding);
+    assert.deepEqual(resolved.repositoryIds, ['owner/repo']);
+  });
+
+  it('reports malformed string fingerprints through the conversation binding contract', () => {
+    assert.throws(() => validateBgsmAgentConversationBinding({
+      version: 1,
+      candidateContract: candidate,
+      scopeFingerprint: 'malformed',
+      label: 'owner/repo',
+      count: 1,
+      providerFingerprint: PROVIDER,
+    }), {
+      name: 'TypeError',
+      message: 'Conversation scope fingerprint is malformed.',
+    });
   });
 });

--- a/tests/unit/background-watch-integration-contract.test.ts
+++ b/tests/unit/background-watch-integration-contract.test.ts
@@ -100,12 +100,14 @@ describe('Watch background integration contract', () => {
   });
 
   it('validates Watch notification mutations and keeps them inside the Watch queue', () => {
-    assert.match(backgroundSource, /type: ["']markWatchThreadsRead["']; threadIds\?: unknown/);
-    assert.match(backgroundSource, /type: ["']markWatchThreadsDone["']; threadIds\?: unknown/);
+    assert.match(backgroundSource, /type: ["']markWatchThreadsRead["']; accountLogin\?: unknown; threadIds\?: unknown/);
+    assert.match(backgroundSource, /type: ["']markWatchThreadsDone["']; accountLogin\?: unknown; threadIds\?: unknown/);
     const block = caseBlock('markWatchThreadsDone', 'disconnectWatchInbox');
+    assert.match(block, /const accountLogin = parseWatchAccountLogin\(req\.accountLogin\)/);
     assert.match(block, /const threadIds = parseWatchThreadIds\(req\.threadIds\)/);
-    assert.match(block, /watchRefreshCoordinator\.markThreadsRead\(threadIds\)/);
-    assert.match(block, /watchRefreshCoordinator\.markThreadsDone\(threadIds\)/);
+    assert.match(block, /const mutation = \{ accountLogin, threadIds \}/);
+    assert.match(block, /watchRefreshCoordinator\.markThreadsRead\(mutation\)/);
+    assert.match(block, /watchRefreshCoordinator\.markThreadsDone\(mutation\)/);
     assert.match(block, /watchThreadActionInvalid/);
     assert.match(block, /watchThreadActionFailed/);
     assert.doesNotMatch(block, /setProgress|invalidateCache|broadcastDataChanged/);

--- a/tests/unit/background-watch-refresh.test.ts
+++ b/tests/unit/background-watch-refresh.test.ts
@@ -142,6 +142,7 @@ function harness(input: {
   watchCredentialSource?: Config['watchCredentialSource'];
   fetchScope?: WatchRefreshCoordinatorDependencies['fetchScope'];
   fetchNotifications?: WatchRefreshCoordinatorDependencies['fetchNotifications'];
+  mutateNotification?: WatchRefreshCoordinatorDependencies['mutateNotification'];
   queryInbox?: typeof watchStore.queryStoredWatchInbox;
   disconnectInbox?: typeof watchStore.disconnectWatchInbox;
   liveRepositoryNames?: string[] | (() => string[] | Promise<string[]>);
@@ -198,6 +199,7 @@ function harness(input: {
   };
   const fetchScope = input.fetchScope ?? vi.fn(async () => scopeSnapshot());
   const fetchNotifications = input.fetchNotifications ?? vi.fn(async () => inboxSnapshot());
+  const mutateNotification = input.mutateNotification ?? vi.fn();
   const broadcastChanged = vi.fn();
   const clearWatchNotificationsToken = vi.fn(async () => {
     dedicatedNotificationsToken = null;
@@ -234,7 +236,7 @@ function harness(input: {
     },
     fetchScope,
     fetchNotifications,
-    mutateNotification: vi.fn(),
+    mutateNotification,
     fetchSubjectDetail: vi.fn(),
     loadLiveRepositoryNames: async () => typeof input.liveRepositoryNames === 'function'
       ? input.liveRepositoryNames()
@@ -262,6 +264,7 @@ function harness(input: {
     coordinator,
     fetchScope,
     fetchNotifications,
+    mutateNotification,
     broadcastChanged,
     clearWatchNotificationsToken,
     clearWatchToken() {
@@ -334,6 +337,17 @@ afterAll(async () => {
 });
 
 describe('Watch background refresh coordinator', () => {
+  it('rejects a thread mutation bound to a different GitHub account', async () => {
+    const mutateNotification = vi.fn();
+    const h = harness({ mutateNotification });
+
+    await expect(h.coordinator.markThreadsDone({
+      accountLogin: 'another-user',
+      threadIds: ['1'],
+    })).rejects.toMatchObject({ code: 'authentication_required' });
+    expect(mutateNotification).not.toHaveBeenCalled();
+  });
+
   it('publishes live-star Notifications even when native scope omits the repository', async () => {
     const h = harness({
       fetchScope: vi.fn(async () => ({

--- a/tests/unit/github-radar-source.test.ts
+++ b/tests/unit/github-radar-source.test.ts
@@ -194,6 +194,99 @@ describe('GitHub Radar source', () => {
     expect(new Headers(calls[0]?.init.headers).get('authorization')).toBe('Bearer secret');
   });
 
+  it('keeps valid activity aliases when a followed account is missing', async () => {
+    let request = 0;
+    const fetchImpl = vi.fn(async () => {
+      request += 1;
+      if (request === 1) {
+        return jsonResponse(followingEnvelope({ logins: ['alice', 'bob'] }));
+      }
+      const valid = activityEnvelope([{
+        login: 'bob',
+        edges: [{ starredAt: NOW.toISOString(), node: repository('owner/valid') }],
+      }]);
+      return jsonResponse({
+        data: {
+          ...valid.data,
+          follower0: null,
+          follower1: (valid.data as Record<string, unknown>).follower0,
+        },
+        errors: [{ type: 'NOT_FOUND', path: ['follower0'] }],
+      });
+    }) as typeof fetch;
+
+    const snapshot = await fetchGitHubRadar({ token: 'token', fetchImpl, now: () => NOW });
+
+    expect(snapshot.activities.map((activity) => activity.repositoryKey)).toEqual(['owner/valid']);
+    expect(snapshot.scannedFollowingCount).toBe(1);
+    expect(snapshot.batchCount).toBe(1);
+    expect(snapshot.partialReasons).toEqual(['following_scan_truncated']);
+  });
+
+  it('keeps earlier activity when a continuation alias disappears', async () => {
+    let request = 0;
+    const fetchImpl = vi.fn(async () => {
+      request += 1;
+      if (request === 1) return jsonResponse(followingEnvelope({ logins: ['alice'] }));
+      if (request === 2) {
+        return jsonResponse(activityEnvelope([{
+          login: 'alice',
+          edges: [{ starredAt: NOW.toISOString(), node: repository('owner/first-page') }],
+          hasNextPage: true,
+          endCursor: 'page-2',
+        }]));
+      }
+      return jsonResponse({
+        data: {
+          follower0: null,
+          rateLimit: { remaining: 4_800, resetAt: '2026-08-10T13:00:00Z' },
+        },
+        errors: [{ type: 'NOT_FOUND', path: ['follower0'] }],
+      });
+    }) as typeof fetch;
+
+    const snapshot = await fetchGitHubRadar({ token: 'token', fetchImpl, now: () => NOW });
+
+    expect(snapshot.activities.map((activity) => activity.repositoryKey)).toEqual(['owner/first-page']);
+    expect(snapshot.scannedFollowingCount).toBe(1);
+    expect(snapshot.batchCount).toBe(2);
+    expect(snapshot.partialReasons).toEqual(['github_star_list_truncated']);
+  });
+
+  it.each([
+    {
+      name: 'unscoped missing resource',
+      errors: [{ type: 'NOT_FOUND', path: ['viewer'] }],
+      code: 'invalid_response',
+    },
+    {
+      name: 'out-of-range activity alias',
+      errors: [{ type: 'NOT_FOUND', path: ['follower9'] }],
+      code: 'invalid_response',
+    },
+    {
+      name: 'mixed missing and rate-limited aliases',
+      errors: [
+        { type: 'NOT_FOUND', path: ['follower0'] },
+        { type: 'RATE_LIMITED', path: ['rateLimit'] },
+      ],
+      code: 'rate_limited',
+    },
+  ])('keeps $name GraphQL errors fatal', async ({ errors, code }) => {
+    let request = 0;
+    const fetchImpl = vi.fn(async () => {
+      request += 1;
+      if (request === 1) return jsonResponse(followingEnvelope({ logins: ['alice'] }));
+      return jsonResponse({
+        ...activityEnvelope([{ login: 'alice', edges: [] }]),
+        errors,
+      });
+    }) as typeof fetch;
+
+    await expect(fetchGitHubRadar({ token: 'token', fetchImpl, now: () => NOW }))
+      .rejects.toMatchObject({ code });
+  });
+
   it('truthfully reports following truncation before making unaffordable activity requests', async () => {
     const fetchImpl = vi.fn(async () => jsonResponse(followingEnvelope({
       logins: ['alice', 'bob'],

--- a/tests/unit/github-watch-sources.test.ts
+++ b/tests/unit/github-watch-sources.test.ts
@@ -523,6 +523,8 @@ describe('GitHub Watch API sources', () => {
       .rejects.toMatchObject({ code: 'invalid_response' });
 
     const hostileAvatarQuery = vi.fn<typeof fetch>(async () => jsonResponse(subjectDetail({
+      html_url: identity.htmlUrl,
+      pull_request: undefined,
       user: {
         login: 'octocat',
         avatar_url: 'https://avatars.githubusercontent.com/u/1?redirect=https://attacker.example',

--- a/tests/unit/options-preferences.test.tsx
+++ b/tests/unit/options-preferences.test.tsx
@@ -448,6 +448,50 @@ describe('Options preferences', () => {
     expect(panel?.textContent).toContain('Disabled after opening the store');
   });
 
+  it('keeps rating persistence errors local without replacing token feedback', async () => {
+    const disabled = config({
+      storeRatingPrompt: {
+        version: 1,
+        status: 'disabled',
+        activeLocalDays: [],
+        meaningfulActionCount: 0,
+        exposureCount: 0,
+        snoozeUntil: null,
+      },
+    });
+    const tracking = config({
+      storeRatingPrompt: { ...disabled.storeRatingPrompt, status: 'tracking' },
+    });
+    authMocks.getConfig.mockResolvedValue(disabled);
+    authMocks.hasToken.mockResolvedValue(true);
+    authMocks.setToken.mockRejectedValue(new Error('token persistence failed'));
+    authMocks.reenableStoreRatingPrompt
+      .mockRejectedValueOnce(new Error('rating persistence failed'))
+      .mockResolvedValueOnce(tracking);
+
+    await renderOptions();
+
+    const tokenInput = document.querySelector<HTMLTextAreaElement>('textarea[placeholder="github_pat_..."]');
+    const githubPanel = document.querySelector('[data-testid="github-connection-settings"]');
+    const saveToken = [...githubPanel!.querySelectorAll<HTMLButtonElement>('button')]
+      .find((button) => button.textContent?.includes(watchCopy.saveVerify));
+    await setTextareaValue(tokenInput!, 'github_pat_example');
+    await click(saveToken!);
+
+    const panel = document.querySelector('[data-testid="store-rating-settings"]');
+    const reminder = panel?.querySelector<HTMLButtonElement>('#store-rating-reminder');
+    await click(reminder!);
+
+    expect(document.querySelector('[data-testid="main-token-status"]')?.getAttribute('role')).toBe('alert');
+    expect(panel?.querySelector('[data-testid="store-rating-status"]')?.getAttribute('role')).toBe('alert');
+
+    await click(reminder!);
+
+    expect(authMocks.reenableStoreRatingPrompt).toHaveBeenCalledTimes(2);
+    expect(panel?.querySelector('[data-testid="store-rating-status"]')).toBeNull();
+    expect(document.querySelector('[data-testid="main-token-status"]')?.getAttribute('role')).toBe('alert');
+  });
+
   it('normalizes and persists split auto-tag policy inputs independently', async () => {
     authMocks.getConfig.mockResolvedValue(config());
     authMocks.hasToken.mockResolvedValue(true);

--- a/tests/unit/radar-surface.test.tsx
+++ b/tests/unit/radar-surface.test.tsx
@@ -442,13 +442,16 @@ describe('Radar', () => {
 
     await act(async () => { forYouTab?.click(); });
     expect(onDiscoverViewChange).toHaveBeenCalledWith('for-you');
+    onDiscoverViewChange.mockClear();
+
 
     const followingTab = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="tab"]'))
       .find((button) => button.textContent?.includes('Following'));
     await act(async () => {
       followingTab?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
     });
-    expect(onDiscoverViewChange).toHaveBeenLastCalledWith('for-you');
+    expect(onDiscoverViewChange).toHaveBeenCalledTimes(1);
+    expect(onDiscoverViewChange).toHaveBeenCalledWith('for-you');
   });
 
   it('renders repository identity and topics without annotation controls', () => {

--- a/tests/unit/use-watch-inbox.test.tsx
+++ b/tests/unit/use-watch-inbox.test.tsx
@@ -52,14 +52,17 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
-function queryResponse(totalCount: number): WatchInboxQueryResponse {
+function queryResponse(
+  totalCount: number,
+  accountLogin = 'octocat',
+): WatchInboxQueryResponse {
   return {
     threads: [],
     groups: [],
     unreadCount: totalCount,
     totalCount,
     status: {
-      accountLogin: 'octocat',
+      accountLogin,
       hasMainToken: true,
       hasNotificationsToken: true,
       refreshing: false,
@@ -604,13 +607,16 @@ describe('useWatchInbox', () => {
   it('tracks notification mutations and reloads the authoritative projection', async () => {
     const mutation = deferred<unknown>();
     let queryCount = 0;
-    watchMocks.bgCall.mockImplementation((type: string, payload?: { threadIds?: string[] }) => {
+    watchMocks.bgCall.mockImplementation((
+      type: string,
+      payload?: { accountLogin?: string; threadIds?: string[] },
+    ) => {
       if (type === 'queryWatchInbox') {
         queryCount++;
         return Promise.resolve(queryResponse(queryCount === 1 ? 2 : 1));
       }
       if (type === 'markWatchThreadsRead') {
-        expect(payload?.threadIds).toEqual(['1']);
+        expect(payload).toEqual({ accountLogin: 'octocat', threadIds: ['1'] });
         return mutation.promise;
       }
       throw new Error(`Unexpected request: ${type}`);
@@ -637,10 +643,11 @@ describe('useWatchInbox', () => {
 
   it('chunks a repository action with more than one thousand notifications', async () => {
     const mutationBatches: string[][] = [];
+    const mutationAccounts: Array<string | undefined> = [];
     let queryCount = 0;
     watchMocks.bgCall.mockImplementation((
       type: string,
-      payload?: { threadIds?: string[] },
+      payload?: { accountLogin?: string; threadIds?: string[] },
     ) => {
       if (type === 'queryWatchInbox') {
         queryCount += 1;
@@ -648,6 +655,7 @@ describe('useWatchInbox', () => {
       }
       if (type === 'markWatchThreadsDone') {
         const threadIds = payload?.threadIds ?? [];
+        mutationAccounts.push(payload?.accountLogin);
         mutationBatches.push(threadIds);
         return threadIds.length <= WATCH_MAX_THREAD_ACTIONS
           ? Promise.resolve(undefined)
@@ -671,8 +679,76 @@ describe('useWatchInbox', () => {
 
     expect(mutationBatches.map((batch) => batch.length)).toEqual([500, 500, 1]);
     expect(mutationBatches.flat()).toEqual(MANY_THREAD_IDS);
+    expect(mutationAccounts).toEqual(['octocat', 'octocat', 'octocat']);
     expect(container.querySelector('[data-testid="action-error"]')?.textContent).toBe('none');
     expect(queryCount).toBe(2);
+  });
+
+  it('stops remaining chunks when the active GitHub account changes', async () => {
+    const firstBatch = deferred<unknown>();
+    const mutationRequests: Array<{
+      accountLogin: string | undefined;
+      threadIds: string[];
+    }> = [];
+    let activeAccount = 'octocat';
+    let queryCount = 0;
+    watchMocks.bgCall.mockImplementation((
+      type: string,
+      payload?: { accountLogin?: string; threadIds?: string[] },
+    ) => {
+      if (type === 'queryWatchInbox') {
+        queryCount += 1;
+        return Promise.resolve(queryResponse(1_001, activeAccount));
+      }
+      if (type === 'markWatchThreadsDone') {
+        const request = {
+          accountLogin: payload?.accountLogin,
+          threadIds: payload?.threadIds ?? [],
+        };
+        mutationRequests.push(request);
+        if (request.accountLogin !== activeAccount) {
+          return Promise.reject(new Error('Watch account changed'));
+        }
+        return mutationRequests.length === 1 ? firstBatch.promise : Promise.resolve(undefined);
+      }
+      throw new Error(`Unexpected request: ${type}`);
+    });
+    const container = mountReact(<Harness />, mountedRoots);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await click(container.querySelector<HTMLButtonElement>('[data-testid="mark-many-done"]')!);
+    await vi.waitFor(() => expect(mutationRequests).toHaveLength(1));
+    expect(mutationRequests[0]).toMatchObject({ accountLogin: 'octocat' });
+
+    activeAccount = 'another-user';
+    await act(async () => {
+      storageListeners[0]?.({
+        gsm_github_credentials: {
+          oldValue: { accountLogin: 'octocat' },
+          newValue: { accountLogin: activeAccount },
+        },
+      }, 'local');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    firstBatch.resolve(undefined);
+    await act(async () => {
+      await firstBatch.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mutationRequests).toHaveLength(2);
+    expect(mutationRequests.map((request) => request.accountLogin))
+      .toEqual(['octocat', 'octocat']);
+    expect(mutationRequests.map((request) => request.threadIds.length)).toEqual([500, 500]);
+    expect(container.querySelector('[data-testid="action-error"]')?.textContent).toBe('done');
+    expect(queryCount).toBe(3);
   });
 
   it('surfaces a failed done mutation after reloading saved rows', async () => {

--- a/tests/unit/use-watch-inbox.test.tsx
+++ b/tests/unit/use-watch-inbox.test.tsx
@@ -4,7 +4,10 @@
 import { act, useState } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useWatchInbox } from '@/ui/hooks/use-watch-inbox';
-import type { WatchInboxQueryResponse } from '@/watch/watch-contract';
+import {
+  WATCH_MAX_THREAD_ACTIONS,
+  type WatchInboxQueryResponse,
+} from '@/watch/watch-contract';
 import {
   cleanupMountedRootsAndBody,
   click,
@@ -27,6 +30,7 @@ type StorageListener = (
 const runtimeListeners: RuntimeListener[] = [];
 const storageListeners: StorageListener[] = [];
 
+const MANY_THREAD_IDS = Array.from({ length: 1_001 }, (_, index) => String(index + 1));
 vi.mock('@/utils/messaging', () => ({
   bgCall: watchMocks.bgCall,
 }));
@@ -128,6 +132,13 @@ function Harness({ initialActive = true }: { initialActive?: boolean } = {}) {
         onClick={() => void inbox.markThreadsDone(['1', '2'])}
       >
         Mark done
+      </button>
+      <button
+        type="button"
+        data-testid="mark-many-done"
+        onClick={() => void inbox.markThreadsDone(MANY_THREAD_IDS)}
+      >
+        Mark many done
       </button>
       <button
         type="button"
@@ -622,6 +633,46 @@ describe('useWatchInbox', () => {
     expect(container.querySelector('[data-testid="action-pending"]')?.textContent).toBe('none');
     expect(container.querySelector('[data-testid="action-error"]')?.textContent).toBe('none');
     expect(container.querySelector('[data-testid="count"]')?.textContent).toBe('1');
+  });
+
+  it('chunks a repository action with more than one thousand notifications', async () => {
+    const mutationBatches: string[][] = [];
+    let queryCount = 0;
+    watchMocks.bgCall.mockImplementation((
+      type: string,
+      payload?: { threadIds?: string[] },
+    ) => {
+      if (type === 'queryWatchInbox') {
+        queryCount += 1;
+        return Promise.resolve(queryResponse(1_001));
+      }
+      if (type === 'markWatchThreadsDone') {
+        const threadIds = payload?.threadIds ?? [];
+        mutationBatches.push(threadIds);
+        return threadIds.length <= WATCH_MAX_THREAD_ACTIONS
+          ? Promise.resolve(undefined)
+          : Promise.reject(new Error('oversized Watch mutation'));
+      }
+      throw new Error(`Unexpected request: ${type}`);
+    });
+    const container = mountReact(<Harness />, mountedRoots);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await click(container.querySelector<HTMLButtonElement>('[data-testid="mark-many-done"]')!);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mutationBatches.map((batch) => batch.length)).toEqual([500, 500, 1]);
+    expect(mutationBatches.flat()).toEqual(MANY_THREAD_IDS);
+    expect(container.querySelector('[data-testid="action-error"]')?.textContent).toBe('none');
+    expect(queryCount).toBe(2);
   });
 
   it('surfaces a failed done mutation after reloading saved rows', async () => {

--- a/tests/unit/watch-inbox-presentation.test.ts
+++ b/tests/unit/watch-inbox-presentation.test.ts
@@ -226,9 +226,22 @@ describe('Watch repository collapse signatures', () => {
   });
 
   it('treats malformed persisted signatures as stale', () => {
-    expect(hasNewWatchGroupContent('not-json', threads)).toBe(true);
-    expect(hasNewWatchGroupContent('{}', threads)).toBe(true);
+    const currentMarker = [threads[0].id, threads[0].updatedAt];
+    const malformedSignatures = [
+      'not-json',
+      '{}',
+      JSON.stringify([currentMarker, null]),
+      JSON.stringify([currentMarker, 'unexpected']),
+      JSON.stringify([currentMarker, [threads[0].id]]),
+      JSON.stringify([currentMarker, [...currentMarker, 'extra']]),
+      JSON.stringify([currentMarker, [42, threads[0].updatedAt]]),
+    ];
+
+    for (const signature of malformedSignatures) {
+      expect(hasNewWatchGroupContent(signature, [threads[0]])).toBe(true);
+    }
   });
+
 });
 
 describe('Watch status presentation', () => {

--- a/tests/unit/watch-model.test.ts
+++ b/tests/unit/watch-model.test.ts
@@ -7,7 +7,11 @@ import {
   safeSubjectHtmlUrl,
   watchSubjectIdentity,
 } from '@/watch/watch-model';
-import { parseWatchThreadIds, WATCH_MAX_THREAD_ACTIONS } from '@/watch/watch-contract';
+import {
+  parseWatchAccountLogin,
+  parseWatchThreadIds,
+  WATCH_MAX_THREAD_ACTIONS,
+} from '@/watch/watch-contract';
 
 function thread(id: string, repositoryFullName: string, updatedAt: string, unread = true) {
   return normalizeNotificationThread({
@@ -190,6 +194,13 @@ describe('Watch domain model', () => {
       { length: WATCH_MAX_THREAD_ACTIONS + 1 },
       (_, index) => String(index + 1),
     ))).toBeNull();
+  });
+
+  it('normalizes bounded Watch account identities at the message boundary', () => {
+    expect(parseWatchAccountLogin(' OctoCat ')).toBe('octocat');
+    expect(parseWatchAccountLogin('')).toBeNull();
+    expect(parseWatchAccountLogin(null)).toBeNull();
+    expect(parseWatchAccountLogin('a'.repeat(40))).toBeNull();
   });
 
 });


### PR DESCRIPTION
## Summary

- validate Watch collapse markers as exact two-string tuples
- batch repository-level Watch actions into ordered requests of at most 500 IDs, so selections above 1,000 no longer fail the background message boundary
- bind every Watch batch to the account that owned the selected projection; an account switch rejects the next batch before any GitHub mutation and stops later chunks
- preserve successful Radar GraphQL aliases while treating only path-scoped missing aliases as recoverable
- normalize current and legacy Cubby scope fingerprints to the same digest while keeping stable validation errors
- keep store-rating persistence failures inside the owning Options panel and clear them on retry
- strengthen account-isolation, hostile-avatar, keyboard, fingerprint, GraphQL, feedback, oversized Watch, and cross-account regressions

## Verification

- [x] cross-cutting focused regression run: 135 tests
- [x] oversized Watch focused run: 25 tests, including a 1,001-ID action split into 500/500/1
- [x] Watch account-fence focused run: 66 tests across hook, coordinator, parser, and request boundaries
- [x] `pnpm typecheck`
- [x] `pnpm test:logic`: 2,369 tests before the isolated Watch follow-ups; every changed Watch test file was rerun afterward
- [x] `pnpm test:regressions`: 717 tests
- [x] post-fence `pnpm build`
- [x] post-fence packaged `pnpm test:smoke` passed on immediate retry after one scheduled-alarm setup timeout
- [x] packaged Chrome Options failure/retry browser probe
- [x] `git diff --check` and changed-file privacy/residue scan

## Scope

No dependency, schema, manifest, permission, compatibility-shim, or UI-copy changes. The 500-ID background request validation remains intact. Existing unrelated README edits are not part of this PR update.