### PR TITLE
fix(release): refresh Chrome worker identity

### DIFF
--- a/scripts/package-manifest-closure.mjs
+++ b/scripts/package-manifest-closure.mjs
@@ -2,11 +2,11 @@ import { createHash } from 'node:crypto';
 import { lstatSync, realpathSync } from 'node:fs';
 import path from 'node:path';
 
-export const WORKER_BYTE_CEILING = 741_694;
+export const WORKER_BYTE_CEILING = 741_693;
 export const RELEASE_WORKER_BASELINE = Object.freeze({
-  relativePath: 'assets/index.ts-B-zMDfya.js',
+  relativePath: 'assets/index.ts-CYGIhXwD.js',
   bytes: WORKER_BYTE_CEILING,
-  sha256: '51100a0ab0ac3fd95dec93744663f3edfd56afb63489fc5875abdc4afa6997b7',
+  sha256: '902c0726442c96d00674910ae245ade7f1ad153ac4bbe742d3a3e366d7b41ea2',
 });
 
 const SHA256 = /^[0-9a-f]{64}$/u;

--- a/tests/unit/package-manifest-closure.test.mjs
+++ b/tests/unit/package-manifest-closure.test.mjs
@@ -212,7 +212,7 @@ test('measures bundle identities and enforces the frozen release worker exactly'
     ...RELEASE_WORKER_BASELINE,
     kib: RELEASE_WORKER_BASELINE.bytes / 1024,
   };
-  assert.equal(exact.bytes, 741_694);
+  assert.equal(exact.bytes, 741_693);
   assert.equal(WORKER_BYTE_CEILING, exact.bytes);
   assert.equal(enforceWorkerByteCeiling(exact).withinCeiling, true);
   assert.deepEqual(enforceWorkerReleaseBaseline(exact), exact);


### PR DESCRIPTION
## Problem / 问题

After PR #68 changed the production bundle, `GSM_APPROVED_RELEASE_VERSION=2.0.1 pnpm package:chrome` correctly stopped with `worker_identity_mismatch`. The frozen release-worker identity still described the previous build.

Related issue / 关联 Issue: N/A

## Decision / 方案

Refresh the exact Chrome release-worker path, byte count, and SHA-256 to the deterministic output produced twice from the merged v2.0.1 source. Keep strict path/size/hash equality and the byte ceiling unchanged in semantics; no gate is bypassed or loosened.

## Verification / 验证

Tested / 已验证：

- `pnpm exec vitest run tests/unit/package-manifest-closure.test.mjs tests/unit/agent-runtime-release-evidence.test.mjs` — 39/39 passed
- `pnpm exec vitest run tests/unit/package-extension.test.mjs` — 10/10 passed
- `pnpm typecheck` — passed
- Two `GSM_RELEASE=true GSM_DEV=false GSM_PACKAGE_TARGET=chrome pnpm build` runs emitted the same worker identity
- Direct `enforceWorkerReleaseBaseline` exercise passed for `assets/index.ts-CYGIhXwD.js`, 741,693 bytes, SHA-256 `902c0726442c96d00674910ae245ade7f1ad153ac4bbe742d3a3e366d7b41ea2`
- `GSM_APPROVED_RELEASE_VERSION=2.0.1 pnpm package:chrome` — passed on this clean branch

Not tested / 未验证：

- Final package regeneration from the post-merge `master` commit
- Chrome Web Store upload

## Risk / 风险

Narrow release-build change. Runtime product code, manifest permissions, storage, sync, and credentials are unchanged. An incorrect identity would block packaging rather than ship an unchecked worker.

## Visual evidence / 视觉证据

N/A — release tooling only; no UI change.

## Checklist / 检查清单

- [x] The diff addresses one focused problem and contains no unrelated refactor or formatting work / 改动只解决一个明确问题，不含无关重构或格式化
- [x] New behavior and bug fixes have suitable behavior tests / 新行为和 Bug 修复有合适的行为测试
- [x] `pnpm typecheck` and the smallest relevant tests pass / `pnpm typecheck` 和适用的最小测试已通过
- [x] English and Chinese documentation match user-visible behavior changes, when applicable / 如有用户可见变化，中英文文档已同步
- [x] UI changes were verified in the real extension surface, when applicable / 如有界面改动，已在真实扩展页面验证
- [x] The diff contains no generated output, credentials, private data, personal information, or copied external work-item text / 改动不含生成文件、凭据、私人数据、个人信息或外部工作项原文
- [x] Tested and untested scope is stated accurately / 已准确说明验证和未验证范围