### PR TITLE
fix(release): refresh worker identity snapshot

### DIFF
--- a/scripts/package-manifest-closure.mjs
+++ b/scripts/package-manifest-closure.mjs
@@ -2,11 +2,11 @@ import { createHash } from 'node:crypto';
 import { lstatSync, realpathSync } from 'node:fs';
 import path from 'node:path';
 
-export const WORKER_BYTE_CEILING = 740_206;
+export const WORKER_BYTE_CEILING = 741_694;
 export const RELEASE_WORKER_BASELINE = Object.freeze({
-  relativePath: 'assets/index.ts-CkQeZGmv.js',
+  relativePath: 'assets/index.ts-B-zMDfya.js',
   bytes: WORKER_BYTE_CEILING,
-  sha256: '9752d7463acee5886173e823f981c94c73bd0f2ac61e23724e3b79462636595e',
+  sha256: '51100a0ab0ac3fd95dec93744663f3edfd56afb63489fc5875abdc4afa6997b7',
 });
 
 const SHA256 = /^[0-9a-f]{64}$/u;

--- a/tests/unit/package-manifest-closure.test.mjs
+++ b/tests/unit/package-manifest-closure.test.mjs
@@ -212,7 +212,7 @@ test('measures bundle identities and enforces the frozen release worker exactly'
     ...RELEASE_WORKER_BASELINE,
     kib: RELEASE_WORKER_BASELINE.bytes / 1024,
   };
-  assert.equal(exact.bytes, 740_206);
+  assert.equal(exact.bytes, 741_694);
   assert.equal(WORKER_BYTE_CEILING, exact.bytes);
   assert.equal(enforceWorkerByteCeiling(exact).withinCeiling, true);
   assert.deepEqual(enforceWorkerReleaseBaseline(exact), exact);


### PR DESCRIPTION
## Problem

The v2.0.0 release gate built the intentional Watch batch fix into a new deterministic service-worker chunk, but the frozen release identity still described the prior bundle. The workflow rejected the new worker before packaging or creating a GitHub Release.

## Fix

- freeze the measured production worker path, byte count, and SHA-256
- keep exact path, size, and hash equality enforcement
- update the focused snapshot assertion without widening gate semantics

## Verification

- `pnpm vitest run tests/unit/package-manifest-closure.test.mjs` — 18 passed
- `pnpm typecheck`
- release-mode `pnpm build` — emitted `assets/index.ts-B-zMDfya.js`, 741,694 bytes
- direct `enforceWorkerReleaseBaseline` exercise — passed with SHA-256 `51100a0ab0ac3fd95dec93744663f3edfd56afb63489fc5875abdc4afa6997b7`
- scoped Trellis review — PASS

The failed tag produced no GitHub Release or packaged release assets.