### PR TITLE
docs(contributing): add contribution and security workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,123 @@
+name: Bug report / 问题报告
+description: Report reproducible incorrect behavior / 报告可复现的错误行为
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. 感谢你报告问题。
+
+        Search existing issues first. Remove tokens, API keys, private repository data, personal information, and local paths from every field and attachment.
+
+        请先搜索已有 Issue。请从所有字段和附件中删除 Token、API Key、私人仓库数据、个人信息和本机路径。
+
+        Do not report security vulnerabilities here. Follow the repository [security policy](https://github.com/izumi0uu/better-github-stars-manager/security/policy).
+
+        请勿在此报告安全漏洞；请遵循仓库的[安全政策](https://github.com/izumi0uu/better-github-stars-manager/security/policy)。
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight / 提交前确认
+      options:
+        - label: I searched existing issues for the same problem. / 我已搜索已有 Issue，确认没有相同问题。
+          required: true
+        - label: I removed credentials, private data, personal information, and identifying screenshots. / 我已删除凭据、私人数据、个人信息和可识别身份的截图。
+          required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface / 受影响功能
+      description: Select the surface where the problem appears. / 选择出现问题的功能。
+      options:
+        - Stars manager / Stars 管理
+        - Watch Inbox
+        - Following Radar
+        - Cubby Agent
+        - Options and authentication / 设置与认证
+        - Gist sync / Gist 同步
+        - Browser build or runtime / 浏览器构建或运行时
+        - Public demo / 公开演示
+        - Other / 其他
+    validations:
+      required: true
+
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: Browser / 浏览器
+      description: Select every browser where you reproduced the problem. / 选择所有能够复现问题的浏览器。
+      multiple: true
+      options:
+        - Google Chrome
+        - Mozilla Firefox
+        - Microsoft Edge
+        - Opera
+        - Other / 其他
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Extension version or commit / 扩展版本或 commit
+      description: Provide the store version or commit SHA you tested. / 填写你测试的商店版本或 commit SHA。
+      placeholder: Store version or commit SHA / 商店版本或 commit SHA
+    validations:
+      required: true
+
+  - type: input
+    id: operating-system
+    attributes:
+      label: Operating system / 操作系统
+      placeholder: macOS, Windows, or Linux and its version / 系统及版本
+    validations:
+      required: false
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps / 复现步骤
+      description: Provide the smallest deterministic sequence that reproduces the problem. / 提供能够稳定复现问题的最短步骤。
+      placeholder: |
+        1. Open… / 打开……
+        2. Select… / 选择……
+        3. Observe… / 观察……
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior / 实际行为
+      description: Describe what happened, including visible error states. / 描述实际结果，包括可见错误状态。
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior / 预期行为
+      description: Describe the observable result you expected. / 描述你期望看到的结果。
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Sanitized logs / 已脱敏日志
+      description: Paste only the minimum relevant output after removing secrets and private data. / 删除秘密和私人数据后，仅粘贴最相关的最小输出。
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context / 补充信息
+      description: Add sanitized screenshots, recordings, or links that help reproduce the problem. / 添加有助于复现问题的已脱敏截图、录屏或链接。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,113 @@
+name: Feature request / 功能建议
+description: Propose a user problem and desired behavior / 提出用户问题和期望行为
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the user problem before proposing implementation details. 先说明用户问题，再描述期望行为。
+
+        Significant permission, storage, sync, data-transfer, dependency, or interaction changes need scope agreement before implementation.
+
+        涉及权限、存储、同步、数据传输、依赖或明显交互变化的提案，需要先确认范围再实现。
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight / 提交前确认
+      options:
+        - label: I searched existing issues and found no equivalent request. / 我已搜索已有 Issue，没有发现相同建议。
+          required: true
+        - label: This request contains no credentials, private repository data, personal information, or copied private work-item text. / 本建议不含凭据、私人仓库数据、个人信息或私有工作项原文。
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: User problem / 用户问题
+      description: Explain who is blocked, what they are trying to do, and the current limitation. / 说明谁遇到了阻碍、想完成什么，以及当前限制。
+    validations:
+      required: true
+
+  - type: textarea
+    id: desired-behavior
+    attributes:
+      label: Desired behavior / 期望行为
+      description: Describe the observable outcome without prescribing internal implementation. / 描述可观察结果，不要求指定内部实现。
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Current alternatives / 当前替代方式
+      description: Describe any workaround or existing feature you use today. / 描述目前使用的临时方案或已有功能。
+    validations:
+      required: false
+
+  - type: dropdown
+    id: surfaces
+    attributes:
+      label: Affected surface / 受影响功能
+      description: Select every relevant surface. / 选择所有相关功能。
+      multiple: true
+      options:
+        - Stars manager / Stars 管理
+        - Watch Inbox
+        - Following Radar
+        - Cubby Agent
+        - Options and authentication / 设置与认证
+        - Gist sync / Gist 同步
+        - Browser support / 浏览器支持
+        - Public demo or documentation / 公开演示或文档
+        - Other / 其他
+    validations:
+      required: true
+
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: Browser scope / 浏览器范围
+      multiple: true
+      options:
+        - Google Chrome
+        - Mozilla Firefox
+        - Microsoft Edge
+        - Opera
+        - Cross-browser or not sure / 跨浏览器或不确定
+    validations:
+      required: true
+
+  - type: dropdown
+    id: data-permissions
+    attributes:
+      label: Data or permission impact / 数据或权限影响
+      description: Select the closest answer. The maintainer will verify it. / 选择最接近的答案，维护者会进一步确认。
+      options:
+        - No expected data or permission change / 预计不改变数据或权限
+        - May change extension or host permissions / 可能改变扩展或主机权限
+        - May change local storage, sync, or external data transfer / 可能改变本地存储、同步或外部数据传输
+        - Not sure / 不确定
+    validations:
+      required: true
+
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Contribution interest / 参与意愿
+      options:
+        - I can implement this after scope agreement / 确认范围后我可以实现
+        - I can help test or document it / 我可以协助测试或编写文档
+        - I am proposing the idea only / 我只提出建议
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context / 补充信息
+      description: Add public references, synthetic mockups, or other context. Do not copy private work-item text. / 添加公开资料、合成数据原型或其他背景，不要复制私有工作项原文。
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+<!--
+Read CONTRIBUTING.md or CONTRIBUTING.en.md before submitting.
+提交前请阅读 CONTRIBUTING.md 或 CONTRIBUTING.en.md。
+
+Use a focused Conventional Commit style title. GitHub hides these comments in the rendered Pull Request.
+PR 标题使用范围清晰的 Conventional Commit 格式。GitHub 不会在渲染后的 Pull Request 中显示这些注释。
+-->
+
+## Problem / 问题
+
+<!-- Describe the incorrect or missing behavior and its user impact. 描述错误或缺失的行为，以及对用户的影响。 -->
+
+Related issue / 关联 Issue: <!-- Closes #123 or N/A / 填写 Closes #123 或 N/A -->
+
+## Decision / 方案
+
+<!-- Explain what changed, why this approach was chosen, and what remains unchanged. 说明改了什么、为什么这样改，以及哪些边界保持不变。 -->
+
+## Verification / 验证
+
+<!-- List exact commands and manual scenarios that you actually ran. 只列出实际运行过的命令和手动场景。 -->
+
+Tested / 已验证：
+
+- <!-- Add each command or scenario / 添加每条命令或场景 -->
+
+Not tested / 未验证：
+
+- <!-- State each excluded scenario / 列出每个未验证场景 -->
+
+## Risk / 风险
+
+<!-- Cover permissions, data, storage, sync, browser compatibility, and release risk. Write N/A when none apply. 说明权限、数据、存储、同步、浏览器兼容和发布风险；不适用时写 N/A。 -->
+
+## Visual evidence / 视觉证据
+
+<!-- Required for visual changes. Use synthetic or explicitly approved public data. 视觉改动必须提供；只能使用合成数据或明确获准公开的数据。 -->
+
+## Checklist / 检查清单
+
+- [ ] The diff addresses one focused problem and contains no unrelated refactor or formatting work / 改动只解决一个明确问题，不含无关重构或格式化
+- [ ] New behavior and bug fixes have suitable behavior tests / 新行为和 Bug 修复有合适的行为测试
+- [ ] `pnpm typecheck` and the smallest relevant tests pass / `pnpm typecheck` 和适用的最小测试已通过
+- [ ] English and Chinese documentation match user-visible behavior changes, when applicable / 如有用户可见变化，中英文文档已同步
+- [ ] UI changes were verified in the real extension surface, when applicable / 如有界面改动，已在真实扩展页面验证
+- [ ] The diff contains no generated output, credentials, private data, personal information, or copied external work-item text / 改动不含生成文件、凭据、私人数据、个人信息或外部工作项原文
+- [ ] Tested and untested scope is stated accurately / 已准确说明验证和未验证范围

--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -1,29 +1,74 @@
-# Contributing
+# Contributing to Better GitHub Stars Manager
 
-[中文](CONTRIBUTING.md)
+[简体中文](CONTRIBUTING.md)
 
-Thanks for improving Better GitHub Stars Manager. Keep changes focused and verifiable, and reuse established repository patterns.
+Use this guide to propose, implement, verify, and submit a focused change. Maintainers own release packaging, store submissions, and version releases.
 
 ## Before you start
 
-- Read [AGENTS.md](AGENTS.md) for the repository's data, sync, privacy, and verification rules.
-- Before changing or debugging Cubby Agent, read the [Cubby Agent technical reference](docs/en/cubby-agent.md).
-- Never put real accounts, tokens, API keys, local absolute paths, private repository content, or verbatim external work items in code, tests, logs, screenshots, or documentation. Use synthetic data.
+- Read [AGENTS.md](AGENTS.md) for the repository's data, sync, privacy, and verification rules
+- Before changing or debugging Cubby Agent, read the [Cubby Agent technical reference](docs/en/cubby-agent.md)
+- Reuse established repository patterns instead of creating a second convention
 
-## Install and build
+## Choose the right starting point
 
-The project uses the pnpm version pinned in `package.json`:
+Search the existing [GitHub Issues](https://github.com/izumi0uu/better-github-stars-manager/issues) before writing code. This avoids duplicate work.
+
+You can open a Pull Request directly for:
+
+- A focused bug fix
+- Regression coverage or test reliability work
+- Documentation corrections that match current behavior
+- Small maintenance changes that do not change product behavior
+
+Open an Issue and agree on scope before working on:
+
+- A new feature or substantial interaction redesign
+- Manifest, permission, or browser compatibility changes
+- IndexedDB schema, index, migration, or backfill changes
+- GitHub sync, authentication, retention, or data-transfer semantics
+- New dependencies, large refactors, or cross-module API changes
+
+Include these details in a bug report:
+
+- Browser, browser version, and extension version or commit
+- Minimal reproduction steps with private data removed
+- Expected behavior and actual behavior
+- Sanitized errors, console output, or screenshots
+
+Never include tokens, API keys, private repository data, or personally identifiable information in an Issue. For a security vulnerability, read the [security policy](SECURITY.md) and use the private reporting option on the repository's [Security page](https://github.com/izumi0uu/better-github-stars-manager/security). If it is unavailable, open only a redacted Issue requesting a private contact route. Do not publish vulnerability details.
+
+## Set up your development environment
+
+Continuous integration uses Node.js 24 and pnpm 10.33.2. Use the same versions to reduce local differences.
+
+1. Fork the repository and clone your fork
+2. Create a focused branch from `master`, such as `fix/watch-account-fence`
+3. Install dependencies and build the Chrome extension
 
 ```bash
-pnpm install
+pnpm install --frozen-lockfile
 pnpm build
 ```
 
-The normal Chrome build is written to `dist/`. Build Firefox with:
+`pnpm install` configures the repository's commit message hook. The Chrome build writes to `dist/`, which Git ignores.
+
+Verify the build in Chrome:
+
+1. Open `chrome://extensions`
+2. Enable **Developer mode**
+3. Click **Load unpacked**
+4. Select the project's `dist/` directory
+
+Use these commands for Firefox-specific work:
 
 ```bash
 pnpm build:firefox
+pnpm lint:firefox
+pnpm test:smoke:firefox
 ```
+
+The Firefox build writes to `dist-firefox/`. Do not edit generated files in `dist/`, `dist-firefox/`, `dist-demo/`, or `artifacts/`.
 
 ## Debug Cubby Agent
 
@@ -35,7 +80,7 @@ Create a reproducible Agent diagnostics build:
 pnpm build:agent-dev-diagnostics
 ```
 
-The output is `artifacts/agent-diagnostics-dev-dist/`. In `chrome://extensions`, enable **Developer mode**, choose **Load unpacked**, and load that directory.
+The output is `artifacts/agent-diagnostics-dev-dist/`. In `chrome://extensions`, enable **Developer mode**, click **Load unpacked**, and load that directory.
 
 For live Provider monitoring, run:
 
@@ -45,26 +90,103 @@ pnpm dev:agent-diagnostics
 
 This command builds `dist/` and then starts the local diagnostics service. Load or reload `dist/` as instructed by the command, and keep the process running while monitoring.
 
-These entry points are development-only. `artifacts/agent-diagnostics-dev-dist/`, the local diagnostics service, and development traces are not store packages or release evidence. Release verification must use the production build and release gates.
+These entry points are development-only. The Agent diagnostics build, local diagnostics service, and development traces are not store packages or release evidence. Release verification must use the production build and release gates.
 
-## Verify changes
+## Preserve data and browser boundaries
 
-Every code change must run:
+Keep these contracts when changing data models, sync, or manifests:
+
+- IndexedDB in `src/storage/db.ts` is the local source of truth for stars, tags, and tag metadata
+- `chrome.storage.local` stores lightweight configuration, UI state, credential material, and backfill state
+- GitHub is the source of truth for remote metadata such as `archived`, `fork`, `created_at`, `pushed_at`, and `starred_at`
+- Define a safe default for each new `Config` field in `src/types/index.ts`, then normalize it in `src/auth/auth-store.ts`
+- Update types, the Dexie schema, and legacy-row handling when changing a persisted entity or index
+- Use a capability backfill when existing rows need remote fields; do not trigger a full sync on every extension update
+- Change `manifest.config.ts` or the owning build transform; do not edit a generated `manifest.json`
+- Never download or execute remote code; treat external responses only as data
+
+Fix behavior at its owning source and migrate every caller. Do not retain aliases or parallel paths for unreleased experiments.
+
+## Protect privacy and test data
+
+Every tracked file and asset must be safe to publish:
+
+- Use synthetic values such as `octocat`, `user@example.com`, and repository-relative paths
+- Do not commit real usernames, names, email addresses, local paths, tokens, account data, or private repository details
+- Do not commit screenshots from a personal account unless a maintainer explicitly approves the public asset and it contains no private data
+- Do not copy Jira, support, chat, or other external work-item text into code, tests, comments, documentation, or assets
+- Translate external requirements into generic product behavior and test conditions
+- Check images, JSON, logs, and other non-code assets for metadata before submission
+
+## Verify your change
+
+Run the smallest test that owns the changed behavior first. Every code change must run `pnpm typecheck`.
+
+| Change surface | Verification command |
+| --- | --- |
+| Pure logic, filtering, or sorting | `pnpm test:logic` |
+| Query or store integration | `pnpm test:integration` |
+| Sync, storage compatibility, migration, or backfill | `pnpm test:regressions` |
+| Extension runtime behavior | `pnpm test:runtime` or `pnpm test:smoke` |
+| Cubby Agent logic or runtime | `pnpm test:logic`, `pnpm test:runtime:agent-diagnostics`, or `pnpm test:runtime:agent-scenarios` |
+| Firefox-specific behavior | `pnpm build:firefox`, `pnpm lint:firefox`, and `pnpm test:smoke:firefox` |
+| Documentation | Check links, commands, and both languages; code tests are optional |
+
+A bug fix needs a regression test that fails before the fix and passes after it. Sync semantics, storage compatibility, migrations, and backfills require regression coverage.
+
+Verify UI changes in the real extension surface. Include screenshots or recordings created with synthetic data for visual changes. Agent runtime changes cannot treat a development diagnostics build as a release build or skip the real extension runtime boundary.
+
+Before submitting a broad or high-risk change, also run:
 
 ```bash
-pnpm typecheck
+pnpm build
+pnpm test
 ```
 
-Then run the smallest test layer that covers the changed behavior. Cubby Agent changes usually start with the relevant commands below:
+Continuous integration (CI) runs `pnpm typecheck`, `pnpm build`, and `pnpm test` for each Pull Request. CI also runs a credential-free Chrome extension smoke check.
 
-```bash
-pnpm test:logic
-pnpm test:runtime:agent-diagnostics
-pnpm test:runtime:agent-scenarios
+## Use the repository's commit format
+
+Use a Conventional Commit title with at most 72 characters and no trailing period. Supported types are `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, and `revert`.
+
+A `docs:` or `chore:` commit can contain only one line. Every other type needs a blank line after its title and the required Lore trailers:
+
+```text
+fix(watch): preserve source account during bulk actions
+
+Constraint: Keep each background request within the existing batch limit
+Rejected: Retry against the new account | it could mutate the wrong account
+Confidence: high
+Scope-risk: narrow
+Directive: Bind remote mutations to the projection that selected them
+Tested: pnpm typecheck; focused Watch regression tests
+Not-tested: Authenticated GitHub mutation against a live account
 ```
 
-See `package.json` for the other Agent runtime commands. Do not skip the real extension runtime boundary or treat a development diagnostics build as a release build.
+Describe the real verification scope in `Tested` and `Not-tested`. The commit hook rejects missing fields and invalid formats.
 
-## Submit a pull request
+## Submit a Pull Request
 
-Describe the observable behavior change, its risk boundary, and the exact commands you ran. Do not commit generated build directories, personal data, or unsanitized diagnostic artifacts.
+Target `master` and keep each Pull Request focused on one problem. Include these sections in its description:
+
+- **Problem**: what is incorrect or missing
+- **Decision**: what changed and why
+- **Check**: what you verified and did not verify
+- **Risk**: permission, data, compatibility, or release risks
+- **Evidence**: relevant tests, screenshots, or recordings
+
+Check your Pull Request before submission:
+
+- [ ] The diff contains no unrelated refactor or formatting work
+- [ ] New behavior and bug fixes have suitable behavior tests
+- [ ] `pnpm typecheck` and the smallest relevant tests pass
+- [ ] English and Chinese docs match any user-visible behavior change
+- [ ] You verified visual changes in the real extension surface
+- [ ] The diff contains no generated output, credentials, private data, or copied external work-item text
+- [ ] The Pull Request lists the tested and untested scope accurately
+
+Maintainers review correctness, privacy boundaries, cross-browser behavior, and maintenance cost. Store releases, version numbers, and publishing credentials are outside a normal Pull Request.
+
+## License
+
+By contributing, you agree to license your contribution under this repository's [MIT License](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,33 +1,78 @@
-# 参与贡献
+# 为 Better GitHub Stars Manager 贡献
 
 [English](CONTRIBUTING.en.md)
 
-感谢你改进 Better GitHub Stars Manager。请保持改动聚焦、可验证，并优先复用现有实现模式。
+本指南说明如何提出、实现、验证和提交一个范围清晰的改动。发布打包、商店提交和版本发布由维护者负责。
 
 ## 开始前
 
-- 阅读 [AGENTS.md](AGENTS.md)，其中记录了数据、同步、隐私和验证规则。
-- 修改或调试 Cubby Agent 前，阅读 [Cubby Agent 技术参考](docs/zh/cubby-agent.md)。
-- 不要把真实账号、Token、API Key、本地绝对路径、私人仓库内容或外部工单原文写入代码、测试、日志、截图或文档。使用合成数据。
+- 阅读 [AGENTS.md](AGENTS.md)，其中记录了数据、同步、隐私和验证规则
+- 修改或调试 Cubby Agent 前，阅读 [Cubby Agent 技术参考](docs/zh/cubby-agent.md)
+- 优先复用现有实现模式，避免为同一问题创建第二套约定
 
-## 安装与常规构建
+## 选择正确的提交方式
 
-项目使用 `package.json` 中固定版本的 pnpm：
+开始编码前，先搜索现有的 [GitHub Issues](https://github.com/izumi0uu/better-github-stars-manager/issues)，避免重复工作。
+
+以下改动可以直接提交 Pull Request：
+
+- 范围明确的 Bug 修复
+- 回归测试或测试可靠性改进
+- 与当前行为一致的文档修正
+- 不改变产品行为的小型维护改动
+
+以下改动应先创建 Issue 并确认范围：
+
+- 新功能或明显的交互改版
+- Manifest、权限或浏览器兼容性变化
+- IndexedDB schema、索引、迁移或 backfill 变化
+- GitHub 同步、认证、数据保留或数据传输语义变化
+- 新依赖、大型重构或跨模块 API 变化
+
+报告 Bug 时，请提供：
+
+- 浏览器、浏览器版本和扩展版本或 commit
+- 可去除私人数据后复现的最小步骤
+- 预期行为和实际行为
+- 已脱敏的错误信息、控制台输出或截图
+
+不要在 Issue 中提交 Token、API Key、私人仓库数据或可识别个人身份的信息。报告安全漏洞时，请阅读[安全政策](SECURITY.md)，并优先使用仓库 [Security 页面](https://github.com/izumi0uu/better-github-stars-manager/security)中提供的私密报告入口。如果该入口不可用，只创建一条已脱敏的 Issue 请求私密联系方式，不要公开漏洞细节。
+
+## 准备开发环境
+
+项目的持续集成环境使用 Node.js 24 和 pnpm 10.33.2。使用相同版本可以减少本地与持续集成环境的差异。
+
+1. Fork 本仓库并克隆你的 Fork
+2. 从 `master` 创建一个范围明确的分支，例如 `fix/watch-account-fence`
+3. 安装依赖并构建 Chrome 扩展
 
 ```bash
-pnpm install
+pnpm install --frozen-lockfile
 pnpm build
 ```
 
-常规 Chrome 构建输出到 `dist/`。Firefox 构建使用：
+`pnpm install` 会安装仓库的 commit message hook。Chrome 构建输出位于 `dist/`，该目录不会提交到 Git。
+
+在 Chrome 中验证构建结果：
+
+1. 打开 `chrome://extensions`
+2. 开启 **开发者模式**
+3. 点击 **加载已解压的扩展程序**
+4. 选择项目中的 `dist/` 目录
+
+Firefox 专用改动使用以下命令：
 
 ```bash
 pnpm build:firefox
+pnpm lint:firefox
+pnpm test:smoke:firefox
 ```
+
+Firefox 构建输出位于 `dist-firefox/`。不要直接编辑 `dist/`、`dist-firefox/`、`dist-demo/` 或 `artifacts/` 中的生成文件。
 
 ## 调试 Cubby Agent
 
-需要检查 Cubby Agent 的开发诊断、Provider 事件或恢复行为时，不要修改发布构建来临时暴露调试状态。使用仓库提供的开发入口。
+检查 Cubby Agent 的开发诊断、Provider 事件或恢复行为时，不要修改发布构建来临时暴露调试状态。使用仓库提供的开发入口。
 
 生成一个可重复加载的 Agent 诊断构建：
 
@@ -35,7 +80,7 @@ pnpm build:firefox
 pnpm build:agent-dev-diagnostics
 ```
 
-构建输出位于 `artifacts/agent-diagnostics-dev-dist/`。在 `chrome://extensions` 中开启开发者模式，选择 **加载已解压的扩展程序**，并加载这个目录。
+构建输出位于 `artifacts/agent-diagnostics-dev-dist/`。在 `chrome://extensions` 中开启 **开发者模式**，点击 **加载已解压的扩展程序**，并加载这个目录。
 
 需要实时 Provider 监控时运行：
 
@@ -45,26 +90,103 @@ pnpm dev:agent-diagnostics
 
 该命令会构建 `dist/`，随后启动本地诊断服务。按终端输出加载或重新加载 `dist/`，并在监控期间保持进程运行。
 
-这些入口仅用于本地开发。`artifacts/agent-diagnostics-dev-dist/`、本地诊断服务和开发记录都不是商店包或发布证据；发布验证必须使用正式构建和发布门禁。
+这些入口仅用于本地开发。Agent 诊断构建、本地诊断服务和开发记录都不是商店包或发布证据；发布验证必须使用正式构建和发布门禁。
 
-## 验证
+## 遵守数据和浏览器边界
 
-代码改动至少运行：
+改动数据模型、同步或 manifest 前，请保持以下约束：
+
+- `src/storage/db.ts` 中的 IndexedDB 是 stars、tags 和 tag metadata 的本地事实来源
+- `chrome.storage.local` 只保存轻量配置、界面状态、凭据材料和 backfill 状态
+- GitHub 是 `archived`、`fork`、`created_at`、`pushed_at` 和 `starred_at` 等远端元数据的事实来源
+- 新增 `Config` 字段时，在 `src/types/index.ts` 定义安全默认值，并在 `src/auth/auth-store.ts` 读取时规范化
+- 改变持久化实体或索引时，同步更新类型、Dexie schema 和旧数据兼容逻辑
+- 为现有行补充远端字段时，优先使用 capability backfill，不要在每次扩展更新时触发 full sync
+- 修改 manifest 时更新 `manifest.config.ts` 或对应构建转换，不要修改生成后的 `manifest.json`
+- 扩展不能下载或执行远程代码；外部响应只能作为数据处理
+
+修复应解决拥有该行为的源代码，并迁移所有调用方。不要为尚未发布的实验行为保留兼容别名或双路径。
+
+## 保护隐私和测试数据
+
+所有 tracked 文件和资源都必须适合公开发布：
+
+- 使用 `octocat`、`user@example.com` 和仓库相对路径等合成值
+- 不提交真实用户名、姓名、邮箱、本机路径、Token、账号数据或私人仓库信息
+- 不提交来自个人账号的截图，除非维护者已明确批准公开且截图不含私人数据
+- 不把 Jira、支持工单、聊天或其他外部工作项的原文复制进代码、测试、注释、文档或资源
+- 将外部需求改写为通用的产品行为和测试条件
+- 提交前检查图片、JSON、日志和其他非代码资源中的元数据
+
+## 验证改动
+
+先运行覆盖改动边界的最小测试。所有代码改动都必须运行 `pnpm typecheck`。
+
+| 改动范围 | 验证命令 |
+| --- | --- |
+| 纯逻辑、筛选或排序 | `pnpm test:logic` |
+| Query 或 store 集成 | `pnpm test:integration` |
+| 同步、存储兼容、迁移或 backfill | `pnpm test:regressions` |
+| 扩展运行时行为 | `pnpm test:runtime` 或 `pnpm test:smoke` |
+| Cubby Agent 逻辑或运行时 | `pnpm test:logic`、`pnpm test:runtime:agent-diagnostics` 或 `pnpm test:runtime:agent-scenarios` |
+| Firefox 专用行为 | `pnpm build:firefox`、`pnpm lint:firefox` 和 `pnpm test:smoke:firefox` |
+| 文档 | 检查链接、命令和中英文内容；代码测试可省略 |
+
+Bug 修复需要能在修复前失败、修复后通过的回归测试。同步语义、存储兼容、迁移和 backfill 变化必须增加回归覆盖。
+
+涉及界面的改动还需要在真实扩展页面中验证。视觉变化应附上使用合成数据生成的截图或录屏。Agent runtime 改动不能把开发诊断构建当作发布构建，也不能跳过真实扩展运行边界。
+
+范围较大或风险较高的改动在提交前还应运行：
 
 ```bash
-pnpm typecheck
+pnpm build
+pnpm test
 ```
 
-然后运行覆盖改动行为的最小测试层。Cubby Agent 改动通常从对应的命令开始：
+持续集成会在 Pull Request 上运行 `pnpm typecheck`、`pnpm build` 和 `pnpm test`，并执行无凭据的 Chrome 扩展 smoke check。
 
-```bash
-pnpm test:logic
-pnpm test:runtime:agent-diagnostics
-pnpm test:runtime:agent-scenarios
+## 使用仓库的 commit 格式
+
+Commit 标题使用 Conventional Commits 格式，最长 72 个字符，结尾不加句号。支持的类型为 `feat`、`fix`、`docs`、`style`、`refactor`、`perf`、`test`、`build`、`ci`、`chore` 和 `revert`。
+
+`docs:` 和 `chore:` 可以只写一行。其他类型必须在标题后空一行，并填写仓库要求的 Lore trailers：
+
+```text
+fix(watch): preserve source account during bulk actions
+
+Constraint: Keep each background request within the existing batch limit
+Rejected: Retry against the new account | it could mutate the wrong account
+Confidence: high
+Scope-risk: narrow
+Directive: Bind remote mutations to the projection that selected them
+Tested: pnpm typecheck; focused Watch regression tests
+Not-tested: Authenticated GitHub mutation against a live account
 ```
 
-其他 Agent runtime 命令见 `package.json`。不要为了方便跳过真实扩展运行边界，也不要把开发诊断构建当作发布构建。
+`Tested` 和 `Not-tested` 必须准确描述实际验证范围。Commit hook 会拒绝缺少必填字段或格式错误的消息。
 
 ## 提交 Pull Request
 
-说明可观察到的行为变化、风险边界，以及实际运行过的命令。不要提交生成的构建目录、个人数据或未经脱敏的诊断产物。
+Pull Request 应以 `master` 为目标，并只解决一个清晰的问题。描述中请写明：
+
+- **Problem**：当前行为哪里不正确或缺少什么
+- **Decision**：采用了什么改动，以及为什么
+- **Check**：运行了哪些验证，哪些场景没有验证
+- **Risk**：权限、数据、兼容性或发布风险
+- **Evidence**：相关测试、截图或录屏
+
+提交前检查：
+
+- [ ] 改动没有混入无关重构或格式化
+- [ ] 新行为和 Bug 修复有合适的行为测试
+- [ ] 已运行 `pnpm typecheck` 和适用的最小测试
+- [ ] 用户可见行为对应的中英文文档已同步
+- [ ] 视觉改动已在真实扩展页面验证
+- [ ] 没有提交生成目录、凭据、私人数据或外部工作项原文
+- [ ] Pull Request 描述准确列出已测试和未测试范围
+
+维护者会根据正确性、隐私边界、跨浏览器行为和后续维护成本审查改动。商店发布、版本号和发布凭据不属于普通 Pull Request 的范围。
+
+## 许可证
+
+提交贡献即表示你同意按照本仓库的 [MIT License](LICENSE) 发布该贡献。

--- a/README.en.md
+++ b/README.en.md
@@ -257,6 +257,7 @@ pnpm test:smoke
 - [How For You recommendations work](docs/en/for-you-recommendation-strategy.md)
 - [Cubby Agent technical reference](docs/en/cubby-agent.md)
 - [Privacy policy](docs/en/privacy-policy.md)
+- [Security policy](SECURITY.md)
 - [Chrome Web Store update notes](docs/en/chrome-web-store-submission.md)
 - [Firefox Add-ons submission reference](docs/en/firefox-amo-submission.md)
 - [Microsoft Edge Add-ons submission reference](docs/en/edge-addons-submission.md)
@@ -264,7 +265,7 @@ pnpm test:smoke
 
 ## Contributing
 
-Report bugs and request features through [GitHub Issues](https://github.com/izumi0uu/better-github-stars-manager/issues). Pull requests are welcome; read the [contribution guide](CONTRIBUTING.en.md) first for the Cubby Agent diagnostics build and debugging workflow.
+Report bugs and request features through [GitHub Issues](https://github.com/izumi0uu/better-github-stars-manager/issues). Pull Requests are welcome; read the [contribution guide](CONTRIBUTING.en.md) for setup, testing, commit, submission requirements, and the Cubby Agent diagnostics workflow.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ pnpm test:smoke
 - [For You 推荐如何工作](docs/zh/for-you-recommendation-strategy.md)
 - [Cubby Agent 技术参考](docs/zh/cubby-agent.md)
 - [隐私政策](docs/zh/privacy-policy.md)
+- [安全政策](SECURITY.md)
 - [Chrome Web Store 更新说明](docs/zh/chrome-web-store-submission.md)
 - [Firefox Add-ons 提交参考](docs/zh/firefox-amo-submission.md)
 - [Microsoft Edge Add-ons 提交参考](docs/zh/edge-addons-submission.md)
@@ -264,7 +265,7 @@ pnpm test:smoke
 
 ## 参与贡献
 
-欢迎在 [GitHub Issues](https://github.com/izumi0uu/better-github-stars-manager/issues) 报告问题或提交功能建议。Pull request 也可以直接提交到本仓库；提交前请阅读 [贡献指南](CONTRIBUTING.md)，其中包含 Cubby Agent 的诊断构建与调试流程。
+欢迎在 [GitHub Issues](https://github.com/izumi0uu/better-github-stars-manager/issues) 报告问题或提交功能建议。Pull Request 也可以直接提交到本仓库；提交前请阅读[贡献指南](CONTRIBUTING.md)，了解开发环境、测试、commit、提交要求，以及 Cubby Agent 的诊断构建与调试流程。
 
 ## 许可证
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,95 @@
+# Security policy
+
+[简体中文](#简体中文) | [English](#english)
+
+This policy explains how to report a vulnerability without exposing users or maintainers to unnecessary risk.
+
+本政策说明如何报告安全漏洞，避免给用户和维护者带来不必要的风险。
+
+## 简体中文
+
+### 支持范围
+
+安全修复以当前 `master` 和每个已支持商店的最新公开版本为目标。旧版本不会单独发布补丁；修复会进入后续商店版本，实际可用时间还取决于各商店审核。
+
+尚未发布的分支行为也可以报告，但请注明对应 commit。
+
+### 私密报告漏洞
+
+不要在公开 Issue、Pull Request、Discussion、截图或日志中披露漏洞细节、真实 Token、API Key、私人仓库数据或个人信息。
+
+请按以下顺序报告：
+
+1. 打开仓库的 [Security 页面](https://github.com/izumi0uu/better-github-stars-manager/security)
+2. 如果页面显示 **Report a vulnerability**，使用该入口创建私密报告
+3. 如果私密报告入口不可用，只创建一条[已脱敏的 Issue](https://github.com/izumi0uu/better-github-stars-manager/issues/new)，请求维护者提供私密联系方式
+4. 在建立私密渠道前，不要在该 Issue 中加入漏洞原理、利用步骤或未发布的修复方案
+
+报告中请提供：
+
+- 受影响的扩展版本或 commit
+- 浏览器和浏览器版本
+- 漏洞影响和攻击前提
+- 使用合成数据编写的最小复现步骤
+- 已脱敏的日志、截图或概念验证
+- 已知缓解方式
+
+### 报告后的处理
+
+维护者确认报告后，可能会请求补充信息、验证影响并准备修复。修复时间取决于漏洞范围、跨浏览器验证和商店审核，不承诺固定响应或发布时间。
+
+在修复版本公开前，请勿公开漏洞细节。维护者会与报告者协调披露时间和署名。
+
+### 不属于安全漏洞的问题
+
+以下内容请使用普通 [GitHub Issues](https://github.com/izumi0uu/better-github-stars-manager/issues)：
+
+- 不涉及安全边界的 Bug
+- 功能建议
+- 安装或配置问题
+- 隐私政策解释请求
+- 已公开且不包含敏感信息的依赖问题
+
+## English
+
+### Supported versions
+
+Security fixes target the current `master` branch and the latest public version in each supported store. Older versions do not receive separate patches. Fixes ship through a later store release, and availability depends on each store's review.
+
+You can also report behavior on an unreleased branch. Include the affected commit.
+
+### Report a vulnerability privately
+
+Do not disclose vulnerability details, real tokens, API keys, private repository data, or personal information in a public Issue, Pull Request, Discussion, screenshot, or log.
+
+Report vulnerabilities in this order:
+
+1. Open the repository's [Security page](https://github.com/izumi0uu/better-github-stars-manager/security)
+2. Select **Report a vulnerability** when GitHub shows that option
+3. If private reporting is unavailable, open only a [redacted Issue](https://github.com/izumi0uu/better-github-stars-manager/issues/new) asking the maintainer for a private contact route
+4. Do not add vulnerability mechanics, exploitation steps, or an unpublished fix before a private route exists
+
+Include these details in the private report:
+
+- Affected extension version or commit
+- Browser and browser version
+- Impact and attack prerequisites
+- Minimal reproduction steps using synthetic data
+- Sanitized logs, screenshots, or proof of concept
+- Known mitigations
+
+### What happens after a report
+
+After acknowledging the report, the maintainer may request details, validate impact, and prepare a fix. Timing depends on scope, cross-browser verification, and store review. This policy does not promise a fixed response or release deadline.
+
+Do not publish vulnerability details before a fixed version is public. The maintainer will coordinate disclosure timing and credit with the reporter.
+
+### Reports that are not security vulnerabilities
+
+Use regular [GitHub Issues](https://github.com/izumi0uu/better-github-stars-manager/issues) for:
+
+- Bugs that do not cross a security boundary
+- Feature requests
+- Installation or configuration problems
+- Privacy policy questions
+- Public dependency reports that contain no sensitive details


### PR DESCRIPTION
## Problem / 问题

The repository had a compact contributor guide focused on Cubby diagnostics, but it did not define the full contribution workflow, structured issue intake, a Pull Request checklist, or a security reporting policy.

仓库已有以 Cubby 诊断为重点的简短贡献说明，但缺少完整贡献流程、结构化 Issue 表单、Pull Request 检查清单和安全报告政策。

## Decision / 方案

- Expand the Chinese and English contribution guides while preserving the existing Cubby diagnostics workflow
- Document setup, architecture boundaries, privacy, tests, commit requirements, and Pull Request expectations
- Add bilingual Bug report and Feature request Issue Forms
- Add a bilingual Pull Request template
- Add a bilingual security policy with a safe fallback when private vulnerability reporting is unavailable
- Link the guides and security policy from both READMEs

## Verification / 验证

Tested / 已验证：

- Both Issue Forms pass the GitHub Issue Form JSON Schema after rebasing onto current `master`
- The configured `bug` and `enhancement` labels exist in the repository
- All local Markdown links resolve and every documented pnpm script exists
- No trailing whitespace, prose anti-patterns, credentials, local paths, or sensitive residue were found
- The documented commit example passes the repository commit-message validator

Not tested / 未验证：

- GitHub-rendered Issue and Pull Request forms, which activate only after merge to the default branch
- Product runtime tests, because this Pull Request changes repository collaboration files and documentation only

## Risk / 风险

GitHub Private Vulnerability Reporting is a repository setting and is not enabled by `SECURITY.md`. The policy directs reporters to the private entry when available and otherwise permits only a redacted request for a private contact route.

No extension code, manifest, permission, storage, dependency, or release artifact changes.

## Visual evidence / 视觉证据

N/A. These templates render through GitHub after merge.

## Checklist / 检查清单

- [x] The diff addresses one focused documentation and collaboration problem
- [x] Relevant schema, label, command, link, and privacy checks pass
- [x] English and Chinese documentation are aligned
- [x] Existing Cubby Agent diagnostics guidance is preserved
- [x] The diff contains no generated output, credentials, private data, or copied external work-item text
- [x] Tested and untested scope is stated accurately