### PR TITLE
fix(watch): keep oversized done batches progressing

### DIFF
--- a/src/api/github-notifications-source.ts
+++ b/src/api/github-notifications-source.ts
@@ -310,9 +310,12 @@ export async function mutateGitHubNotificationThread(
         signal: controller.signal,
       },
     );
+    // 404 on 'done' means the thread is already absent from the inbox, which
+    // is the target state; treat it as an idempotent success instead of
+    // aborting an oversized repository batch on one stale thread.
     const succeeded = options.action === 'read'
       ? response.status === 205 || response.status === 304
-      : response.status === 204;
+      : response.status === 204 || response.status === 404;
     if (succeeded) return;
     throw responseError(response);
   } catch (error) {

--- a/src/background/watch-refresh.ts
+++ b/src/background/watch-refresh.ts
@@ -598,13 +598,16 @@ export function createWatchRefreshCoordinator(
       return { action, requestedCount: threadIds.length, changedCount: 0 };
     }
 
+    // A repository action can cover a thousand-plus threads. One transient
+    // failure (rate limit, stale thread) must not abort the rest of the batch;
+    // succeeded threads are applied and the remainder converges on retry.
     let cursor = 0;
-    let failure: unknown = null;
+    let firstFailure: unknown = null;
     const succeeded: string[] = [];
     const workers = Array.from(
       { length: Math.min(THREAD_MUTATION_CONCURRENCY, targets.length) },
       async () => {
-        while (failure === null) {
+        for (;;) {
           const index = cursor++;
           const threadId = targets[index];
           if (threadId === undefined) return;
@@ -616,7 +619,7 @@ export function createWatchRefreshCoordinator(
             });
             succeeded.push(threadId);
           } catch (error) {
-            failure = error;
+            if (firstFailure === null) firstFailure = error;
           }
         }
       },
@@ -634,7 +637,7 @@ export function createWatchRefreshCoordinator(
       })
       : 0;
     if (changedCount > 0) dependencies.broadcastChanged();
-    if (failure !== null) throw failure;
+    if (succeeded.length === 0 && firstFailure !== null) throw firstFailure;
     return { action, requestedCount: threadIds.length, changedCount };
   }
 

--- a/tests/unit/background-watch-refresh.test.ts
+++ b/tests/unit/background-watch-refresh.test.ts
@@ -375,6 +375,8 @@ describe('Watch background refresh coordinator', () => {
       if (threadId === '250') throw new GitHubWatchError('rate_limited');
     });
     const h = harness({ mutateNotification });
