### PR TITLE
fix(runtime): respect Radar hover media capability

### DIFF
--- a/tests/runtime/extension-browser-smoke.mjs
+++ b/tests/runtime/extension-browser-smoke.mjs
@@ -3261,6 +3261,7 @@ async function assertRadarSourceFilters(page) {
       y: rect.top + rect.height / 2,
       backgroundColor: style.backgroundColor,
       boxShadow: style.boxShadow,
+      finePointerHover: matchMedia('(hover: hover) and (pointer: fine)').matches,
     };
   });
   assert.ok(hoverProbe, 'could not locate Radar row for hover probe');
@@ -3276,11 +3277,19 @@ async function assertRadarSourceFilters(page) {
   assert.ok(hoveredStyle, 'could not read Radar row hover style');
   assert.equal(hoverProbe.boxShadow, 'none', 'Radar row rendered a pre-hover inset edge');
   assert.equal(hoveredStyle.boxShadow, 'none', 'Radar row rendered a hover inset edge');
-  assert.notEqual(
-    hoveredStyle.backgroundColor,
-    hoverProbe.backgroundColor,
-    'Radar row hover did not change the immediate row background',
-  );
+  if (hoverProbe.finePointerHover) {
+    assert.notEqual(
+      hoveredStyle.backgroundColor,
+      hoverProbe.backgroundColor,
+      'Radar row hover did not change the immediate row background',
+    );
+  } else {
+    assert.equal(
+      hoveredStyle.backgroundColor,
+      hoverProbe.backgroundColor,
+      'Radar row applied a hover background in a runtime without fine-pointer hover',
+    );
+  }
   const unseen = await page.evaluate(() => {
     const root = document.getElementById('gsm-manager-host')?.shadowRoot?.getElementById('gsm-manager-root');
     const tab = root?.querySelector('#gsm-radar-surface-tab');


### PR DESCRIPTION
## Problem

The v2.0.1 release smoke runs Linux Chrome headless, where the Radar row may report no fine-pointer hover capability. Product CSS deliberately applies the hover background only under `(hover: hover) and (pointer: fine)`, but the smoke test required the background change unconditionally. Two release attempts failed at that mismatch.

## Fix

- record the browser's exact fine-pointer hover media result
- require the background change when the product hover rule applies
- require no hover background when that media rule does not apply
- preserve the pre/post box-shadow and unseen-state assertions

## Verification

- `pnpm typecheck`
- `CI=true pnpm test:smoke` — real Chrome extension smoke passed
- scoped Trellis review — PASS

A non-tag Release workflow dispatch will run before any protected tag is moved.