### PR TITLE
chore(release): set version 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-github-stars-manager",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Manage your GitHub starred repos: tag, note, filter, search across thousands of stars. UI injected into the stars page.",
   "packageManager": "pnpm@10.33.2",
   "devEngines": {


### PR DESCRIPTION
## Context

The protected `v2.0.0` tag points to a commit whose release workflow failed before packaging or GitHub Release creation. Repository rules intentionally prohibit updating or deleting `v*` tags, so the corrected release must use a new version.

## Change

- set the extension package version to `2.0.1`
- preserve the immutable `v2.0.0` tag and active tag-protection rules

## Verification

- `pnpm typecheck`
- release-mode `pnpm build`
- emitted manifest version: `2.0.1`
- worker identity unchanged and accepted by the exact release baseline
- scoped Trellis review: PASS