### PR TITLE
fix(options): remove automatic rating reminder toggle

### DIFF
--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -833,14 +833,6 @@ export interface MessageCatalog {
     storeRatingHeading: string;
     storeRatingManualAction: (store: string) => string;
     storeRatingManualHint: (store: string) => string;
-    storeRatingReminderLabel: string;
-    storeRatingReminderTracking: string;
-    storeRatingReminderSnoozed: (date: string) => string;
-    storeRatingReminderDisabled: string;
-    storeRatingReminderExhausted: string;
-    storeRatingReminderStoreOpened: string;
-    storeRatingReminderEnable: string;
-    storeRatingReminderDisable: string;
     agentHeading: string;
     agentIntro: string;
     agentServiceLabel: string;
@@ -2071,14 +2063,6 @@ const messages: Record<Locale, MessageCatalog> = {
       storeRatingManualAction: (store) => `Rate in ${store}`,
       storeRatingManualHint: (store) =>
         `Opens the verified Better GitHub Stars Manager listing in ${store}.`,
-      storeRatingReminderLabel: "Automatic rating reminder",
-      storeRatingReminderTracking: "Enabled",
-      storeRatingReminderSnoozed: (date) => `Paused until ${date}`,
-      storeRatingReminderDisabled: "Disabled",
-      storeRatingReminderExhausted: "Finished after two reminders",
-      storeRatingReminderStoreOpened: "Disabled after opening the store",
-      storeRatingReminderEnable: "Enable reminders",
-      storeRatingReminderDisable: "Disable reminders",
       agentHeading: "2. Cubby",
       agentIntro:
         "Connect an AI service. Cubby sends requests directly to it and shows the results in the extension.",
@@ -3373,14 +3357,6 @@ const messages: Record<Locale, MessageCatalog> = {
       storeRatingManualAction: (store) => `前往 ${store} 评分`,
       storeRatingManualHint: (store) =>
         `打开 Better GitHub Stars Manager 在 ${store} 中已验证的商店页面。`,
-      storeRatingReminderLabel: "自动评分提醒",
-      storeRatingReminderTracking: "已启用",
-      storeRatingReminderSnoozed: (date) => `已暂停至 ${date}`,
-      storeRatingReminderDisabled: "已停用",
-      storeRatingReminderExhausted: "两次提醒已完成",
-      storeRatingReminderStoreOpened: "打开商店后已停用",
-      storeRatingReminderEnable: "启用提醒",
-      storeRatingReminderDisable: "停用提醒",
       tokenHeading: "1. GitHub Classic PAT",
       tokenIntroPrefix: "创建 Stars、Gist、Watch 和 Following 共用的唯一 GitHub token：",
       tokenLinkLabel: "打开已预填的 classic token 表单",

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -50,9 +50,7 @@ import {
 } from "@/preferences";
 import {
   CURRENT_EXTENSION_STORE_LISTING,
-  DEFAULT_STORE_RATING_PROMPT_STATE,
 } from '@/store-rating';
-import type { StoreRatingPromptState } from "@/types";
 import tokenGuideCreateUrl from "../../store-assets/screenshots/token-guide-create-classic-pat.webp?url";
 import tokenGuideScopesUrl from "../../store-assets/screenshots/token-guide-select-scopes.webp?url";
 import tokenGuideGenerateUrl from "../../store-assets/screenshots/token-guide-generate-token.webp?url";
@@ -105,9 +103,6 @@ export function Options() {
   const persistedMaxTagsPerRepoRef = useRef(String(DEFAULT_AUTO_TAG_LIMIT));
   const persistedMinTopicRepoCountRef = useRef(String(DEFAULT_MIN_TOPIC_REPO_COUNT));
   const [starsPanelDefaultEnabled, setStarsPanelDefaultEnabled] = useState(true);
-  const [storeRatingPrompt, setStoreRatingPrompt] = useState<StoreRatingPromptState>(
-    DEFAULT_STORE_RATING_PROMPT_STATE,
-  );
   const [tokenBusy, setTokenBusy] = useState(false);
   const [syncStatus, setSyncStatus] = useState<SyncStatus | null>(null);
   const [msg, setMsg] = useState<OptionsMessage | null>(null);
@@ -137,7 +132,6 @@ export function Options() {
     persistedMaxTagsPerRepoRef.current = String(c.maxTagsPerRepo);
     persistedMinTopicRepoCountRef.current = String(c.minTopicRepoCount);
     setStarsPanelDefaultEnabled(c.starsPanelDefaultEnabled);
-    setStoreRatingPrompt(c.storeRatingPrompt);
     setSyncStatus((current) => mergeStatusSnapshot(current, status));
   };
   useEffect(() => {
@@ -246,22 +240,9 @@ export function Options() {
     await authStore.update({ starsPanelDefaultEnabled: checked });
   };
 
-  const setStoreRatingReminderEnabled = async (enabled: boolean) => {
-    setStoreRatingMessage(null);
-    try {
-      const config = enabled
-        ? await authStore.reenableStoreRatingPrompt()
-        : await authStore.disableStoreRatingPrompt();
-      setStoreRatingPrompt(config.storeRatingPrompt);
-    } catch (error) {
-      setStoreRatingMessage({ kind: "err", text: translateError(error, m) });
-    }
-  };
-
   const markStoreRatingOpened = () => {
     setStoreRatingMessage(null);
     void authStore.recordStoreRatingNavigation()
-      .then((config) => setStoreRatingPrompt(config.storeRatingPrompt))
       .catch((error) => {
         setStoreRatingMessage({ kind: "err", text: translateError(error, m) });
       });
@@ -289,24 +270,6 @@ export function Options() {
     : null;
   const starsUrl =
     hasUsableToken && username ? `https://github.com/${username}?tab=stars` : null;
-  const storeRatingSnoozeActive = storeRatingPrompt.status === 'snoozed'
-    && !!storeRatingPrompt.snoozeUntil
-    && Date.parse(storeRatingPrompt.snoozeUntil) > Date.now();
-  const storeRatingReminderEnabled = storeRatingPrompt.status === 'tracking'
-    || storeRatingPrompt.status === 'snoozed';
-  const storeRatingReminderStatus = storeRatingSnoozeActive
-    ? m.options.storeRatingReminderSnoozed(
-      new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }).format(
-        new Date(storeRatingPrompt.snoozeUntil!),
-      ),
-    )
-    : storeRatingPrompt.status === 'exhausted'
-      ? m.options.storeRatingReminderExhausted
-      : storeRatingPrompt.status === 'store_opened'
-        ? m.options.storeRatingReminderStoreOpened
-        : storeRatingPrompt.status === 'disabled'
-          ? m.options.storeRatingReminderDisabled
-          : m.options.storeRatingReminderTracking;
 
 
   useEffect(() => {
@@ -681,31 +644,6 @@ export function Options() {
                 </Button>
               </div>
 
-              <div className="flex items-start gap-3">
-                <Checkbox
-                  id="store-rating-reminder"
-                  checked={storeRatingReminderEnabled}
-                  onCheckedChange={(checked) => {
-                    void setStoreRatingReminderEnabled(checked === true);
-                  }}
-                  aria-label={storeRatingReminderEnabled
-                    ? m.options.storeRatingReminderDisable
-                    : m.options.storeRatingReminderEnable}
-                  aria-describedby="store-rating-reminder-status"
-                  className="mt-0.5"
-                />
-                <label
-                  htmlFor="store-rating-reminder"
-                  className="grid cursor-pointer gap-1"
-                >
-                  <span className="text-sm font-medium text-foreground">
-                    {m.options.storeRatingReminderLabel}
-                  </span>
-                  <span id="store-rating-reminder-status" className="gsm-body-note">
-                    {storeRatingReminderStatus}
-                  </span>
-                </label>
-              </div>
               {storeRatingMessage && (
                 <StatusNotice
                   message={storeRatingMessage}

--- a/tests/runtime/extension-browser-smoke.mjs
+++ b/tests/runtime/extension-browser-smoke.mjs
@@ -394,7 +394,7 @@ export async function runExtensionBrowserSmoke(options = {}) {
         storeRatingSync.restore();
       }
       await assertStoreRatingOptions(extensionId);
-      ok('prompt stayed suppressed through onboarding, recovery, and active work; keyboard dismissal restored the favorite control and Options could disable/re-enable reminders');
+      ok('prompt stayed suppressed through onboarding, recovery, and active work; keyboard dismissal restored the favorite control and Options showed the store link without a reminder toggle');
     }
 
     step('12) Watch recovery opens focused GitHub authorization without clearing the Classic PAT');
@@ -2969,8 +2969,8 @@ async function assertStoreRatingOptions(extId) {
     await page.waitForSelector('[data-testid="store-rating-settings"]', { timeout: 10_000 });
     await page.waitForFunction(() => {
       const settings = document.querySelector('[data-testid="store-rating-settings"]');
-      return settings?.querySelector('#store-rating-reminder')?.getAttribute('aria-checked') === 'true'
-        && settings.textContent?.includes('Paused until');
+      return settings?.querySelector('a') instanceof HTMLAnchorElement
+        && settings.querySelector('#store-rating-reminder') === null;
     }, { polling: DOM_POLLING_MS, timeout: 10_000 });
     const initial = await page.evaluate(async () => {
       const settings = document.querySelector('[data-testid="store-rating-settings"]');
@@ -2991,26 +2991,23 @@ async function assertStoreRatingOptions(extId) {
       hasRatingValue: false,
     });
 
-    await page.click('#store-rating-reminder');
-    await page.waitForFunction(
-      () => document.querySelector('#store-rating-reminder')?.getAttribute('aria-checked') === 'false',
-      { polling: DOM_POLLING_MS, timeout: 5_000 },
-    );
-    const disabled = await page.evaluate(async () => (
-      (await chrome.storage.local.get('gsm_config')).gsm_config?.storeRatingPrompt?.status
-    ));
-    assert.equal(disabled, 'disabled');
-
-    await page.click('#store-rating-reminder');
-    await page.waitForFunction(
-      () => document.querySelector('#store-rating-reminder')?.getAttribute('aria-checked') === 'true',
-      { polling: DOM_POLLING_MS, timeout: 5_000 },
-    );
-    const reenabled = await page.evaluate(async () => {
+    await page.evaluate(() => {
+      const settings = document.querySelector('[data-testid="store-rating-settings"]');
+      const link = settings?.querySelector('a');
+      if (link instanceof HTMLAnchorElement) {
+        link.addEventListener('click', (event) => event.preventDefault());
+        link.click();
+      }
+    });
+    await page.waitForFunction(async () => {
+      const prompt = (await chrome.storage.local.get('gsm_config')).gsm_config?.storeRatingPrompt;
+      return prompt?.status === 'store_opened';
+    }, { polling: DOM_POLLING_MS, timeout: 5_000 });
+    const opened = await page.evaluate(async () => {
       const prompt = (await chrome.storage.local.get('gsm_config')).gsm_config?.storeRatingPrompt;
       return { status: prompt?.status ?? null, exposureCount: prompt?.exposureCount ?? null };
     });
-    assert.deepEqual(reenabled, { status: 'tracking', exposureCount: 0 });
+    assert.deepEqual(opened, { status: 'store_opened', exposureCount: 1 });
   } finally {
     await page.close();
   }

--- a/tests/unit/options-preferences.test.tsx
+++ b/tests/unit/options-preferences.test.tsx
@@ -387,7 +387,7 @@ describe('Options preferences', () => {
     expect(clearCache?.disabled).toBe(true);
   });
 
-  it('offers the verified store link and explicit reminder disable/re-enable controls', async () => {
+  it('offers the verified store link without an automatic-reminder toggle', async () => {
     const disabled = config({
       storeRatingPrompt: {
         version: 1,
@@ -398,49 +398,23 @@ describe('Options preferences', () => {
         snoozeUntil: null,
       },
     });
-    const tracking = config({
-      storeRatingPrompt: {
-        ...disabled.storeRatingPrompt,
-        status: 'tracking',
-        exposureCount: 0,
-      },
-    });
     const storeOpened = config({
       storeRatingPrompt: {
-        ...tracking.storeRatingPrompt,
+        ...disabled.storeRatingPrompt,
         status: 'store_opened',
       },
     });
     authMocks.getConfig.mockResolvedValue(disabled);
     authMocks.hasToken.mockResolvedValue(true);
-    authMocks.reenableStoreRatingPrompt.mockResolvedValue(tracking);
-    authMocks.disableStoreRatingPrompt.mockResolvedValue(disabled);
     authMocks.recordStoreRatingNavigation.mockResolvedValue(storeOpened);
 
     await renderOptions();
 
     const panel = document.querySelector('[data-testid="store-rating-settings"]');
     const link = panel?.querySelector<HTMLAnchorElement>('a[href="https://example.com/reviews"]');
-    const reminder = panel?.querySelector<HTMLButtonElement>('#store-rating-reminder');
     expect(link?.textContent).toContain('Rate in Chrome Web Store');
     expect(link?.target).toBe('_blank');
-    expect(reminder?.getAttribute('aria-checked')).toBe('false');
-    expect(panel?.textContent).toContain('Disabled');
-
-    await click(reminder!);
-    await act(async () => {
-      await Promise.resolve();
-    });
-    expect(authMocks.reenableStoreRatingPrompt).toHaveBeenCalledTimes(1);
-    expect(reminder?.getAttribute('aria-checked')).toBe('true');
-    expect(panel?.textContent).toContain('Enabled');
-
-    await click(reminder!);
-    await act(async () => {
-      await Promise.resolve();
-    });
-    expect(authMocks.disableStoreRatingPrompt).toHaveBeenCalledTimes(1);
-    expect(reminder?.getAttribute('aria-checked')).toBe('false');
+    expect(panel?.querySelector('#store-rating-reminder')).toBeNull();
 
     link!.addEventListener('click', (event) => event.preventDefault());
     await act(async () => {
@@ -448,7 +422,6 @@ describe('Options preferences', () => {
       await Promise.resolve();
     });
     expect(authMocks.recordStoreRatingNavigation).toHaveBeenCalledTimes(1);
-    expect(panel?.textContent).toContain('Disabled after opening the store');
   });
 
   it('keeps rating persistence errors local without replacing token feedback', async () => {
@@ -462,15 +435,12 @@ describe('Options preferences', () => {
         snoozeUntil: null,
       },
     });
-    const tracking = config({
-      storeRatingPrompt: { ...disabled.storeRatingPrompt, status: 'tracking' },
-    });
     authMocks.getConfig.mockResolvedValue(disabled);
     authMocks.hasToken.mockResolvedValue(true);
     authMocks.setToken.mockRejectedValue(new Error('token persistence failed'));
-    authMocks.reenableStoreRatingPrompt
+    authMocks.recordStoreRatingNavigation
       .mockRejectedValueOnce(new Error('rating persistence failed'))
-      .mockResolvedValueOnce(tracking);
+      .mockResolvedValueOnce(disabled);
 
     await renderOptions();
 
@@ -482,15 +452,22 @@ describe('Options preferences', () => {
     await click(saveToken!);
 
     const panel = document.querySelector('[data-testid="store-rating-settings"]');
-    const reminder = panel?.querySelector<HTMLButtonElement>('#store-rating-reminder');
-    await click(reminder!);
+    const link = panel?.querySelector<HTMLAnchorElement>('a[href="https://example.com/reviews"]');
+    link!.addEventListener('click', (event) => event.preventDefault());
+    await act(async () => {
+      link!.click();
+      await Promise.resolve();
+    });
 
     expect(document.querySelector('[data-testid="main-token-status"]')?.getAttribute('role')).toBe('alert');
     expect(panel?.querySelector('[data-testid="store-rating-status"]')?.getAttribute('role')).toBe('alert');
 
-    await click(reminder!);
+    await act(async () => {
+      link!.click();
+      await Promise.resolve();
+    });
 
-    expect(authMocks.reenableStoreRatingPrompt).toHaveBeenCalledTimes(2);
+    expect(authMocks.recordStoreRatingNavigation).toHaveBeenCalledTimes(2);
     expect(panel?.querySelector('[data-testid="store-rating-status"]')).toBeNull();
     expect(document.querySelector('[data-testid="main-token-status"]')?.getAttribute('role')).toBe('alert');
   });


### PR DESCRIPTION
## Problem / 问题

The Options page exposed a switch that could disable or re-enable automatic store-rating reminders. Reminder opt-out should be available only from the rating prompt itself, not from settings.

Related issue / 关联 Issue: N/A

## Decision / 方案

Remove the automatic-reminder switch, status text, and now-unused English/Chinese Options copy. Keep the permanent verified store-rating link and continue recording `store_opened` when that link is used. The prompt-level **Never remind me** action and persisted reminder policy remain unchanged.

## Verification / 验证

Tested / 已验证：

- `pnpm exec vitest run tests/unit/options-preferences.test.tsx` — 30/30 passed
- `pnpm typecheck` — passed
- `GSM_STORE_TARGET=chrome pnpm build` — passed
- `GSM_STORE_TARGET=chrome pnpm test:smoke` — passed against the real extension surface in Chrome 149; verified the store link, absence of the Options reminder toggle, and `store_opened` persistence

Not tested / 未验证：

- Navigation against the published Chrome Web Store listing or review submission
- Firefox, Edge, or Opera store-target builds

## Risk / 风险

Low. No permission, schema, migration, sync, or credential behavior changes. Existing persisted reminder decisions remain intact; this only removes the Options control that could change them.

## Visual evidence / 视觉证据

The real-browser extension smoke exercised the built Options page and asserted that the verified store link remains while the reminder toggle is absent. No screenshot was added because this is a control-removal change rather than a styling change.

## Checklist / 检查清单

- [x] The diff addresses one focused problem and contains no unrelated refactor or formatting work / 改动只解决一个明确问题，不含无关重构或格式化
- [x] New behavior and bug fixes have suitable behavior tests / 新行为和 Bug 修复有合适的行为测试
- [x] `pnpm typecheck` and the smallest relevant tests pass / `pnpm typecheck` 和适用的最小测试已通过
- [x] English and Chinese documentation match user-visible behavior changes, when applicable / 如有用户可见变化，中英文文档已同步
- [x] UI changes were verified in the real extension surface, when applicable / 如有界面改动，已在真实扩展页面验证
- [x] The diff contains no generated output, credentials, private data, personal information, or copied external work-item text / 改动不含生成文件、凭据、私人数据、个人信息或外部工作项原文
- [x] Tested and untested scope is stated accurately / 已准确说明验证和未验证范围