### PR TITLE
chore(release): prepare version 2.0.0

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -9,7 +9,7 @@
 
 Search, filter, tag, and annotate repositories directly on your GitHub Stars page. Enable Watch, Following, For You, Secret Gist sync, or Cubby AI when you need them.
 
-**Official website:** [betterstars.app](https://betterstars.app/)
+[Website](https://betterstars.app/) · [DEMO](https://better-github-stars-manager.vercel.app/)
 
 [![Chrome Web Store](https://img.shields.io/badge/Chrome%20Web%20Store-Install%20Now-4285F4?logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/better-github-stars-manag/jbiacpcceoffcnmpepifoegagjopjpfa)
 [![Chrome Web Store users](https://img.shields.io/chrome-web-store/users/jbiacpcceoffcnmpepifoegagjopjpfa?logo=googlechrome&label=Chrome%20Web%20Store%20users)](https://chromewebstore.google.com/detail/better-github-stars-manag/jbiacpcceoffcnmpepifoegagjopjpfa)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 直接在 GitHub Stars 页面搜索、筛选、添加标签和笔记。需要时再启用 Watch、Following、For You、Secret Gist 同步和 Cubby AI等功能。
 
-**官方网站：** [betterstars.app](https://betterstars.app/)
+[官网](https://betterstars.app/) · [DEMO](https://better-github-stars-manager.vercel.app/)
 
 [![Chrome Web Store](https://img.shields.io/badge/Chrome%20Web%20Store-立即安装-4285F4?logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/better-github-stars-manag/jbiacpcceoffcnmpepifoegagjopjpfa)
 [![Chrome MV3](https://img.shields.io/badge/Chrome-MV3-4285F4?logo=googlechrome&logoColor=white)](https://developer.chrome.com/docs/extensions/mv3/intro/)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-github-stars-manager",
-  "version": "1.0.9",
+  "version": "2.0.0",
   "description": "Manage your GitHub starred repos: tag, note, filter, search across thousands of stars. UI injected into the stars page.",
   "packageManager": "pnpm@10.33.2",
   "devEngines": {


### PR DESCRIPTION
## Summary
- set the extension version to `2.0.0`
- show compact `官网 · DEMO` links in the Chinese README
- show compact `Website · DEMO` links in the English README

## Version contract
- `package.json` remains the sole product version source
- Chrome and Firefox generated manifests both report `2.0.0`
- generic version fixtures, the observed public-version baseline, and lockfile dependency versions remain unchanged

## Verification
- `pnpm typecheck`
- 34 focused packaging tests
- `pnpm build`
- Chrome manifest version `2.0.0`
- `pnpm build:firefox`
- Firefox manifest version `2.0.0`
- `pnpm check:firefox-output`
- `pnpm lint:firefox`
- `pnpm test:smoke`
- scoped Trellis reviews: PASS
- GitHub rendering verified for both README hero links