+    await h.coordinator.reconcileAccount();
+    h.broadcastChanged.mockClear();
 
     const result = await h.coordinator.markThreadsDone({
       accountLogin: ACCOUNT,
@@ -385,6 +387,7 @@ describe('Watch background refresh coordinator', () => {
     expect(result).toEqual({ action: 'done', requestedCount: 500, changedCount: 499 });
     const remaining = await watchStore.queryStoredWatchInbox({ accountLogin: ACCOUNT });
     expect(remaining.threads.map((item) => item.id)).toEqual(['250']);
+    expect(h.broadcastChanged).toHaveBeenCalledTimes(1);
   });
 
   it('rejects a done batch when every thread mutation fails', async () => {
@@ -413,6 +416,8 @@ describe('Watch background refresh coordinator', () => {
       throw new GitHubWatchError('rate_limited');
     });
     const h = harness({ mutateNotification });
+    await h.coordinator.reconcileAccount();
+    h.broadcastChanged.mockClear();
 
     await expect(h.coordinator.markThreadsDone({
       accountLogin: ACCOUNT,
@@ -420,6 +425,133 @@ describe('Watch background refresh coordinator', () => {
     })).rejects.toMatchObject({ code: 'rate_limited' });
     expect((await watchStore.queryStoredWatchInbox({ accountLogin: ACCOUNT })).threads)
       .toHaveLength(2);
+    expect(h.broadcastChanged).not.toHaveBeenCalled();
+  });
+
+  it('revalidates credentials before applying completed thread mutations', async () => {
+    await watchStore.replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads: [thread('1')],
+      attemptedAt: new Date(NOW).toISOString(),
+      lastModified: null,
+      nextAllowedAt: null,
+      candidateCount: 1,
+      truncated: false,
+      mode: 'replace',
+    });
+    const pendingMutation = deferred<void>();
+    const mutateNotification = vi.fn(async () => pendingMutation.promise);
+    const h = harness({ mutateNotification });
+
+    const mutation = h.coordinator.markThreadsDone({
+      accountLogin: ACCOUNT,
+      threadIds: ['1'],
+    });
+    const rejected = expect(mutation).rejects.toMatchObject({ code: 'authentication_required' });
+    await vi.waitFor(() => expect(mutateNotification).toHaveBeenCalledTimes(1));
+    h.changeAccount('another-user');
+    pendingMutation.resolve();
+
+    await rejected;
+    expect((await watchStore.queryStoredWatchInbox({ accountLogin: ACCOUNT })).threads)
+      .toHaveLength(1);
+    expect(h.broadcastChanged).not.toHaveBeenCalled();
+  });
+
+  it('caps thread mutations at four workers and consumes every target once', async () => {
+    const threads = Array.from({ length: 9 }, (_, index) => thread(String(index + 1)));
+    await watchStore.replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads,
+      attemptedAt: new Date(NOW).toISOString(),
+      lastModified: null,
+      nextAllowedAt: null,
+      candidateCount: threads.length,
+      truncated: false,
+      mode: 'replace',
+    });
+    const releaseMutations = deferred<void>();
+    const seen: string[] = [];
+    let active = 0;
+    let peakActive = 0;
+    const mutateNotification = vi.fn(async ({ threadId }: { threadId: string }) => {
+      seen.push(threadId);
+      active += 1;
+      peakActive = Math.max(peakActive, active);
+      await releaseMutations.promise;
+      active -= 1;
+    });
+    const h = harness({ mutateNotification });
+
+    const mutation = h.coordinator.markThreadsDone({
+      accountLogin: ACCOUNT,
+      threadIds: threads.map((item) => item.id),
+    });
+    await vi.waitFor(() => expect(mutateNotification).toHaveBeenCalledTimes(4));
+    expect(active).toBe(4);
+    expect(peakActive).toBe(4);
+
+    releaseMutations.resolve();
+    const result = await mutation;
+
+    expect(result).toEqual({ action: 'done', requestedCount: 9, changedCount: 9 });
+    expect(mutateNotification).toHaveBeenCalledTimes(9);
+    expect([...seen].sort((left, right) => Number(left) - Number(right)))
+      .toEqual(threads.map((item) => item.id));
+    expect(peakActive).toBe(4);
+    expect(h.broadcastChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes overlapping thread mutation commands', async () => {
+    await watchStore.replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads: [thread('1'), thread('2')],
+      attemptedAt: new Date(NOW).toISOString(),
+      lastModified: null,
+      nextAllowedAt: null,
+      candidateCount: 2,
+      truncated: false,
+      mode: 'replace',
+    });
+    const releaseFirstMutation = deferred<void>();
+    let mutationCalls = 0;
+    const mutateNotification = vi.fn(async () => {
+      mutationCalls += 1;
+      if (mutationCalls === 1) await releaseFirstMutation.promise;
+    });
+    const runner = createSerializedRunner();
+    let serializedRuns = 0;
+    let activeRuns = 0;
+    let peakActiveRuns = 0;
+    const runSerialized: WatchRefreshCoordinatorDependencies['runSerialized'] = (operation) => {
+      serializedRuns += 1;
+      return runner.run(async () => {
+        activeRuns += 1;
+        peakActiveRuns = Math.max(peakActiveRuns, activeRuns);
+        try {
+          return await operation();
+        } finally {
+          activeRuns -= 1;
+        }
+      });
+    };
+    const h = harness({ mutateNotification, runSerialized });
+
+    const first = h.coordinator.markThreadsDone({ accountLogin: ACCOUNT, threadIds: ['1'] });
+    const second = h.coordinator.markThreadsDone({ accountLogin: ACCOUNT, threadIds: ['2'] });
+    await vi.waitFor(() => expect(mutateNotification).toHaveBeenCalledTimes(1));
+    await Promise.resolve();
+    expect(mutateNotification).toHaveBeenCalledTimes(1);
+
+    releaseFirstMutation.resolve();
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { action: 'done', requestedCount: 1, changedCount: 1 },
+      { action: 'done', requestedCount: 1, changedCount: 1 },
+    ]);
+    expect(mutateNotification).toHaveBeenCalledTimes(2);
+    expect(serializedRuns).toBe(4);
+    expect(peakActiveRuns).toBe(1);
+    expect(h.broadcastChanged).toHaveBeenCalledTimes(2);
   });
 
   it('publishes live-star Notifications even when native scope omits the repository', async () => {

--- a/tests/unit/background-watch-refresh.test.ts
+++ b/tests/unit/background-watch-refresh.test.ts
@@ -348,6 +348,80 @@ describe('Watch background refresh coordinator', () => {
     expect(mutateNotification).not.toHaveBeenCalled();
   });
 
+  it('applies the successful part of an oversized done batch', async () => {
+    const threads = Array.from({ length: 500 }, (_, index) => thread(String(index + 1)));
+    await db.watchNotificationThreads.bulkPut(threads);
+    await db.watchState.put({
+      id: 'singleton',
+      accountLogin: ACCOUNT,
+      scope: {
+        lastAttemptAt: null,
+        lastSuccessfulAt: null,
+        errorCode: null,
+        repositoryCount: 0,
+      },
+      inbox: {
+        lastAttemptAt: null,
+        lastSuccessfulAt: null,
+        errorCode: null,
+        lastModified: null,
+        nextAllowedAt: null,
+        candidateCount: 0,
+        matchedCount: 0,
+        truncated: false,
+      },
+    });
+    const mutateNotification = vi.fn(async ({ threadId }: { threadId: string }) => {
+      if (threadId === '250') throw new GitHubWatchError('rate_limited');
+    });
+    const h = harness({ mutateNotification });
+
+    const result = await h.coordinator.markThreadsDone({
+      accountLogin: ACCOUNT,
+      threadIds: threads.map((item) => item.id),
+    });
+
+    expect(mutateNotification).toHaveBeenCalledTimes(500);
+    expect(result).toEqual({ action: 'done', requestedCount: 500, changedCount: 499 });
+    const remaining = await watchStore.queryStoredWatchInbox({ accountLogin: ACCOUNT });
+    expect(remaining.threads.map((item) => item.id)).toEqual(['250']);
+  });
+
+  it('rejects a done batch when every thread mutation fails', async () => {
+    await db.watchNotificationThreads.bulkPut([thread('1'), thread('2')]);
+    await db.watchState.put({
+      id: 'singleton',
+      accountLogin: ACCOUNT,
+      scope: {
+        lastAttemptAt: null,
+        lastSuccessfulAt: null,
+        errorCode: null,
+        repositoryCount: 0,
+      },
+      inbox: {
+        lastAttemptAt: null,
+        lastSuccessfulAt: null,
+        errorCode: null,
+        lastModified: null,
+        nextAllowedAt: null,
+        candidateCount: 0,
+        matchedCount: 0,
+        truncated: false,
+      },
+    });
+    const mutateNotification = vi.fn(async () => {
+      throw new GitHubWatchError('rate_limited');
+    });
+    const h = harness({ mutateNotification });
+
+    await expect(h.coordinator.markThreadsDone({
+      accountLogin: ACCOUNT,
+      threadIds: ['1', '2'],
+    })).rejects.toMatchObject({ code: 'rate_limited' });
+    expect((await watchStore.queryStoredWatchInbox({ accountLogin: ACCOUNT })).threads)
+      .toHaveLength(2);
+  });
+
   it('publishes live-star Notifications even when native scope omits the repository', async () => {
     const h = harness({
       fetchScope: vi.fn(async () => ({

--- a/tests/unit/github-watch-sources.test.ts
+++ b/tests/unit/github-watch-sources.test.ts
@@ -418,12 +418,15 @@ describe('GitHub Watch API sources', () => {
     })).rejects.toMatchObject({ code: 'invalid_thread' });
     expect(fetchImpl).not.toHaveBeenCalled();
 
+    // A done transition on a missing thread is the target state; other
+    // non-contract statuses still surface as failures.
+    const unavailable = vi.fn<typeof fetch>(async () => new Response(null, { status: 503 }));
     await expect(mutateGitHubNotificationThread({
       token: 'token',
       threadId: '123',
       action: 'done',
-      fetchImpl,
-    })).rejects.toMatchObject({ code: 'invalid_response', status: 404 });
+      fetchImpl: unavailable,
+    })).rejects.toMatchObject({ code: 'github_unavailable', status: 503 });
   });
 
   it('fetches and normalizes Issue/PR details with the main-token contract', async () => {
@@ -580,5 +583,73 @@ describe('GitHub Watch API sources', () => {
       fetchImpl: hanging,
       timeoutMs: 1,
     })).rejects.toMatchObject({ code: 'deadline_exceeded' });
+  });
+});
+
+describe('mutateGitHubNotificationThread', () => {
+  it('marks a thread done on 204', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(null, { status: 204 }));
+    await expect(mutateGitHubNotificationThread({
+      token: 'token',
+      threadId: '42',
+      action: 'done',
+      fetchImpl,
+    })).resolves.toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.github.com/notifications/threads/42',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('treats a missing done thread as already in the target state', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(null, { status: 404 }));
+    await expect(mutateGitHubNotificationThread({
+      token: 'token',
+      threadId: '42',
+      action: 'done',
+      fetchImpl,
+    })).resolves.toBeUndefined();
+  });
+
+  it('still fails a done transition on a real error', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(null, { status: 403 }));
+    await expect(mutateGitHubNotificationThread({
+      token: 'token',
+      threadId: '42',
+      action: 'done',
+      fetchImpl,
+    })).rejects.toBeInstanceOf(GitHubWatchError);
+  });
+
+  it('marks a thread read on 205 and treats 304 as already read', async () => {
+    const reset = vi.fn<typeof fetch>(async () => new Response(null, { status: 205 }));
+    await expect(mutateGitHubNotificationThread({
+      token: 'token',
+      threadId: '42',
+      action: 'read',
+      fetchImpl: reset,
+    })).resolves.toBeUndefined();
+    expect(reset).toHaveBeenCalledWith(
+      'https://api.github.com/notifications/threads/42',
+      expect.objectContaining({ method: 'PATCH' }),
+    );
+
+    const unmodified = vi.fn<typeof fetch>(async () => new Response(null, { status: 304 }));
+    await expect(mutateGitHubNotificationThread({
+      token: 'token',
+      threadId: '42',
+      action: 'read',
+      fetchImpl: unmodified,
+    })).resolves.toBeUndefined();
+  });
+
+  it('keeps a missing thread a failure for read', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(null, { status: 404 }));
+    await expect(mutateGitHubNotificationThread({
+      token: 'token',
+      threadId: '42',
+      action: 'read',
+      fetchImpl,
+    })).rejects.toBeInstanceOf(GitHubWatchError);
   });
 });


### PR DESCRIPTION
## Problem
A repository-level Watch `done` action can span hundreds of notification threads. One stale or transiently failing thread stopped workers early and prevented later targets from being attempted.

## Fix
- treat DELETE 404 as idempotent success because the thread is already absent from the inbox
- attempt every target in a batch even when individual mutations fail
- apply every successful mutation locally
- surface the first error only when all targets fail
- preserve account revalidation, serialized ownership, and the 500-ID message boundary

## Regression coverage
- post-request credential and account revalidation
- maximum four concurrent mutation workers
- exact-once target consumption
- serialization of overlapping mutation commands
- one broadcast for partial success and no mutation broadcast when all targets fail

## Verification
- `pnpm typecheck`
- 55 focused Watch source and coordinator tests
- original implementation commit also reports the full 2,450-test logic suite passing
- one scoped Trellis review identified the missing regression cases; the authorized follow-up adds those cases without changing runtime code