### PR TITLE
feat: add Watch history and stabilize Stars sync recovery

### DIFF
--- a/src/api/github-notifications-source.ts
+++ b/src/api/github-notifications-source.ts
@@ -1,5 +1,6 @@
 import {
   GitHubWatchError,
+  isValidWatchHistoryPage,
   dedupeNotificationThreads,
   normalizeNotificationThread,
   type GitHubNotificationThread,
@@ -20,6 +21,7 @@ export interface FetchGitHubNotificationsOptions {
   token: string;
   before?: Date | string | number;
   lastModified?: string | null;
+  startPage?: number;
   fetchImpl?: FetchLike;
   now?: () => Date | string | number;
   maxPages?: number;
@@ -63,7 +65,7 @@ function lastModifiedValidator(value: string | null | undefined): string | null 
   return validator && Number.isFinite(Date.parse(validator)) ? validator : null;
 }
 
-function nextPage(linkHeader: string | null, currentPage: number): number | null {
+function nextPage(linkHeader: string | null, currentPage: number, before: string): number | null {
   if (!linkHeader) return null;
   const parts = linkHeader.split(',');
   const nextParts = parts.filter((part) => /\brel="[^"]*\bnext\b[^"]*"/u.test(part));
@@ -93,7 +95,13 @@ function nextPage(linkHeader: string | null, currentPage: number): number | null
     page !== currentPage + 1 ||
     url.searchParams.getAll('page').length !== 1 ||
     url.searchParams.get('per_page') !== String(PER_PAGE) ||
-    url.searchParams.getAll('per_page').length !== 1
+    url.searchParams.getAll('per_page').length !== 1 ||
+    url.searchParams.get('all') !== 'true' ||
+    url.searchParams.getAll('all').length !== 1 ||
+    url.searchParams.get('participating') !== 'false' ||
+    url.searchParams.getAll('participating').length !== 1 ||
+    url.searchParams.get('before') !== before ||
+    url.searchParams.getAll('before').length !== 1
   ) {
     throw new GitHubWatchError('invalid_pagination', undefined, { page: currentPage });
   }
@@ -176,7 +184,7 @@ async function requestPage(input: {
         page: input.page,
       });
     }
-    const pageAfter = nextPage(response.headers.get('link'), input.page);
+    const pageAfter = nextPage(response.headers.get('link'), input.page, input.before);
     if (threads.length === 0 && pageAfter !== null) {
       throw new GitHubWatchError('invalid_pagination', undefined, { page: input.page });
     }
@@ -210,11 +218,17 @@ export async function fetchGitHubNotifications(
     ? Math.max(1, Math.floor(options.timeoutMs!))
     : DEFAULT_TIMEOUT_MS;
   const fetchImpl = options.fetchImpl ?? fetch;
-  const conditionalLastModified = lastModifiedValidator(options.lastModified);
+  const startPage = options.startPage === undefined ? 1 : options.startPage;
+  if (!isValidWatchHistoryPage(startPage)) {
+    throw new GitHubWatchError('invalid_pagination');
+  }
+  const conditionalLastModified = startPage === 1
+    ? lastModifiedValidator(options.lastModified)
+    : null;
   const allThreads: GitHubNotificationThread[] = [];
-  let page = 1;
+  let page = startPage;
   let pageCount = 0;
-  let truncated = false;
+  let nextPageNumber: number | null = null;
   let lastModified: string | null = null;
   let pollSeconds = WATCH_DEFAULT_POLL_INTERVAL_SECONDS;
   for (;;) {
@@ -240,6 +254,7 @@ export async function fetchGitHubNotifications(
           matchedCount: 0,
           pageCount,
           truncated: false,
+          nextPage: null,
           notModified: true,
           before,
           fetchedAt,
@@ -249,12 +264,9 @@ export async function fetchGitHubNotifications(
       }
     }
     allThreads.push(...result.threads);
-    if (result.nextPage === null) break;
-    if (pageCount >= maxPages) {
-      truncated = true;
-      break;
-    }
-    page = result.nextPage;
+    nextPageNumber = result.nextPage;
+    if (nextPageNumber === null || pageCount >= maxPages) break;
+    page = nextPageNumber;
   }
   const threads = dedupeNotificationThreads(allThreads);
   return {
@@ -262,7 +274,8 @@ export async function fetchGitHubNotifications(
     candidateCount: threads.length,
     matchedCount: threads.length,
     pageCount,
-    truncated,
+    truncated: nextPageNumber !== null,
+    nextPage: nextPageNumber,
     notModified: false,
     before,
     fetchedAt,

--- a/src/background/backfill-executor.ts
+++ b/src/background/backfill-executor.ts
@@ -72,7 +72,7 @@ export function createBackfillExecutor<TFullSyncResult extends object>({
         }));
         throw error;
       }
-    });
+    }, { kind: 'stars-sync' });
 
     queuedById.set(task.id, promise);
     promise.finally(() => {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -112,6 +112,7 @@ import type {
 } from "@/types";
 import {
   normalizeOnboardingStage,
+  resolveOnboardingStageAfterSync,
   stageMarksOnboardingSeen,
 } from "@/onboarding/state";
 import { createAgentProviderGate } from "./agent-provider-gate";
@@ -1485,6 +1486,8 @@ async function getStatusPayload() {
       seenOnboarding: stageMarksOnboardingSeen(onboardingStage),
     });
   }
+  const starsSyncInFlight = jobQueue.isRunning("stars-sync");
+  const progressInFlight = starsSyncInFlight || jobQueue.isRunning("progress");
   return {
     progress:
       lastProgress.phase === "idle" && !lastProgress.message
@@ -1497,6 +1500,8 @@ async function getStatusPayload() {
     backfills,
     activeBackfillId: selectActiveBackfillId(backfills),
     inFlight: jobQueue.isRunning(),
+    progressInFlight,
+    starsSyncInFlight,
     organizeJobActive: !!activeOrganizeJob,
   };
 }
@@ -1512,12 +1517,13 @@ async function performFullSyncJob() {
   const result = await githubStarSource.syncFull((p) => setProgress(p));
   await reconcileWatchScopeAfterStarsChange();
   broadcastDataAndRecommendationsChanged();
+  await finalizeTrackedOnboardingSync();
   setIdleMessage(m.background.fullDone(result.added));
   return result;
 }
 
 async function performFullSync() {
-  return run(performFullSyncJob);
+  return run(performFullSyncJob, { kind: "stars-sync" });
 }
 
 const backfillExecutor = createBackfillExecutor({
@@ -1581,6 +1587,29 @@ async function setStoredOnboardingStage(stage: OnboardingStage): Promise<void> {
   });
 }
 
+async function finalizeTrackedOnboardingSync(): Promise<void> {
+  const config = await authStore.getConfig();
+  if (config.onboardingStage !== "syncing") return;
+  const [hasToken, grandTotal] = await Promise.all([
+    authStore.hasToken(),
+    db.stars.count(),
+  ]);
+  await setStoredOnboardingStage(resolveOnboardingStageAfterSync(hasToken, grandTotal));
+}
+
+async function failTrackedOnboardingSync(): Promise<void> {
+  try {
+    const config = await authStore.getConfig();
+    if (config.onboardingStage !== "syncing") return;
+    await setStoredOnboardingStage("sync_failed");
+  } catch (error) {
+    console.error(
+      "[GSM] failed to persist onboarding sync failure:",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
 function recordProviderProbeStarted(requestId: string, startedAt: number): Promise<void> {
   return Promise.resolve(providerDiagnosticsRuntime?.recordProbeStarted(requestId, startedAt))
     .then(() => undefined)
@@ -1624,8 +1653,10 @@ async function handle(req: Req): Promise<Res> {
     switch (req.type) {
       case "syncIncremental": {
         const m = await getLocaleMessages();
-        if (!(await authStore.hasToken()))
+        if (!(await authStore.hasToken())) {
+          await failTrackedOnboardingSync();
           return { ok: false, error: m.background.noToken };
+        }
         const result = await run(async () => {
           setProgress({
             phase: "incremental",
@@ -1635,16 +1666,19 @@ async function handle(req: Req): Promise<Res> {
           });
           const syncResult = await githubStarSource.syncIncremental();
           await reconcileWatchScopeAfterStarsChange();
+          broadcastDataAndRecommendationsChanged();
+          await finalizeTrackedOnboardingSync();
+          setIdleMessage(m.background.incrementalDone(syncResult.added));
           return syncResult;
-        });
-        broadcastDataAndRecommendationsChanged();
-        setIdleMessage(m.background.incrementalDone(result.added));
+        }, { kind: "stars-sync" });
         return { ok: true, data: { ...result, tagged: 0 } };
       }
       case "syncFull": {
         const m = await getLocaleMessages();
-        if (!(await authStore.hasToken()))
+        if (!(await authStore.hasToken())) {
+          await failTrackedOnboardingSync();
           return { ok: false, error: m.background.noToken };
+        }
         const result = await performFullSync();
         return { ok: true, data: { ...result, tagged: 0 } };
       }
@@ -1661,12 +1695,12 @@ async function handle(req: Req): Promise<Res> {
           });
           const syncResult = await githubStarSource.syncRescan((p) => setProgress(p));
           await reconcileWatchScopeAfterStarsChange();
+          broadcastDataAndRecommendationsChanged();
+          setIdleMessage(
+            m.background.rescanDone(syncResult.tombstoned, syncResult.revived),
+          );
           return syncResult;
-        });
-        broadcastDataAndRecommendationsChanged();
-        setIdleMessage(
-          m.background.rescanDone(result.tombstoned, result.revived),
-        );
+        }, { kind: "stars-sync" });
         return { ok: true, data: result };
       }
       case "autoAssignTags": {
@@ -1678,14 +1712,15 @@ async function handle(req: Req): Promise<Res> {
             total: null,
             message: m.background.autoAssignTagging,
           });
-          return autoTagAll(
+          const result = await autoTagAll(
             m.background.autoAssignTagging,
             (p) => setProgress(p),
             "incremental",
           );
-        });
-        broadcastDataChanged();
-        setIdleMessage(m.background.autoAssignDone(t.tagged));
+          broadcastDataChanged();
+          setIdleMessage(m.background.autoAssignDone(result.tagged));
+          return result;
+        }, { kind: "progress" });
         return { ok: true, data: t };
       }
       case "gistPush": {
@@ -1711,7 +1746,7 @@ async function handle(req: Req): Promise<Res> {
             setIdleMessage(m.background.gistPushRecreated);
           else setIdleMessage(m.background.gistPushNoChanges);
           return result;
-        });
+        }, { kind: "progress" });
         return { ok: true, data: r };
       }
       case "gistPull": {
@@ -1723,7 +1758,7 @@ async function handle(req: Req): Promise<Res> {
             total: null,
             message: m.background.pullingTags,
           });
-          return idbTagStore.syncPull((done, total) => {
+          const result = await idbTagStore.syncPull((done, total) => {
             setProgress({
               phase: "gist",
               done,
@@ -1731,10 +1766,11 @@ async function handle(req: Req): Promise<Res> {
               message: m.background.pullingTags,
             });
           });
-        });
-        broadcastDataChanged();
-        if (r.missing) setIdleMessage(m.background.gistPullMissing);
-        else setIdleMessage(m.background.gistPullDone(r.merged, r.total));
+          broadcastDataChanged();
+          if (result.missing) setIdleMessage(m.background.gistPullMissing);
+          else setIdleMessage(m.background.gistPullDone(result.merged, result.total));
+          return result;
+        }, { kind: "progress" });
         return { ok: true, data: r };
       }
       case "getStatus":
@@ -2234,6 +2270,9 @@ async function handle(req: Req): Promise<Res> {
     }
     return { ok: false, error: 'Unsupported background request.' };
   } catch (e) {
+    if (req.type === "syncIncremental" || req.type === "syncFull") {
+      await failTrackedOnboardingSync();
+    }
     const msg = translateError(e, await getLocaleMessages());
     const agentSessionFailure = bgsmAgentRuntime.sessionRpc.describeFailure(e);
     if (!agentSessionRequest) {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -265,6 +265,8 @@ type Req = BgsmAgentSessionRequest
   | { type: "getWatchSubjectDetail"; threadId?: unknown }
   | { type: "getWatchRepositoryDetail"; fullName?: unknown }
   | { type: "refreshWatchInbox" }
+  | { type: "loadOlderWatchInbox" }
+  | { type: "markWatchInboxLoaded" }
   | { type: "markWatchThreadsRead"; accountLogin?: unknown; threadIds?: unknown }
   | { type: "markWatchThreadsDone"; accountLogin?: unknown; threadIds?: unknown }
   | { type: "disconnectWatchInbox" }
@@ -349,8 +351,11 @@ const watchRefreshCoordinator = createWatchRefreshCoordinator({
     replaceScope: watchStore.replaceWatchScope,
     recordScopeFailure: watchStore.recordWatchScopeFailure,
     replaceInbox: watchStore.replaceWatchInbox,
+    appendHistory: watchStore.appendWatchInboxHistory,
+    markLoaded: watchStore.markWatchInboxLoaded,
     revalidateInbox: watchStore.revalidateWatchInbox,
     recordInboxFailure: watchStore.recordWatchInboxFailure,
+    recordHistoryFailure: watchStore.recordWatchHistoryFailure,
     applyThreadMutation: watchStore.applyWatchThreadMutation,
     disconnectInbox: watchStore.disconnectWatchInbox,
     clearData: watchStore.clearWatchData,
@@ -1801,6 +1806,23 @@ async function handle(req: Req): Promise<Res> {
           return { ok: false, error: m.background.watchRefreshFailed };
         }
       }
+      case 'loadOlderWatchInbox': {
+        const m = await getLocaleMessages();
+        try {
+          return { ok: true, data: await watchRefreshCoordinator.loadOlder() };
+        } catch {
+          return { ok: false, error: m.background.watchRefreshFailed };
+        }
+      }
+      case 'markWatchInboxLoaded': {
+        const m = await getLocaleMessages();
+        try {
+          return { ok: true, data: await watchRefreshCoordinator.markLoaded() };
+        } catch {
+          return { ok: false, error: m.background.watchInboxUnavailable };
+        }
+      }
+
       case 'markWatchThreadsRead':
       case 'markWatchThreadsDone': {
         const m = await getLocaleMessages();

--- a/src/background/serialized-runner.ts
+++ b/src/background/serialized-runner.ts
@@ -1,19 +1,26 @@
+export type SerializedJobKind = 'stars-sync' | 'progress';
+
 export type SerializedRunOptions = {
   signal?: AbortSignal;
+  kind?: SerializedJobKind;
 };
 
 export interface SerializedRunner {
   run<T>(fn: () => Promise<T>, options?: SerializedRunOptions): Promise<T>;
-  isRunning(): boolean;
+  isRunning(kind?: SerializedJobKind): boolean;
 }
 
 export function createSerializedRunner(): SerializedRunner {
   let inFlight: Promise<unknown> | null = null;
+  const pendingByKind = new Map<SerializedJobKind, number>();
 
   const run = async <T>(
     fn: () => Promise<T>,
     options: SerializedRunOptions = {},
   ): Promise<T> => {
+    if (options.kind) {
+      pendingByKind.set(options.kind, (pendingByKind.get(options.kind) ?? 0) + 1);
+    }
     const previous = inFlight;
     const p = (previous ? previous.catch(() => {}) : Promise.resolve()).then(() => {
       if (options.signal?.aborted) {
@@ -26,11 +33,16 @@ export function createSerializedRunner(): SerializedRunner {
       return await p;
     } finally {
       if (inFlight === p) inFlight = null;
+      if (options.kind) {
+        const remaining = (pendingByKind.get(options.kind) ?? 1) - 1;
+        if (remaining === 0) pendingByKind.delete(options.kind);
+        else pendingByKind.set(options.kind, remaining);
+      }
     }
   };
 
   return {
     run,
-    isRunning: () => inFlight != null,
+    isRunning: (kind) => kind ? (pendingByKind.get(kind) ?? 0) > 0 : inFlight != null,
   };
 }

--- a/src/background/watch-refresh.ts
+++ b/src/background/watch-refresh.ts
@@ -8,16 +8,19 @@ import {
 import type { fetchGitHubWatchScope } from '@/api/github-watch-scope-source';
 import type { fetchGitHubWatchSubjectDetail } from '@/api/github-watch-subject-source';
 import type {
+  appendWatchInboxHistory,
   clearWatchData,
   applyWatchThreadMutation,
   disconnectWatchInbox,
   getWatchNotificationThread,
   getWatchRepositories,
   getWatchState,
+  markWatchInboxLoaded,
   queryStoredWatchInbox,
   reconcileWatchAccount,
   reconcileWatchLiveStars,
   recordWatchInboxFailure,
+  recordWatchHistoryFailure,
   recordWatchScopeFailure,
   replaceWatchInbox,
   replaceWatchScope,
@@ -26,6 +29,7 @@ import type {
 import {
   GitHubWatchError,
   canonicalRepositoryFullName,
+  isValidWatchHistoryPage,
   projectWatchInbox,
   watchSubjectIdentity,
   type WatchSubjectDetail,
@@ -35,6 +39,7 @@ import {
   parseWatchAccountLogin,
   parseWatchThreadIds,
   type WatchInboxQueryResponse,
+  type WatchLoadOlderResult,
   type WatchRefreshResult,
   type WatchStatus,
   type WatchThreadAction,
@@ -65,8 +70,11 @@ export interface WatchRefreshCoordinatorDependencies {
     replaceScope: typeof replaceWatchScope;
     recordScopeFailure: typeof recordWatchScopeFailure;
     replaceInbox: typeof replaceWatchInbox;
+    appendHistory: typeof appendWatchInboxHistory;
+    markLoaded: typeof markWatchInboxLoaded;
     revalidateInbox: typeof revalidateWatchInbox;
     recordInboxFailure: typeof recordWatchInboxFailure;
+    recordHistoryFailure: typeof recordWatchHistoryFailure;
     applyThreadMutation: typeof applyWatchThreadMutation;
     disconnectInbox: typeof disconnectWatchInbox;
     clearData: typeof clearWatchData;
@@ -80,6 +88,8 @@ export interface WatchRefreshCoordinator {
   queryInbox(unreadOnly: boolean): Promise<WatchInboxQueryResponse>;
   refresh(): Promise<WatchRefreshResult>;
   getSubjectDetail(threadId: string): Promise<WatchSubjectDetail>;
+  loadOlder(): Promise<WatchLoadOlderResult>;
+  markLoaded(): Promise<string | null>;
   refreshInbox(): Promise<WatchRefreshResult>;
   markThreadsRead(input: WatchThreadMutationInput): Promise<WatchThreadMutationResult>;
   markThreadsDone(input: WatchThreadMutationInput): Promise<WatchThreadMutationResult>;
@@ -110,6 +120,7 @@ function nextAllowedAt(attemptedAtMs: number, pollIntervalSeconds: number): stri
 
 const THREAD_MUTATION_CONCURRENCY = 4;
 const SUBJECT_DETAIL_CACHE_LIMIT = 100;
+const HISTORY_PAGE_BATCH = 2;
 
 function sameSubjectIdentity(
   left: WatchSubjectIdentity,
@@ -128,6 +139,7 @@ export function createWatchRefreshCoordinator(
   const now = dependencies.now ?? Date.now;
   let inFlight: { identity: string; promise: Promise<WatchRefreshResult> } | null = null;
   let inboxInFlight: { identity: string; promise: Promise<WatchRefreshResult> } | null = null;
+  let historyInFlight: { identity: string; promise: Promise<WatchLoadOlderResult> } | null = null;
   const subjectDetails = new Map<string, WatchSubjectDetail>();
   const subjectDetailInFlight = new Map<string, Promise<WatchSubjectDetail>>();
   let subjectAuthority = '';
@@ -387,6 +399,12 @@ export function createWatchRefreshCoordinator(
           credentialsChanged: false,
         };
       }
+      const previousSuccessfulAt = Date.parse(state?.inbox.lastSuccessfulAt ?? '');
+      const headOverlapsPreviousRefresh = Number.isFinite(previousSuccessfulAt)
+        && snapshot.threads.some((thread) => Date.parse(thread.updatedAt) <= previousSuccessfulAt);
+      const resetHistory = snapshot.nextPage !== null
+        && Number.isFinite(previousSuccessfulAt)
+        && !headOverlapsPreviousRefresh;
       await dependencies.store.replaceInbox({
         accountLogin: auth.accountLogin!,
         threads: snapshot.threads,
@@ -396,7 +414,10 @@ export function createWatchRefreshCoordinator(
         nextAllowedAt: allowedAt,
         candidateCount: snapshot.candidateCount,
         truncated: snapshot.truncated,
-        mode: state?.inbox.lastModified ? 'merge' : 'replace',
+        historyBefore: snapshot.before,
+        historyNextPage: snapshot.nextPage,
+        resetHistory,
+        mode: state?.inbox.lastSuccessfulAt ? 'merge' : 'replace',
         requireLiveStars: true,
       });
       return {
@@ -425,6 +446,69 @@ export function createWatchRefreshCoordinator(
         changed: true,
         credentialsChanged: false,
       };
+    }
+  }
+
+  async function performLoadOlder(auth: AuthSnapshot): Promise<{
+    addedCount: number;
+    hasMore: boolean;
+  }> {
+    if (
+      !auth.accountLogin
+      || !auth.mainToken
+      || !auth.notificationsToken
+      || !await sameCredentials(auth, true)
+    ) throw new GitHubWatchError('authentication_required');
+
+    const state = await dependencies.store.getState(auth.accountLogin);
+    const historyBefore = state?.inbox.historyBefore ?? null;
+    const historyPage = state?.inbox.historyNextPage ?? null;
+    if (!historyBefore || historyPage === null || state?.inbox.historyExhausted) {
+      return { addedCount: 0, hasMore: false };
+    }
+
+    try {
+      if (!isValidWatchHistoryPage(historyPage)) {
+        throw new GitHubWatchError('invalid_pagination');
+      }
+      const snapshot = await dependencies.fetchNotifications({
+        token: auth.notificationsToken,
+        before: historyBefore,
+        startPage: historyPage,
+        maxPages: HISTORY_PAGE_BATCH,
+        now: () => now(),
+      });
+      if (!await sameCredentials(auth, true)) {
+        throw new GitHubWatchError('credential_changed');
+      }
+      if (snapshot.notModified || snapshot.before !== historyBefore) {
+        throw new GitHubWatchError('invalid_pagination', undefined, { page: historyPage });
+      }
+      const committed = await dependencies.store.appendHistory({
+        accountLogin: auth.accountLogin,
+        historyBefore,
+        historyPage,
+        threads: snapshot.threads,
+        candidateCount: snapshot.candidateCount,
+        nextPage: snapshot.nextPage,
+        requireLiveStars: true,
+      });
+      if (committed.applied) dependencies.broadcastChanged();
+      return {
+        addedCount: committed.addedCount,
+        hasMore: committed.state?.inbox.historyExhausted === false,
+      };
+    } catch (error) {
+      if (await sameCredentials(auth, true)) {
+        const recorded = await dependencies.store.recordHistoryFailure({
+          accountLogin: auth.accountLogin,
+          historyBefore,
+          historyPage,
+          errorCode: stableErrorCode(error),
+        });
+        if (recorded) dependencies.broadcastChanged();
+      }
+      throw error;
     }
   }
 
@@ -569,6 +653,34 @@ export function createWatchRefreshCoordinator(
     return promise;
   }
 
+  async function loadOlder(): Promise<WatchLoadOlderResult> {
+    await reconcileAccount();
+    const requestedAuth = await readAuth();
+    const identity = refreshIdentity(requestedAuth);
+    const current = historyInFlight;
+    if (current) {
+      if (current.identity === identity) return current.promise;
+      try {
+        await current.promise;
+      } catch {
+        // A changed credential identity gets its own queued history attempt.
+      }
+      if (historyInFlight === current) historyInFlight = null;
+      return loadOlder();
+    }
+
+    const operation = dependencies.runSerialized(() => performLoadOlder(requestedAuth));
+    const promise = operation.then(async (outcome) => ({
+      ...outcome,
+      status: await deriveStatus(false),
+    }));
+    historyInFlight = { identity, promise };
+    void promise.finally(() => {
+      if (historyInFlight?.promise === promise) historyInFlight = null;
+    }).catch(() => {});
+    return promise;
+  }
+
   async function performThreadMutation(
     auth: AuthSnapshot,
     action: WatchThreadAction,
@@ -650,6 +762,19 @@ export function createWatchRefreshCoordinator(
     return dependencies.runSerialized(() => performThreadMutation(auth, action, input));
   }
 
+  async function markLoaded(): Promise<string | null> {
+    await reconcileAccount();
+    const auth = await readAuth();
+    if (!auth.accountLogin || !auth.mainToken) return null;
+    const accountLogin = auth.accountLogin;
+    const loadedAt = new Date(now()).toISOString();
+    return dependencies.runSerialized(async () => {
+      if (!await sameCredentials(auth, false)) return null;
+      const state = await dependencies.store.markLoaded({ accountLogin, loadedAt });
+      return state?.inbox.newerThan ?? null;
+    });
+  }
+
   async function disconnectInboxCommand(): Promise<WatchStatus> {
     await reconcileAccount();
     await dependencies.runSerialized(async () => {
@@ -711,6 +836,8 @@ export function createWatchRefreshCoordinator(
     getSubjectDetail,
     refresh,
     refreshInbox,
+    loadOlder,
+    markLoaded,
     markThreadsRead: (input) => mutateThreads('read', input),
     markThreadsDone: (input) => mutateThreads('done', input),
     disconnectInbox: disconnectInboxCommand,

--- a/src/demo/fixtures/index.ts
+++ b/src/demo/fixtures/index.ts
@@ -202,7 +202,7 @@ const WATCH_THREADS: GitHubNotificationThread[] = WATCH_TITLES.map((title, index
     subjectApiUrl: null,
     subjectHtmlUrl: '#',
     unread: index % 4 !== 3,
-    updatedAt: beforeNow(1, index),
+    updatedAt: beforeNow(index < 5 ? 0 : index < 10 ? 1 : 3, index % 5),
     lastReadAt: index % 4 === 3 ? beforeNow(2, index) : null,
     fetchedAt: beforeNow(1),
   };
@@ -249,14 +249,19 @@ const WATCH_STATE: GitHubWatchStateRecord = {
     repositoryCount: WATCH_REPOSITORIES.length,
   },
   inbox: {
-    lastAttemptAt: beforeNow(1),
-    lastSuccessfulAt: beforeNow(1),
+    lastAttemptAt: beforeNow(0),
+    lastSuccessfulAt: beforeNow(0),
     errorCode: null,
     lastModified: null,
     nextAllowedAt: null,
     candidateCount: WATCH_THREADS.length,
     matchedCount: WATCH_THREADS.length,
     truncated: false,
+    newerThan: beforeNow(1),
+    historyBefore: beforeNow(0),
+    historyNextPage: null,
+    historyExhausted: true,
+    historyErrorCode: null,
   },
 };
 

--- a/src/demo/runtime/index.ts
+++ b/src/demo/runtime/index.ts
@@ -14,6 +14,7 @@ import { projectStarsQuery, type StarsQueryParams, type StarsQueryResult } from 
 import { projectWatchInbox, normalizeRepositoryFullName, type WatchSubjectDetail } from '@/watch/watch-model';
 import type {
   WatchInboxQueryResponse,
+  WatchLoadOlderResult,
   WatchRefreshResult,
   WatchStatus,
   WatchThreadMutationInput,
@@ -382,6 +383,20 @@ class DemoManagerRuntime implements ManagerRuntime {
       inboxPublished: true,
       notModified: true,
     });
+  }
+
+  async loadOlderWatch(): Promise<WatchLoadOlderResult> {
+    return cloneMutable({
+      status: this.watchStatus(),
+      addedCount: 0,
+      hasMore: false,
+    });
+  }
+
+  async markWatchLoaded(): Promise<string | null> {
+    const loadedAt = timestamp(this.state.now);
+    this.state.watchState.inbox.newerThan = loadedAt;
+    return loadedAt;
   }
 
   async markWatchThreadsRead(input: WatchThreadMutationInput): Promise<WatchThreadMutationResult> {

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -109,6 +109,14 @@ export interface MessageCatalog {
     listEndMatches: (count: number) => string;
     listEndWindow: string;
     listEndSaved: (count: number) => string;
+    timelineToday: string;
+    timelineYesterday: string;
+    newBadge: string;
+    newSinceLastVisit: string;
+    loadOlder: string;
+    loadingOlder: string;
+    loadOlderFailed: string;
+    historyComplete: (count: number) => string;
     staleSnapshot: string;
     credentialStaleSnapshot: string;
     scopeFailed: string;
@@ -1215,6 +1223,14 @@ const messages: Record<Locale, MessageCatalog> = {
       listEndMatches: (count) => `End of matching results · ${count} ${count === 1 ? "thread" : "threads"}`,
       listEndWindow: "End of current window · older threads may exist",
       listEndSaved: (count) => `End of saved snapshot · ${count} ${count === 1 ? "thread" : "threads"}`,
+      timelineToday: "Today",
+      timelineYesterday: "Yesterday",
+      newBadge: "New",
+      newSinceLastVisit: "Updated since your last Watch visit",
+      loadOlder: "Load older notifications",
+      loadingOlder: "Loading older notifications…",
+      loadOlderFailed: "Couldn’t load older notifications. Your saved timeline is unchanged.",
+      historyComplete: (count) => `All caught up · ${count} ${count === 1 ? "thread" : "threads"}`,
       staleSnapshot: "Showing the last successful snapshot because the latest refresh failed.",
       scopeFailed: "Watched-repository membership could not be refreshed; Inbox coverage is unaffected.",
       inboxFailed: "Inbox threads could not be refreshed.",
@@ -2516,6 +2532,14 @@ const messages: Record<Locale, MessageCatalog> = {
       listEndMatches: (count) => `匹配结果末尾 · 共 ${count} 个 thread`,
       listEndWindow: "当前窗口末尾 · 可能还有更早的 thread",
       listEndSaved: (count) => `已保存快照末尾 · 共 ${count} 个 thread`,
+      timelineToday: "今天",
+      timelineYesterday: "昨天",
+      newBadge: "新",
+      newSinceLastVisit: "自上次查看 Watch 后有更新",
+      loadOlder: "加载更早的通知",
+      loadingOlder: "正在加载更早的通知…",
+      loadOlderFailed: "无法加载更早的通知，已保存的时间线未受影响。",
+      historyComplete: (count) => `已看完 · 共 ${count} 个 thread`,
       staleSnapshot: "最近一次刷新失败，当前仍显示上一次成功快照。",
       scopeFailed: "无法刷新已 Watch 仓库成员关系；不影响 Inbox 覆盖范围。",
       inboxFailed: "无法刷新 Inbox threads。",

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -249,7 +249,7 @@ export function Options() {
   };
 
   const syncing = !!(
-    syncStatus?.inFlight && syncStatus.progress && syncStatus.progress.phase !== "idle"
+    syncStatus?.progressInFlight && syncStatus.progress && syncStatus.progress.phase !== "idle"
   );
   const progressValue = syncStatus?.progress.total
     ? Math.max(

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -89,7 +89,7 @@ export function Popup() {
 
   const p = status?.progress;
   const hasToken = status?.hasToken;
-  const syncing = !!(status?.inFlight && p && p.phase !== 'idle');
+  const syncing = !!(status?.progressInFlight && p && p.phase !== 'idle');
   const actionBusy = syncing || pendingAction !== null;
   const progressValue = p?.total ? Math.max(1, Math.min(100, Math.round((p.done / p.total) * 100))) : null;
   const progressCount = p?.total ? `${p.done}/${p.total}` : null;

--- a/src/runtime/extension-manager-runtime.ts
+++ b/src/runtime/extension-manager-runtime.ts
@@ -24,6 +24,7 @@ import type { StarsQueryParams, StarsQueryResult } from '@/stars/stars-query';
 import type { Config, Star } from '@/types';
 import type {
   WatchInboxQueryResponse,
+  WatchLoadOlderResult,
   WatchRefreshResult,
   WatchThreadMutationInput,
   WatchThreadMutationResult,
@@ -198,6 +199,14 @@ export class ExtensionManagerRuntime implements ManagerRuntime {
 
   refreshWatch(): Promise<WatchRefreshResult> {
     return bgCall<WatchRefreshResult>('refreshWatchInbox');
+  }
+
+  loadOlderWatch(): Promise<WatchLoadOlderResult> {
+    return bgCall<WatchLoadOlderResult>('loadOlderWatchInbox');
+  }
+
+  markWatchLoaded(): Promise<string | null> {
+    return bgCall<string | null>('markWatchInboxLoaded');
   }
 
   markWatchThreadsRead(input: WatchThreadMutationInput): Promise<WatchThreadMutationResult> {

--- a/src/runtime/manager-runtime.ts
+++ b/src/runtime/manager-runtime.ts
@@ -2,6 +2,7 @@ import type { Config, Star, Tag } from '@/types';
 import type { StarsQueryParams, StarsQueryResult } from '@/stars/stars-query';
 import type {
   WatchInboxQueryResponse,
+  WatchLoadOlderResult,
   WatchRefreshResult,
   WatchThreadMutationInput,
   WatchThreadMutationResult,
@@ -103,6 +104,8 @@ export interface ManagerRuntime {
   getWatchRepositoryDetail(fullName: string): Promise<WatchRepositoryDetail>;
   getWatchSubjectDetail(threadId: string): Promise<WatchSubjectDetail>;
   refreshWatch(): Promise<WatchRefreshResult>;
+  loadOlderWatch(): Promise<WatchLoadOlderResult>;
+  markWatchLoaded(): Promise<string | null>;
   markWatchThreadsRead(input: WatchThreadMutationInput): Promise<WatchThreadMutationResult>;
   markWatchThreadsDone(input: WatchThreadMutationInput): Promise<WatchThreadMutationResult>;
   updateWatchCollapse(repositoryFullName: string, contentSignature: string | null): Promise<void>;

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -123,9 +123,9 @@ export class StarsDB extends Dexie {
       watchState: 'id',
     });
     // v5 adds account-bound Radar activity, the optional
-    // `Star.viewer_has_starred` source marker and owner avatar URL, and the
-    // derived For You cache. Neither Star field nor recommendation score is
-    // queried by an index; legacy Star rows remain valid when either is absent.
+    // `Star.viewer_has_starred` source marker and owner avatar URL, the
+    // derived For You cache, and Watch head/history pagination checkpoints.
+    // Non-indexed legacy fields remain valid when absent.
     this.version(5).stores({
       stars: 'full_name, language, starred_at, pushed_at, created_at, tombstone',
       tags: 'full_name, mtime',

--- a/src/storage/watch-store.ts
+++ b/src/storage/watch-store.ts
@@ -1,6 +1,8 @@
 import { db } from '@/storage/db';
 import {
   canonicalRepositoryFullName,
+  dedupeNotificationThreads,
+  isValidWatchHistoryPage,
   projectWatchInbox,
   type GitHubNotificationThread,
   type GitHubWatchRepository,
@@ -134,6 +136,11 @@ function emptyInbox(): WatchInboxRefreshSnapshot {
     candidateCount: 0,
     matchedCount: 0,
     truncated: false,
+    newerThan: null,
+    historyBefore: null,
+    historyNextPage: null,
+    historyExhausted: true,
+    historyErrorCode: null,
   };
 }
 
@@ -146,10 +153,30 @@ function emptyState(accountLogin: string): GitHubWatchStateRecord {
   };
 }
 
+function normalizeWatchState(state: GitHubWatchStateRecord): GitHubWatchStateRecord {
+  const inbox = state.inbox as Partial<WatchInboxRefreshSnapshot>;
+  const historyBefore = inbox.historyBefore ?? null;
+  const historyNextPage = inbox.historyNextPage ?? null;
+  return {
+    ...state,
+    inbox: {
+      ...emptyInbox(),
+      ...inbox,
+      newerThan: inbox.newerThan ?? null,
+      historyBefore,
+      historyNextPage,
+      historyExhausted: inbox.historyExhausted ?? (
+        historyBefore === null || historyNextPage === null
+      ),
+      historyErrorCode: inbox.historyErrorCode ?? null,
+    },
+  };
+}
+
 async function replaceAccountIfNeeded(accountLogin: string): Promise<GitHubWatchStateRecord> {
   const normalizedLogin = normalizeAccountLogin(accountLogin);
   const current = await db.watchState.get(WATCH_STATE_ID);
-  if (current?.accountLogin === normalizedLogin) return current;
+  if (current?.accountLogin === normalizedLogin) return normalizeWatchState(current);
 
   // Tables without their account-bound state are orphaned and must never be
   // adopted by the next account that writes a refresh result.
@@ -199,7 +226,7 @@ export async function getWatchState(
   if (!accountLogin?.trim()) return null;
   const normalizedLogin = normalizeAccountLogin(accountLogin);
   const state = await db.watchState.get(WATCH_STATE_ID);
-  return state?.accountLogin === normalizedLogin ? state : null;
+  return state?.accountLogin === normalizedLogin ? normalizeWatchState(state) : null;
 }
 
 export async function countUnreadWatchThreads(
@@ -276,7 +303,7 @@ export async function queryStoredWatchInbox(input: {
           await db.watchNotificationThreads.toArray(),
           { unreadOnly: input.unreadOnly },
         ),
-        state,
+        state: normalizeWatchState(state),
       };
     },
   );
@@ -293,8 +320,9 @@ export async function applyWatchThreadMutation(input: {
     throw new TypeError('Watch thread mutation contains an invalid thread id.');
   }
   return db.transaction('rw', db.watchNotificationThreads, db.watchState, async () => {
-    const state = await db.watchState.get(WATCH_STATE_ID);
-    if (state?.accountLogin !== accountLogin) return 0;
+    const storedState = await db.watchState.get(WATCH_STATE_ID);
+    if (storedState?.accountLogin !== accountLogin) return 0;
+    const state = normalizeWatchState(storedState);
     const rows = (await db.watchNotificationThreads.bulkGet(threadIds))
       .filter((row): row is GitHubNotificationThread => row !== undefined);
     if (input.action === 'done') {
@@ -389,9 +417,19 @@ export async function replaceWatchInbox(input: {
   nextAllowedAt: string | null;
   candidateCount: number;
   truncated: boolean;
+  historyBefore?: string;
+  historyNextPage?: number | null;
+  resetHistory?: boolean;
   mode: 'replace' | 'merge';
   requireLiveStars?: boolean;
 }): Promise<GitHubWatchStateRecord> {
+  if (
+    input.historyNextPage !== undefined
+    && input.historyNextPage !== null
+    && !isValidWatchHistoryPage(input.historyNextPage)
+  ) {
+    throw new TypeError('Watch next history page must be a positive safe integer.');
+  }
   const normalizedThreads = normalizeThreads(input.threads);
   return db.transaction(
     'rw',
@@ -415,6 +453,11 @@ export async function replaceWatchInbox(input: {
         if (staleThreadIds.length) await db.watchNotificationThreads.bulkDelete(staleThreadIds);
       }
       if (publishedThreads.length) await db.watchNotificationThreads.bulkPut(publishedThreads);
+      const initializeHistory = input.mode === 'replace'
+        || current.inbox.historyBefore === null
+        || input.resetHistory === true;
+      const historyBefore = input.historyBefore ?? input.successfulAt ?? input.attemptedAt;
+      const historyNextPage = input.historyNextPage ?? null;
       const matchedCount = await db.watchNotificationThreads.count();
       const next: GitHubWatchStateRecord = {
         ...current,
@@ -428,15 +471,148 @@ export async function replaceWatchInbox(input: {
             ? current.inbox.candidateCount + input.candidateCount
             : input.candidateCount,
           matchedCount,
-          truncated: input.mode === 'merge'
-            ? current.inbox.truncated || input.truncated
-            : input.truncated,
+          truncated: initializeHistory ? input.truncated : current.inbox.truncated,
+          newerThan: current.inbox.newerThan,
+          historyBefore: initializeHistory ? historyBefore : current.inbox.historyBefore,
+          historyNextPage: initializeHistory ? historyNextPage : current.inbox.historyNextPage,
+          historyExhausted: initializeHistory
+            ? historyNextPage === null
+            : current.inbox.historyExhausted,
+          historyErrorCode: initializeHistory ? null : current.inbox.historyErrorCode,
         },
       };
       await db.watchState.put(next);
       return next;
     },
   );
+}
+
+export async function markWatchInboxLoaded(input: {
+  accountLogin: string;
+  loadedAt: string;
+}): Promise<GitHubWatchStateRecord | null> {
+  const accountLogin = normalizeAccountLogin(input.accountLogin);
+  const loadedAtMs = Date.parse(input.loadedAt);
+  if (!Number.isFinite(loadedAtMs)) throw new TypeError('Watch load time is invalid.');
+  return db.transaction('rw', db.watchState, async () => {
+    const storedState = await db.watchState.get(WATCH_STATE_ID);
+    if (storedState?.accountLogin !== accountLogin) return null;
+    const current = normalizeWatchState(storedState);
+    const currentMs = Date.parse(current.inbox.newerThan ?? '');
+    const newerThan = Number.isFinite(currentMs) && currentMs > loadedAtMs
+      ? current.inbox.newerThan
+      : new Date(loadedAtMs).toISOString();
+    if (current.inbox.newerThan === newerThan) return current;
+    const next: GitHubWatchStateRecord = {
+      ...current,
+      inbox: { ...current.inbox, newerThan },
+    };
+    await db.watchState.put(next);
+    return next;
+  });
+}
+
+export async function appendWatchInboxHistory(input: {
+  accountLogin: string;
+  historyBefore: string;
+  historyPage: number;
+  threads: readonly GitHubNotificationThread[];
+  candidateCount: number;
+  nextPage: number | null;
+  requireLiveStars?: boolean;
+}): Promise<{
+  state: GitHubWatchStateRecord | null;
+  addedCount: number;
+  applied: boolean;
+}> {
+  if (!isValidWatchHistoryPage(input.historyPage)) {
+    throw new TypeError('Watch history page must be a positive safe integer.');
+  }
+  if (input.nextPage !== null && !isValidWatchHistoryPage(input.nextPage)) {
+    throw new TypeError('Watch next history page must be a positive safe integer.');
+  }
+  const accountLogin = normalizeAccountLogin(input.accountLogin);
+  const normalizedThreads = normalizeThreads(input.threads);
+  return db.transaction(
+    'rw',
+    db.stars,
+    db.watchNotificationThreads,
+    db.watchState,
+    async () => {
+      const storedState = await db.watchState.get(WATCH_STATE_ID);
+      if (storedState?.accountLogin !== accountLogin) {
+        return { state: null, addedCount: 0, applied: false };
+      }
+      const current = normalizeWatchState(storedState);
+      if (
+        current.inbox.historyExhausted
+        || current.inbox.historyBefore !== input.historyBefore
+        || current.inbox.historyNextPage !== input.historyPage
+      ) return { state: current, addedCount: 0, applied: false };
+
+      const liveNames = input.requireLiveStars
+        ? liveRepositoryNames(await db.stars.toArray())
+        : null;
+      const publishedThreads = liveNames
+        ? normalizedThreads.filter((thread) => liveNames.has(thread.repositoryFullName))
+        : normalizedThreads;
+      const existingRows = publishedThreads.length
+        ? await db.watchNotificationThreads.bulkGet(publishedThreads.map((thread) => thread.id))
+        : [];
+      const existingIds = new Set(existingRows.flatMap((thread) => thread ? [thread.id] : []));
+      const mergedRows = dedupeNotificationThreads([
+        ...existingRows.flatMap((thread) => thread ? [thread] : []),
+        ...publishedThreads,
+      ]);
+      if (mergedRows.length) await db.watchNotificationThreads.bulkPut(mergedRows);
+      const addedCount = publishedThreads.reduce(
+        (count, thread) => count + Number(!existingIds.has(thread.id)),
+        0,
+      );
+      const next: GitHubWatchStateRecord = {
+        ...current,
+        inbox: {
+          ...current.inbox,
+          candidateCount: current.inbox.candidateCount + input.candidateCount,
+          matchedCount: await db.watchNotificationThreads.count(),
+          truncated: input.nextPage !== null,
+          historyNextPage: input.nextPage,
+          historyExhausted: input.nextPage === null,
+          historyErrorCode: null,
+        },
+      };
+      await db.watchState.put(next);
+      return { state: next, addedCount, applied: true };
+    },
+  );
+}
+
+export async function recordWatchHistoryFailure(input: {
+  accountLogin: string;
+  historyBefore: string;
+  historyPage: number;
+  errorCode: string;
+}): Promise<GitHubWatchStateRecord | null> {
+  const accountLogin = normalizeAccountLogin(input.accountLogin);
+  return db.transaction('rw', db.watchState, async () => {
+    const storedState = await db.watchState.get(WATCH_STATE_ID);
+    if (storedState?.accountLogin !== accountLogin) return null;
+    const current = normalizeWatchState(storedState);
+    if (
+      current.inbox.historyExhausted
+      || current.inbox.historyBefore !== input.historyBefore
+      || current.inbox.historyNextPage !== input.historyPage
+    ) return current;
+    const next: GitHubWatchStateRecord = {
+      ...current,
+      inbox: {
+        ...current.inbox,
+        historyErrorCode: input.errorCode,
+      },
+    };
+    await db.watchState.put(next);
+    return next;
+  });
 }
 
 export async function revalidateWatchInbox(input: {

--- a/src/ui/ManagerWorkspace.tsx
+++ b/src/ui/ManagerWorkspace.tsx
@@ -219,12 +219,12 @@ export function ManagerWorkspace({
   const reportMeaningfulAction = useCallback(() => {
     onMeaningfulAction?.();
   }, [onMeaningfulAction]);
+  // Prime Watch and Following on manager entry; switching tabs must not be their first query.
   const watchInbox = useWatchInbox({
-    active: surface === 'watch',
+    visible: surface === 'watch',
     onMeaningfulAction: reportMeaningfulAction,
   });
   const radar = useRadar({
-    active: surface === 'radar',
     onMeaningfulAction: reportMeaningfulAction,
   });
   const surfaceBadges = useManagerSurfaceBadges();
@@ -608,12 +608,10 @@ export function ManagerWorkspace({
             layoutEditChrome={layoutEditChrome}
             surface={surface}
             onSurfaceChange={handleSurfaceChange}
-            watchUnreadCount={watchSurface
-              ? watchInbox.result?.unreadCount ?? surfaceBadges.watchUnreadCount
-              : surfaceBadges.watchUnreadCount}
-            radarUnseenCount={radarSurface
-              ? radar.result?.unseenCount ?? surfaceBadges.radarUnseenCount
-              : surfaceBadges.radarUnseenCount}
+            watchUnreadCount={watchInbox.result?.unreadCount
+              ?? surfaceBadges.watchUnreadCount}
+            radarUnseenCount={radar.result?.unseenCount
+              ?? surfaceBadges.radarUnseenCount}
             {...extension?.toolbar}
           />
           {watchSurface && (
@@ -692,14 +690,18 @@ export function ManagerWorkspace({
               {watchSurface ? (
                 <WatchInbox
                   result={watchInbox.result}
+                  newerThan={watchInbox.newerThan}
                   scrollElement={listElement}
                   loading={watchInbox.loading}
                   refreshing={watchInbox.refreshing}
                   error={watchInbox.error}
+                  loadingOlder={watchInbox.loadingOlder}
+                  loadOlderError={watchInbox.loadOlderError}
                   unreadOnly={watchInbox.unreadOnly}
                   onUnreadOnlyChange={watchInbox.setUnreadOnly}
                   onRefresh={() => { void watchInbox.refresh(); }}
                   onRetryQuery={() => { void watchInbox.reload(); }}
+                  onLoadOlder={() => { void watchInbox.loadOlder(); }}
                   actionPending={watchInbox.actionPending}
                   actionError={watchInbox.actionError}
                   onMarkThreadsRead={(threadIds) => { void watchInbox.markThreadsRead(threadIds); }}

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -42,7 +42,7 @@ export type ToolbarAgentStatusKind =
 
 export type ToolbarStatus = Readonly<{
   hasToken: boolean;
-  inFlight: boolean;
+  progressInFlight: boolean;
   seenTooltips: number;
   progress: SyncProgress;
 }>;
@@ -297,7 +297,7 @@ export function Toolbar({
   const [syncMenuOpen, setSyncMenuOpen] = useState(false);
   const [gistMenuOpen, setGistMenuOpen] = useState(false);
   const starsSurface = surface === 'stars';
-  const syncPresentation = presentSyncProgress(status?.progress ?? { phase: 'idle', done: 0, total: null, message: '' }, status?.inFlight ?? false);
+  const syncPresentation = presentSyncProgress(status?.progress ?? { phase: 'idle', done: 0, total: null, message: '' }, status?.progressInFlight ?? false);
   const syncing = syncPresentation.active;
   const phase = syncing && status ? status.progress : null;
   const actionBusy = busy || syncing || pendingAction !== null;

--- a/src/ui/components/WatchInbox.tsx
+++ b/src/ui/components/WatchInbox.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useI18n } from '@/i18n';
+import { useManagerNow } from '@/ui/manager-runtime-context';
 
 import { cn } from '@/lib/utils';
 import { useImeBufferedInput } from '@/ui/hooks/use-ime-input';
@@ -46,6 +47,29 @@ function isWatchCredentialError(code: string | null | undefined): boolean {
   return code === 'authentication_required' || code === 'permission_denied';
 }
 
+function formatWatchTimelineDay(
+  value: string,
+  locale: string,
+  now: number,
+  todayLabel: string,
+  yesterdayLabel: string,
+): string {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return value;
+  const today = new Date(now);
+  const dayStart = new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+  const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  if (dayStart === todayStart.getTime()) return todayLabel;
+  todayStart.setDate(todayStart.getDate() - 1);
+  if (dayStart === todayStart.getTime()) return yesterdayLabel;
+  return new Intl.DateTimeFormat(locale, {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+    ...(date.getFullYear() === today.getFullYear() ? {} : { year: 'numeric' }),
+  }).format(date);
+}
+
 function EmptyState({
   icon,
   title,
@@ -79,15 +103,19 @@ function EmptyState({
 
 export function WatchInbox({
   result,
+  newerThan,
   scrollElement,
   loading,
   refreshing,
+  loadingOlder,
+  loadOlderError,
   actionPending,
   actionError,
   unreadOnly,
   onUnreadOnlyChange,
   onRefresh,
   onRetryQuery,
+  onLoadOlder,
   onOpenOptions,
   onOpenMainTokenOptions,
   onMarkThreadsRead,
@@ -97,6 +125,7 @@ export function WatchInbox({
   onSelectRepository,
 }: WatchInboxProps) {
   const { m, locale } = useI18n();
+  const now = useManagerNow();
   const [query, setQuery] = useState('');
   const [selectedReasons, setSelectedReasons] = useState<string[]>([]);
   const [manualRepositoryExpansions, setManualRepositoryExpansions] = useState<
@@ -108,9 +137,20 @@ export function WatchInbox({
   const [pendingFocusThreadId, setPendingFocusThreadId] = useState<string | null>(null);
   const [autoExpandedRepositories, setAutoExpandedRepositories] = useState<Record<string, true>>({});
   const reconciledCollapseSignatures = useRef<Record<string, string>>({});
+  const historySentinelRef = useRef<HTMLDivElement | null>(null);
+  const historySentinelVisibleRef = useRef(false);
+  const historyScrollIntentRef = useRef(false);
+  const requestedHistoryKeyRef = useRef<string | null>(null);
   const searchInput = useImeBufferedInput(query, setQuery);
   const status = result?.status;
   const state = status?.state;
+  const historyNextPage = state?.inbox.historyNextPage ?? null;
+  const historyExhausted = state?.inbox.historyExhausted ?? true;
+  const canLoadOlder = historyNextPage !== null && !historyExhausted;
+  const historyRequestKey = canLoadOlder
+    ? `${status?.accountLogin ?? ''}:${state?.inbox.historyBefore ?? ''}:${historyNextPage}`
+    : null;
+  const newerThanMs = Date.parse(newerThan ?? '');
   const modeProjection = useMemo(
     () => result ? projectWatchInbox(result.threads, { unreadOnly }) : null,
     [result, unreadOnly],
@@ -156,18 +196,65 @@ export function WatchInbox({
     sourceGroupsByRepository,
   ]);
   const flatRows = useMemo(
-    () => buildWatchInboxRows(groups, expandedRepositories),
-    [expandedRepositories, groups],
+    () => buildWatchInboxRows(visibleProjection?.threads ?? [], expandedRepositories),
+    [expandedRepositories, visibleProjection?.threads],
   );
   const rowVirtualizer = useVirtualizer({
     count: flatRows.length,
     getScrollElement: () => scrollElement ?? null,
     getItemKey: (index) => flatRows[index]?.key ?? index,
-    estimateSize: (index) => flatRows[index]?.kind === 'repository'
-      ? WATCH_REPOSITORY_ROW_ESTIMATE
-      : WATCH_THREAD_ROW_ESTIMATE,
+    estimateSize: (index) => flatRows[index]?.kind === 'day'
+      ? 32
+      : flatRows[index]?.kind === 'repository'
+        ? WATCH_REPOSITORY_ROW_ESTIMATE
+        : WATCH_THREAD_ROW_ESTIMATE,
     overscan: WATCH_ROW_OVERSCAN,
   });
+
+  useEffect(() => {
+    const sentinel = historySentinelRef.current;
+    if (
+      !sentinel
+      || !historyRequestKey
+      || loadingOlder
+      || loadOlderError
+      || refreshing
+      || typeof IntersectionObserver === 'undefined'
+    ) return;
+    historySentinelVisibleRef.current = false;
+    historyScrollIntentRef.current = false;
+    const requestOlder = () => {
+      if (!historyScrollIntentRef.current || !historySentinelVisibleRef.current) return;
+      if (requestedHistoryKeyRef.current === historyRequestKey) return;
+      requestedHistoryKeyRef.current = historyRequestKey;
+      onLoadOlder();
+    };
+    const handleScroll = () => {
+      historyScrollIntentRef.current = true;
+      requestOlder();
+    };
+    const observer = new IntersectionObserver((entries) => {
+      historySentinelVisibleRef.current = entries.some((entry) => entry.isIntersecting);
+      requestOlder();
+    }, {
+      root: scrollElement ?? null,
+      rootMargin: '320px 0px',
+    });
+    const scrollTarget: EventTarget = scrollElement ?? window;
+    scrollTarget.addEventListener('scroll', handleScroll, { passive: true });
+    observer.observe(sentinel);
+    return () => {
+      historySentinelVisibleRef.current = false;
+      historyScrollIntentRef.current = false;
+      scrollTarget.removeEventListener('scroll', handleScroll);
+      observer.disconnect();
+    };
+  }, [historyRequestKey, loadOlderError, loadingOlder, onLoadOlder, refreshing, scrollElement]);
+
+  const handleLoadOlder = useCallback(() => {
+    if (historyRequestKey) requestedHistoryKeyRef.current = historyRequestKey;
+    onLoadOlder();
+  }, [historyRequestKey, onLoadOlder]);
   const refreshDisabled = refreshing || actionPending !== null || status?.inboxStatus === 'cooldown';
 
   const handleRepositoryToggle = useCallback((
@@ -345,11 +432,33 @@ export function WatchInbox({
   const rowSpacingClass = (index: number) => {
     const row = flatRows[index];
     const nextRow = flatRows[index + 1];
+    if (row.kind === 'day') return index === 0 ? 'pb-1.5' : 'pb-1.5 pt-3';
     if (row.kind === 'repository' && nextRow?.kind === 'thread') return 'pb-1';
-    return !nextRow || nextRow.kind === 'repository' ? 'pb-3.5' : undefined;
+    return !nextRow || nextRow.kind !== 'thread' ? 'pb-3.5' : undefined;
   };
 
   const renderRowContent = (row: (typeof flatRows)[number]) => {
+    if (row.kind === 'day') {
+      return (
+        <div
+          className="relative z-10 flex min-h-7 items-center bg-background"
+          data-watch-day={row.dayKey}
+        >
+          <time
+            dateTime={row.updatedAt}
+            className="rounded-full border border-border bg-muted/40 px-2 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground"
+          >
+            {formatWatchTimelineDay(
+              row.updatedAt,
+              locale,
+              now,
+              m.watch.timelineToday,
+              m.watch.timelineYesterday,
+            )}
+          </time>
+        </div>
+      );
+    }
     if (row.kind === 'repository') {
       const repository = row.group.repositoryFullName.toLowerCase();
       const sourceGroup = sourceGroupsByRepository.get(repository) ?? row.group;
@@ -368,10 +477,15 @@ export function WatchInbox({
         />
       );
     }
+    const updatedAt = Date.parse(row.thread.updatedAt);
+    const newSinceLastVisit = Number.isFinite(updatedAt)
+      && Number.isFinite(newerThanMs)
+      && updatedAt > newerThanMs;
     return (
       <WatchThreadRow
         thread={row.thread}
         locale={locale}
+        newSinceLastVisit={newSinceLastVisit}
         expanded={expandedThreadIds.has(row.thread.id)}
         focusRequested={pendingFocusThreadId === row.thread.id}
         actionPending={actionPending}
@@ -381,6 +495,61 @@ export function WatchInbox({
         onMarkThreadsRead={onMarkThreadsRead}
         onMarkThreadsDone={onMarkThreadsDone}
       />
+    );
+  };
+
+  const renderHistoryBoundary = (
+    visibleThreadCount: number,
+    variant: 'plain' | 'timeline' = 'timeline',
+  ) => {
+    const stale = status.inboxStatus === 'error'
+      || status.inboxStatus === 'stale'
+      || status.inboxStatus === 'cooldown';
+    const boundaryState = loadOlderError
+      ? 'error'
+      : loadingOlder
+        ? 'loading'
+        : canLoadOlder ? 'more' : 'complete';
+    const tone: 'muted' | 'info' | 'warning' = loadOlderError
+      ? 'warning'
+      : canLoadOlder ? 'info' : stale ? 'warning' : 'muted';
+    const text = loadOlderError
+      ? m.watch.loadOlderFailed
+      : loadingOlder
+        ? m.watch.loadingOlder
+        : canLoadOlder
+          ? m.watch.listEndWindow
+          : stale
+            ? m.watch.listEndSaved(visibleThreadCount)
+            : hasPresentationFilters
+              ? m.watch.listEndMatches(visibleThreadCount)
+              : m.watch.historyComplete(visibleThreadCount);
+    return (
+      <div
+        ref={historySentinelRef}
+        data-watch-history-sentinel={boundaryState}
+        aria-busy={loadingOlder}
+      >
+        <SurfaceListEndMarker variant={variant} tone={tone} text={text} />
+        {canLoadOlder && (
+          <div className={cn('flex pb-1', {
+            'pl-[23px]': variant === 'timeline',
+            'justify-center px-3': variant === 'plain',
+          })}>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2.5 text-xs"
+              disabled={loadingOlder || refreshing}
+              onClick={handleLoadOlder}
+            >
+              {loadingOlder && <Spinner data-icon="inline-start" aria-label={m.watch.loadingOlder} />}
+              {loadOlderError ? m.watch.retry : loadingOlder ? m.watch.loadingOlder : m.watch.loadOlder}
+            </Button>
+          </div>
+        )}
+      </div>
     );
   };
 
@@ -416,32 +585,22 @@ export function WatchInbox({
       />
     );
   } else if (groups.length === 0) {
+    const visibleThreadCount = visibleProjection?.threads.length ?? 0;
     content = (
-      <EmptyState
-        icon={<Inbox className="size-4" />}
-        title={hasPresentationFilters ? m.watch.reasonPresetAll : m.watch.watchSurface}
-        text={(modeProjection?.threads.length ?? 0) > 0 && hasPresentationFilters
-          ? m.watch.noMatchingThreads
-          : unreadOnly ? m.watch.noUnreadThreads : m.watch.noThreads}
-        tone={hasPresentationFilters ? 'muted' : 'success'}
-      />
+      <>
+        <EmptyState
+          icon={<Inbox className="size-4" />}
+          title={hasPresentationFilters ? m.watch.reasonPresetAll : m.watch.watchSurface}
+          text={(modeProjection?.threads.length ?? 0) > 0 && hasPresentationFilters
+            ? m.watch.noMatchingThreads
+            : unreadOnly ? m.watch.noUnreadThreads : m.watch.noThreads}
+          tone={hasPresentationFilters ? 'muted' : 'success'}
+        />
+        {(canLoadOlder || loadOlderError) && renderHistoryBoundary(visibleThreadCount, 'plain')}
+      </>
     );
   } else {
-    const listEndTone = state?.inbox.truncated
-      ? 'info'
-      : status.inboxStatus === 'error'
-        || status.inboxStatus === 'stale'
-        || status.inboxStatus === 'cooldown'
-        ? 'warning'
-        : 'muted';
     const visibleThreadCount = visibleProjection?.threads.length ?? 0;
-    const listEndText = state?.inbox.truncated
-      ? m.watch.listEndWindow
-      : listEndTone === 'warning'
-        ? m.watch.listEndSaved(visibleThreadCount)
-        : hasPresentationFilters
-          ? m.watch.listEndMatches(visibleThreadCount)
-          : m.watch.listEndSnapshot(visibleThreadCount);
     content = (
       <SurfaceWorkCanvas variant="watch" className="px-4 py-3 max-sm:px-3">
         <div
@@ -480,11 +639,7 @@ export function WatchInbox({
               </div>
             ))
           )}
-          <SurfaceListEndMarker
-            variant="timeline"
-            tone={listEndTone}
-            text={listEndText}
-          />
+          {renderHistoryBoundary(visibleThreadCount)}
         </div>
       </SurfaceWorkCanvas>
     );

--- a/src/ui/components/WatchThreadRow.tsx
+++ b/src/ui/components/WatchThreadRow.tsx
@@ -295,6 +295,7 @@ function SubjectDetailSlot({
 export function WatchThreadRow({
   thread,
   locale,
+  newSinceLastVisit,
   expanded,
   focusRequested,
   actionPending,
@@ -306,6 +307,7 @@ export function WatchThreadRow({
 }: {
   thread: GitHubNotificationThread;
   locale: string;
+  newSinceLastVisit: boolean;
   expanded: boolean;
   focusRequested: boolean;
   actionPending: WatchThreadActionPending | null;
@@ -346,7 +348,11 @@ export function WatchThreadRow({
   };
 
   return (
-    <article className="min-w-0" data-watch-thread-row={thread.id}>
+    <article
+      className="min-w-0"
+      data-watch-thread-row={thread.id}
+      data-watch-new={newSinceLastVisit || undefined}
+    >
       <button
         ref={buttonRef}
         id={disclosureId}
@@ -359,6 +365,7 @@ export function WatchThreadRow({
         onClick={toggleExpanded}
         className={cn('group flex h-[37px] w-full min-w-0 items-center gap-[9px] rounded-md pr-2 text-left text-foreground outline-none transition-colors hover:bg-muted/55 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring', {
           'bg-muted/45': expanded,
+          'bg-info/[0.08] hover:bg-info/[0.12]': newSinceLastVisit && !expanded,
         })}
       >
         <span className="relative z-10 flex w-[15px] shrink-0 justify-center bg-background" aria-hidden="true">
@@ -386,8 +393,16 @@ export function WatchThreadRow({
         >
           {thread.subjectTitle}
         </span>
+        {newSinceLastVisit && (
+          <span
+            className="shrink-0 rounded-full border border-info/35 bg-info/[0.08] px-1.5 py-px font-mono text-[10px] font-semibold text-info"
+            title={m.watch.newSinceLastVisit}
+          >
+            {m.watch.newBadge}
+          </span>
+        )}
         <span id={metadataId} className="sr-only">
-          {subjectType}. {thread.reason}. {thread.unread ? m.watch.unreadStatus : m.watch.readStatus}. {updatedTitle ?? ''}
+          {subjectType}. {thread.reason}. {thread.unread ? m.watch.unreadStatus : m.watch.readStatus}. {newSinceLastVisit ? m.watch.newSinceLastVisit : ''} {updatedTitle ?? ''}
         </span>
         <code
           className="max-w-44 truncate rounded-sm bg-muted px-1.5 py-px font-mono text-[11px] text-muted-foreground max-[720px]:hidden"

--- a/src/ui/hooks/use-manager-sync-actions.ts
+++ b/src/ui/hooks/use-manager-sync-actions.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { GITHUB_CREDENTIALS_STORAGE_KEY } from '@/auth/auth-store';
 import type { BackfillId } from '@/types';
 import { useI18n } from '@/i18n';
-import { isOnboardingCardStage, resolveOnboardingStageAfterSync, shouldTrackOnboardingSync } from '@/onboarding/state';
+import { isOnboardingCardStage, shouldTrackOnboardingSync } from '@/onboarding/state';
 import { pickInitialSyncAction } from '@/ui/initial-sync';
 import { ACTION_SUCCESS_FEEDBACK_MS } from '@/ui/ui-feedback-constants';
 import { bgCall, mergeProgressStatus, mergeStatusPatch, mergeStatusSnapshot, onProgress, type SyncStatus } from '@/utils/messaging';
@@ -51,13 +51,6 @@ export function useManagerSyncActions({ refreshStars }: { refreshStars: () => vo
     setStatus((cur) => mergeStatusPatch(cur, patch));
   };
 
-  const finalizeOnboardingAfterSync = async (hasToken: boolean) => {
-    const q = await bgCall<{ grandTotal: number }>('query', {
-      params: { filter: emptyFilter(), offset: 0, limit: 1 },
-    }).catch(() => null);
-    if (!q) return;
-    await setOnboardingStage(resolveOnboardingStageAfterSync(hasToken, q.grandTotal));
-  };
 
   const flashSuccess = (type: string) => {
     if (successTimer.current) clearTimeout(successTimer.current);
@@ -79,7 +72,6 @@ export function useManagerSyncActions({ refreshStars }: { refreshStars: () => vo
       const result = await bgCall<{ missing?: boolean }>(type);
       refreshStars();
       await refreshStatus();
-      if (tracksOnboarding) await finalizeOnboardingAfterSync(!!status?.hasToken);
       if (type === 'gistPull' && result?.missing) {
         setInfo(m.background.gistPullMissing);
       } else {
@@ -158,7 +150,6 @@ export function useManagerSyncActions({ refreshStars }: { refreshStars: () => vo
         .then(async () => {
           refreshStars();
           await refreshStatus();
-          if (tracksOnboarding) await finalizeOnboardingAfterSync(true);
         })
         .catch(async (e) => {
           await refreshStatus();
@@ -192,14 +183,6 @@ export function useManagerSyncActions({ refreshStars }: { refreshStars: () => vo
     if (successTimer.current) clearTimeout(successTimer.current);
   }, []);
 
-  const progressActive = !!status?.inFlight && status.progress.phase !== 'idle';
-  const syncingNow = !!pendingAction || progressActive;
-  useEffect(() => {
-    if (!statusLoaded || !status) return;
-    if (status.onboardingStage !== 'syncing' || syncingNow) return;
-    void finalizeOnboardingAfterSync(status.hasToken);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [statusLoaded, status?.onboardingStage, status?.hasToken, syncingNow]);
 
   return {
     status,

--- a/src/ui/hooks/use-watch-inbox.ts
+++ b/src/ui/hooks/use-watch-inbox.ts
@@ -10,10 +10,13 @@ import type { WatchThreadActionPending } from '@/ui/watch-inbox-types';
 
 export function useWatchInbox({
   active = true,
+  visible = false,
   onMeaningfulAction,
 }: {
   /** Dormant resources preserve cached data and perform no background query work. */
   active?: boolean;
+  /** Marks a user-visible Watch visit without disabling background prefetch. */
+  visible?: boolean;
   onMeaningfulAction?: () => void;
 } = {}) {
   const runtime = useManagerRuntime();
@@ -21,18 +24,24 @@ export function useWatchInbox({
   const [collapsedRepositories, setCollapsedRepositories] =
     useState<WatchCollapsedRepositorySignatures>({});
   const [result, setResult] = useState<WatchInboxQueryResponse | null>(null);
+  const [newerThan, setNewerThan] = useState<string | null>(null);
   const [loading, setLoading] = useState(active);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<'query' | 'refresh' | null>(null);
   const [actionPending, setActionPending] = useState<WatchThreadActionPending | null>(null);
   const [actionError, setActionError] = useState<WatchThreadAction | null>(null);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const [loadOlderError, setLoadOlderError] = useState(false);
   const generation = useRef(0);
   const refreshingRef = useRef(false);
   const actionPendingRef = useRef(false);
+  const loadingOlderRef = useRef(false);
   const mountedRef = useRef(true);
   const activeRef = useRef(active);
   activeRef.current = active;
   const hasLoadedRef = useRef(false);
+  const acknowledgedLoadRef = useRef<string | null>(null);
+  const lastAcknowledgedLoadRef = useRef<{ accountLogin: string; loadedAt: string } | null>(null);
   const cooldownProbeRef = useRef<{ deadline: string | null; attempts: number }>({
     deadline: null,
     attempts: 0,
@@ -103,6 +112,9 @@ export function useWatchInbox({
       if (event.kind === 'reset') {
         generation.current += 1;
         hasLoadedRef.current = false;
+        acknowledgedLoadRef.current = null;
+        lastAcknowledgedLoadRef.current = null;
+        setNewerThan(null);
         setResult(null);
         setError(null);
         setLoading(activeRef.current);
@@ -118,6 +130,40 @@ export function useWatchInbox({
       unsubscribe();
     };
   }, [load, runtime]);
+
+  useEffect(() => {
+    if (!visible) {
+      acknowledgedLoadRef.current = null;
+      setNewerThan(null);
+      return;
+    }
+    const accountLogin = result?.status.accountLogin ?? null;
+    const inbox = result?.status.state?.inbox ?? null;
+    if (!accountLogin || !inbox || acknowledgedLoadRef.current === accountLogin) return;
+    acknowledgedLoadRef.current = accountLogin;
+    const localBoundary = lastAcknowledgedLoadRef.current?.accountLogin === accountLogin
+      ? lastAcknowledgedLoadRef.current.loadedAt
+      : null;
+    const persistedBoundaryMs = Date.parse(inbox.newerThan ?? '');
+    const localBoundaryMs = Date.parse(localBoundary ?? '');
+    setNewerThan(Number.isFinite(localBoundaryMs) && (
+      !Number.isFinite(persistedBoundaryMs) || localBoundaryMs > persistedBoundaryMs
+    )
+      ? localBoundary
+      : inbox.newerThan);
+
+    const optimisticLoadedAt = new Date(runtime.now()).toISOString();
+    lastAcknowledgedLoadRef.current = { accountLogin, loadedAt: optimisticLoadedAt };
+    void runtime.markWatchLoaded().then((loadedAt) => {
+      if (loadedAt && lastAcknowledgedLoadRef.current?.accountLogin === accountLogin) {
+        lastAcknowledgedLoadRef.current = { accountLogin, loadedAt };
+      }
+    }).catch(() => {
+      if (lastAcknowledgedLoadRef.current?.loadedAt === optimisticLoadedAt) {
+        lastAcknowledgedLoadRef.current = null;
+      }
+    });
+  }, [result, runtime, visible]);
 
   const cooldownUntil = result?.status.inboxStatus === 'cooldown'
     ? result.status.state?.inbox.nextAllowedAt ?? null
@@ -150,6 +196,7 @@ export function useWatchInbox({
     refreshingRef.current = true;
     setRefreshing(true);
     setError(null);
+    setLoadOlderError(false);
     try {
       await runtime.refreshWatch();
       await load(true);
@@ -161,6 +208,23 @@ export function useWatchInbox({
       if (mountedRef.current) setRefreshing(false);
     }
   }, [load, runtime]);
+  const loadOlder = useCallback(async () => {
+    if (!mountedRef.current || loadingOlderRef.current) return;
+    loadingOlderRef.current = true;
+    setLoadingOlder(true);
+    setLoadOlderError(false);
+    try {
+      await runtime.loadOlderWatch();
+      await load(true);
+    } catch {
+      await load(true);
+      if (mountedRef.current) setLoadOlderError(true);
+    } finally {
+      loadingOlderRef.current = false;
+      if (mountedRef.current) setLoadingOlder(false);
+    }
+  }, [load, runtime]);
+
   const actionAccountLogin = result?.status.accountLogin ?? null;
 
   const mutateThreads = useCallback(async (
@@ -230,16 +294,24 @@ export function useWatchInbox({
     });
   }, [runtime]);
 
+  const visibleLoadOlderError = !loadingOlder && (
+    loadOlderError || result?.status.state?.inbox.historyErrorCode != null
+  );
+
   return {
     unreadOnly,
     setUnreadOnly: changeUnreadOnly,
     collapsedRepositories,
     updateRepositoryCollapse,
     result,
+    newerThan,
     loading,
     refreshing: refreshing || result?.status.refreshing === true,
     error,
     refresh,
+    loadingOlder,
+    loadOlderError: visibleLoadOlderError,
+    loadOlder,
     reload: load,
     actionPending,
     actionError,

--- a/src/ui/initial-sync.ts
+++ b/src/ui/initial-sync.ts
@@ -3,9 +3,9 @@ import type { SyncStatus } from '@/utils/messaging';
 export type InitialSyncAction = 'syncFull' | 'syncIncremental' | null;
 
 export function pickInitialSyncAction(
-  status: Pick<SyncStatus, 'hasToken' | 'inFlight'> | null,
+  status: Pick<SyncStatus, 'hasToken' | 'starsSyncInFlight'> | null,
   grandTotal: number | null,
 ): InitialSyncAction {
-  if (!status?.hasToken || status.inFlight) return null;
+  if (!status?.hasToken || status.starsSyncInFlight) return null;
   return grandTotal && grandTotal > 0 ? 'syncIncremental' : 'syncFull';
 }

--- a/src/ui/watch-inbox-presentation.ts
+++ b/src/ui/watch-inbox-presentation.ts
@@ -123,40 +123,89 @@ export function filterWatchInboxProjection(
 
 export type WatchInboxFlatRow =
   | {
+    kind: 'day';
+    key: string;
+    dayKey: string;
+    updatedAt: string;
+  }
+  | {
     kind: 'repository';
     key: string;
+    dayKey: string;
     group: WatchInboxProjection['groups'][number];
   }
   | {
     kind: 'thread';
     key: string;
+    dayKey: string;
     repositoryFullName: string;
     thread: GitHubNotificationThread;
   };
 
 export type WatchThreadNavigationKey = 'ArrowUp' | 'ArrowDown' | 'Home' | 'End';
 
-/** One logical row stream keeps repository size from defining the render batch. */
+function watchLocalDayKey(value: string): string {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return 'unknown';
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/** A newest-first timeline grouped only within each local calendar day. */
 export function buildWatchInboxRows(
-  groups: WatchInboxProjection['groups'],
+  threads: readonly GitHubNotificationThread[],
   expandedRepositories: ReadonlySet<string>,
 ): WatchInboxFlatRow[] {
-  const rows: WatchInboxFlatRow[] = [];
-  for (const group of groups) {
-    const repository = group.repositoryFullName.toLowerCase();
-    rows.push({
-      kind: 'repository',
-      key: `repository:${repository}`,
-      group,
-    });
-    if (!expandedRepositories.has(repository)) continue;
-    for (const thread of group.threads) {
-      rows.push({
-        kind: 'thread',
-        key: `thread:${thread.id}`,
-        repositoryFullName: group.repositoryFullName,
-        thread,
+  type RepositoryGroup = WatchInboxProjection['groups'][number];
+  const days = new Map<string, {
+    updatedAt: string;
+    repositories: Map<string, RepositoryGroup>;
+  }>();
+  for (const thread of threads) {
+    const dayKey = watchLocalDayKey(thread.updatedAt);
+    let day = days.get(dayKey);
+    if (!day) {
+      day = { updatedAt: thread.updatedAt, repositories: new Map() };
+      days.set(dayKey, day);
+    }
+    const repositoryKey = thread.repositoryFullName.toLowerCase();
+    const group = day.repositories.get(repositoryKey);
+    if (group) {
+      group.threads.push(thread);
+    } else {
+      day.repositories.set(repositoryKey, {
+        repositoryFullName: thread.repositoryFullName,
+        repositoryHtmlUrl: thread.repositoryHtmlUrl,
+        repositoryOwnerLogin: thread.repositoryOwnerLogin ?? null,
+        repositoryOwnerAvatarUrl: thread.repositoryOwnerAvatarUrl ?? null,
+        latestUpdatedAt: thread.updatedAt,
+        threads: [thread],
       });
+    }
+  }
+
+  const rows: WatchInboxFlatRow[] = [];
+  for (const [dayKey, day] of days) {
+    rows.push({ kind: 'day', key: `day:${dayKey}`, dayKey, updatedAt: day.updatedAt });
+    for (const [repository, group] of day.repositories) {
+      rows.push({
+        kind: 'repository',
+        key: `repository:${dayKey}:${repository}`,
+        dayKey,
+        group,
+      });
+      if (!expandedRepositories.has(repository)) continue;
+      for (const thread of group.threads) {
+        rows.push({
+          kind: 'thread',
+          key: `thread:${thread.id}`,
+          dayKey,
+          repositoryFullName: group.repositoryFullName,
+          thread,
+        });
+      }
     }
   }
   return rows;

--- a/src/ui/watch-inbox-types.ts
+++ b/src/ui/watch-inbox-types.ts
@@ -21,9 +21,12 @@ export interface WatchInboxSearchInput {
 
 export interface WatchInboxProps {
   result: WatchInboxQueryResponse | null;
+  newerThan: string | null;
   scrollElement?: HTMLElement | null;
   loading: boolean;
   refreshing: boolean;
+  loadingOlder: boolean;
+  loadOlderError: boolean;
   error: 'query' | 'refresh' | null;
   actionPending: WatchThreadActionPending | null;
   actionError: WatchThreadAction | null;
@@ -31,6 +34,7 @@ export interface WatchInboxProps {
   onUnreadOnlyChange: (unreadOnly: boolean) => void;
   onRefresh: () => void;
   onRetryQuery: () => void;
+  onLoadOlder: () => void;
   onOpenOptions: () => void;
   onOpenMainTokenOptions: () => void;
   onMarkThreadsRead: (ids: readonly string[]) => void;

--- a/src/utils/messaging.ts
+++ b/src/utils/messaging.ts
@@ -81,8 +81,12 @@ export interface SyncStatus {
   backfills: BackfillMap;
   /** Highest-priority backfill that still needs user attention. */
   activeBackfillId: BackfillId | null;
-  /** True while the background is still holding an active serialized job. */
+  /** True while any serialized background job is queued or running. */
   inFlight: boolean;
+  /** True only while a job that owns the shared progress channel is queued or running. */
+  progressInFlight: boolean;
+  /** True only while a Stars full, incremental, rescan, or backfill sync is queued or running. */
+  starsSyncInFlight: boolean;
   /** Authoritative durable Organize job activity from the background store. */
   organizeJobActive: boolean;
 }
@@ -1393,6 +1397,7 @@ export function mergeProgressStatus(
     hasToken,
   );
   const backfills = normalizeBackfillMap(current?.backfills);
+  const progressInFlight = progress.phase !== 'idle';
   return {
     progress,
     hasToken,
@@ -1401,7 +1406,9 @@ export function mergeProgressStatus(
     seenTooltips: current?.seenTooltips ?? 0,
     backfills,
     activeBackfillId: selectActiveBackfillId(backfills),
-    inFlight: progress.phase !== 'idle',
+    inFlight: progressInFlight,
+    progressInFlight,
+    starsSyncInFlight: progressInFlight ? current?.starsSyncInFlight ?? false : false,
     organizeJobActive: current?.organizeJobActive ?? false,
   };
 }
@@ -1420,6 +1427,8 @@ export function mergeStatusPatch(
     backfills: {},
     activeBackfillId: null,
     inFlight: false,
+    progressInFlight: false,
+    starsSyncInFlight: false,
     organizeJobActive: false,
   };
   const hasToken = patch.hasToken ?? base.hasToken;
@@ -1446,11 +1455,11 @@ export function mergeStatusSnapshot(current: SyncStatus | null, snapshot: SyncSt
   const activeProgress = current?.progress;
   const keepLiveProgress =
     !!activeProgress &&
-    !!current?.inFlight &&
+    snapshot.progressInFlight &&
     activeProgress.phase !== 'idle' &&
     snapshot.progress.phase === 'idle';
-  // Preserve the live progress (and seenOnboarding/seenTooltips) from `current`
-  // when the snapshot is idle — a fresh getStatus shouldn't clobber an in-flight phase.
+  // Preserve a live progress event only when the authoritative snapshot says a
+  // progress-owning job is still active. Unrelated Watch work must not keep it alive.
   const merged: SyncStatus = {
     ...snapshot,
     progress: keepLiveProgress ? activeProgress : snapshot.progress,
@@ -1463,7 +1472,9 @@ export function mergeStatusSnapshot(current: SyncStatus | null, snapshot: SyncSt
     seenTooltips: snapshot.seenTooltips ?? current?.seenTooltips ?? 0,
     backfills: normalizeBackfillMap(snapshot.backfills ?? current?.backfills),
     activeBackfillId: selectActiveBackfillId(snapshot.backfills ?? current?.backfills),
-    inFlight: keepLiveProgress ? true : snapshot.inFlight ?? current?.inFlight ?? snapshot.progress.phase !== 'idle',
+    inFlight: snapshot.inFlight,
+    progressInFlight: snapshot.progressInFlight,
+    starsSyncInFlight: snapshot.starsSyncInFlight,
     organizeJobActive: snapshot.organizeJobActive ?? current?.organizeJobActive ?? false,
   };
   merged.seenOnboarding = stageMarksOnboardingSeen(merged.onboardingStage);

--- a/src/watch/watch-contract.ts
+++ b/src/watch/watch-contract.ts
@@ -77,3 +77,9 @@ export interface WatchRefreshResult {
   inboxPublished: boolean;
   notModified: boolean;
 }
+
+export interface WatchLoadOlderResult {
+  status: WatchStatus;
+  addedCount: number;
+  hasMore: boolean;
+}

--- a/src/watch/watch-model.ts
+++ b/src/watch/watch-model.ts
@@ -42,6 +42,10 @@ export class GitHubWatchError extends Error {
   }
 }
 
+export function isValidWatchHistoryPage(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 1;
+}
+
 /** A native watched repository, reduced to the identity needed by Watch. */
 export interface GitHubWatchRepository {
   full_name: string;
@@ -138,6 +142,13 @@ export interface WatchInboxRefreshSnapshot extends WatchRefreshSnapshot {
   candidateCount: number;
   matchedCount: number;
   truncated: boolean;
+  /** Previous Watch-surface load; rows after this boundary are newly updated. */
+  newerThan: string | null;
+  /** Frozen Notifications `before` boundary for stable historical pagination. */
+  historyBefore: string | null;
+  historyNextPage: number | null;
+  historyExhausted: boolean;
+  historyErrorCode: string | null;
 }
 
 export interface GitHubWatchStateRecord {
@@ -161,6 +172,8 @@ export interface WatchNotificationSnapshot {
   matchedCount: number;
   pageCount: number;
   truncated: boolean;
+  /** Next page inside the frozen `before` epoch, or null when exhausted. */
+  nextPage: number | null;
   notModified: boolean;
   before: string;
   fetchedAt: string;

--- a/tests/regressions/auth/token-probe-and-status-regression.test.ts
+++ b/tests/regressions/auth/token-probe-and-status-regression.test.ts
@@ -102,6 +102,8 @@ describe('Status/token regressions', () => {
       backfills: {},
       activeBackfillId: null,
       inFlight: true,
+      progressInFlight: true,
+      starsSyncInFlight: false,
       organizeJobActive: true,
     };
     const next = mergeStatusPatch(current, { seenTooltips: 2 });
@@ -112,7 +114,7 @@ describe('Status/token regressions', () => {
     assert.equal(next.organizeJobActive, true);
   });
 
-  it('mergeStatusSnapshot keeps live progress when a restored snapshot is idle', () => {
+  it('mergeStatusSnapshot clears stale progress when only unrelated work remains', () => {
     const current: SyncStatus = {
       progress: { phase: 'full', done: 8, total: 20, message: 'Fetching…' },
       hasToken: true,
@@ -122,6 +124,8 @@ describe('Status/token regressions', () => {
       backfills: {},
       activeBackfillId: null,
       inFlight: true,
+      progressInFlight: true,
+      starsSyncInFlight: true,
       organizeJobActive: true,
     };
     const snapshot: SyncStatus = {
@@ -132,13 +136,16 @@ describe('Status/token regressions', () => {
       seenTooltips: 3,
       backfills: {},
       activeBackfillId: null,
-      inFlight: false,
+      inFlight: true,
+      progressInFlight: false,
+      starsSyncInFlight: false,
       organizeJobActive: false,
     };
     const merged = mergeStatusSnapshot(current, snapshot);
     assert.ok(merged);
-    assert.deepEqual(merged!.progress, current.progress);
+    assert.deepEqual(merged!.progress, snapshot.progress);
     assert.equal(merged!.inFlight, true);
+    assert.equal(merged!.progressInFlight, false);
     assert.equal(merged!.organizeJobActive, false);
   });
 

--- a/tests/regressions/storage/watch-store-regression.test.ts
+++ b/tests/regressions/storage/watch-store-regression.test.ts
@@ -4,16 +4,19 @@ import { afterAll, beforeEach, describe, it, vi } from 'vitest';
 import { db } from '@/storage/db';
 import { createChromeMock } from '../../helpers/chrome-mock';
 import {
+  appendWatchInboxHistory,
   applyWatchThreadMutation,
   clearWatchData,
   countUnreadWatchThreads,
   disconnectWatchInbox,
   getWatchRepositories,
   getWatchState,
+  markWatchInboxLoaded,
   queryStoredWatchInbox,
   reconcileWatchAccount,
   reconcileWatchLiveStars,
   recordWatchInboxFailure,
+  recordWatchHistoryFailure,
   recordWatchScopeFailure,
   replaceWatchInbox,
   replaceWatchScope,
@@ -331,6 +334,8 @@ describe('Watch snapshot storage', () => {
       nextAllowedAt: null,
       candidateCount: 4,
       truncated: true,
+      historyBefore: FIRST,
+      historyNextPage: 11,
       mode: 'replace',
     });
 
@@ -350,6 +355,108 @@ describe('Watch snapshot storage', () => {
     assert.equal(result.state?.inbox.matchedCount, 2);
     assert.equal(result.state?.inbox.candidateCount, 5);
     assert.equal(result.state?.inbox.truncated, true);
+  });
+
+  it('keeps the head refresh boundary independent while appending frozen history pages', async () => {
+    await db.stars.put(star('owner/repo'));
+    await replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads: [thread('1')],
+      attemptedAt: FIRST,
+      successfulAt: FIRST,
+      lastModified: 'Wed, 05 Aug 2026 01:00:00 GMT',
+      nextAllowedAt: null,
+      candidateCount: 1,
+      truncated: true,
+      historyBefore: FIRST,
+      historyNextPage: 11,
+      mode: 'replace',
+      requireLiveStars: true,
+    });
+    await markWatchInboxLoaded({ accountLogin: ACCOUNT, loadedAt: FIRST });
+    const refreshed = await replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads: [thread('2')],
+      attemptedAt: SECOND,
+      successfulAt: SECOND,
+      lastModified: 'Wed, 05 Aug 2026 02:00:00 GMT',
+      nextAllowedAt: null,
+      candidateCount: 1,
+      truncated: true,
+      historyBefore: SECOND,
+      historyNextPage: 11,
+      mode: 'merge',
+      requireLiveStars: true,
+    });
+
+    assert.equal(refreshed.inbox.newerThan, FIRST);
+    assert.equal(refreshed.inbox.historyBefore, FIRST);
+    assert.equal(refreshed.inbox.historyNextPage, 11);
+
+    const appended = await appendWatchInboxHistory({
+      accountLogin: ACCOUNT,
+      historyBefore: FIRST,
+      historyPage: 11,
+      threads: [thread('3')],
+      candidateCount: 1,
+      nextPage: 13,
+      requireLiveStars: true,
+    });
+    assert.equal(appended.applied, true);
+    assert.equal(appended.addedCount, 1);
+    assert.equal(appended.state?.inbox.lastSuccessfulAt, SECOND);
+    assert.equal(appended.state?.inbox.newerThan, FIRST);
+    assert.equal(appended.state?.inbox.historyNextPage, 13);
+    assert.equal(appended.state?.inbox.historyExhausted, false);
+
+    await recordWatchHistoryFailure({
+      accountLogin: ACCOUNT,
+      historyBefore: FIRST,
+      historyPage: 13,
+      errorCode: 'rate_limited',
+    });
+    const failed = await getWatchState(ACCOUNT);
+    assert.equal(failed?.inbox.errorCode, null);
+    assert.equal(failed?.inbox.historyErrorCode, 'rate_limited');
+    assert.equal(failed?.inbox.historyNextPage, 13);
+  });
+
+  it('rejects malformed history cursors before committing Watch state', async () => {
+    const replaceInput = {
+      accountLogin: ACCOUNT,
+      threads: [thread('1')],
+      attemptedAt: FIRST,
+      lastModified: null,
+      nextAllowedAt: null,
+      candidateCount: 1,
+      truncated: true,
+      historyBefore: FIRST,
+      mode: 'replace' as const,
+    };
+    await assert.rejects(
+      replaceWatchInbox({ ...replaceInput, historyNextPage: 1.5 }),
+      /positive safe integer/u,
+    );
+    await replaceWatchInbox({ ...replaceInput, historyNextPage: 11 });
+
+    await assert.rejects(appendWatchInboxHistory({
+      accountLogin: ACCOUNT,
+      historyBefore: FIRST,
+      historyPage: 11,
+      threads: [thread('2')],
+      candidateCount: 1,
+      nextPage: 12.5,
+    }), /positive safe integer/u);
+    await assert.rejects(appendWatchInboxHistory({
+      accountLogin: ACCOUNT,
+      historyBefore: FIRST,
+      historyPage: 1.5,
+      threads: [thread('2')],
+      candidateCount: 1,
+      nextPage: 13,
+    }), /positive safe integer/u);
+
+    assert.equal((await getWatchState(ACCOUNT))?.inbox.historyNextPage, 11);
   });
 
   it('atomically removes cached rows that leave live Stars during a conditional merge', async () => {

--- a/tests/regressions/sync/background-queue-regression.test.ts
+++ b/tests/regressions/sync/background-queue-regression.test.ts
@@ -44,6 +44,26 @@ describe('Background queue regressions', () => {
     assert.equal(runner.isRunning(), false);
   });
 
+  it('tracks queued Stars sync separately from unrelated work', async () => {
+    const runner = createSerializedRunner();
+    let releaseUnrelated!: () => void;
+    const unrelatedDone = new Promise<void>((resolve) => {
+      releaseUnrelated = resolve;
+    });
+
+    const unrelated = runner.run(() => unrelatedDone);
+    const starsSync = runner.run(async () => {}, { kind: 'stars-sync' });
+
+    assert.equal(runner.isRunning(), true);
+    assert.equal(runner.isRunning('stars-sync'), true);
+    assert.equal(runner.isRunning('progress'), false);
+
+    releaseUnrelated();
+    await Promise.all([unrelated, starsSync]);
+    assert.equal(runner.isRunning(), false);
+    assert.equal(runner.isRunning('stars-sync'), false);
+  });
+
   it('continues the queue after a rejected job', async () => {
     const runner = createSerializedRunner();
     const events: string[] = [];
@@ -124,6 +144,7 @@ describe('Background queue regressions', () => {
 
     await Promise.resolve();
     assert.deepEqual(states, []);
+    assert.equal(jobQueue.isRunning('stars-sync'), true);
 
     releaseFirst();
     await fullSyncStartedPromise;
@@ -136,6 +157,7 @@ describe('Background queue regressions', () => {
     });
     await first;
     assert.deepEqual(states, ['running', 'done']);
+    assert.equal(jobQueue.isRunning('stars-sync'), false);
   });
 
   it('joins duplicate backfill requests onto one queued promise', async () => {

--- a/tests/runtime/extension-browser-smoke.mjs
+++ b/tests/runtime/extension-browser-smoke.mjs
@@ -1004,6 +1004,11 @@ async function seedWatchAndRadarFixture(extId) {
         candidateCount: 4,
         matchedCount: 3,
         truncated: true,
+        newerThan: '2026-08-05T12:00:00.000Z',
+        historyBefore: '2026-08-05T12:05:00.000Z',
+        historyNextPage: 11,
+        historyExhausted: false,
+        historyErrorCode: null,
       },
     });
     radarActivities.put({

--- a/tests/unit/background-sync-auto-tags-contract.test.ts
+++ b/tests/unit/background-sync-auto-tags-contract.test.ts
@@ -2,6 +2,16 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { backgroundSource, caseBlock } from '../helpers/background-case-block';
 
+function assertInsideSerializedJob(block: string, markers: readonly string[]) {
+  const boundary = block.indexOf('}, { kind:');
+  assert.notEqual(boundary, -1, 'serialized job boundary should exist');
+  for (const marker of markers) {
+    const position = block.indexOf(marker);
+    assert.notEqual(position, -1, `${marker} should exist`);
+    assert.ok(position < boundary, `${marker} should remain inside the serialized job`);
+  }
+}
+
 describe('background sync auto-tag contract', () => {
   it('does not keep the old sync auto-tag helper wired into background actions', () => {
     assert.doesNotMatch(backgroundSource, /sync-flow/);
@@ -13,7 +23,7 @@ describe('background sync auto-tag contract', () => {
     const block = caseBlock('syncIncremental', 'syncFull');
 
     assert.match(block, /githubStarSource\.syncIncremental\(\)/);
-    assert.match(block, /setIdleMessage\(m\.background\.incrementalDone\(result\.added\)\)/);
+    assert.match(block, /setIdleMessage\(m\.background\.incrementalDone\(syncResult\.added\)\)/);
     assert.match(block, /tagged: 0/);
     assert.doesNotMatch(block, /autoTagAll/);
     assert.doesNotMatch(block, /autoAssignDone/);
@@ -21,7 +31,7 @@ describe('background sync auto-tag contract', () => {
 
   it('runs full sync and backfill without auto-tagging or nested full-sync runners', () => {
     assert.match(backgroundSource, /const result = await githubStarSource\.syncFull\(\(p\) => setProgress\(p\)\);/);
-    assert.match(backgroundSource, /async function performFullSync\(\)\s*\{\s*return run\(performFullSyncJob\);\s*\}/);
+    assert.match(backgroundSource, /async function performFullSync\(\)\s*\{\s*return run\(performFullSyncJob, \{ kind: "stars-sync" \}\);\s*\}/);
     assert.match(backgroundSource, /setIdleMessage\(m\.background\.fullDone\(result\.added\)\)/);
 
     const fullBlock = caseBlock('syncFull', 'syncRescan');
@@ -40,8 +50,36 @@ describe('background sync auto-tag contract', () => {
     const block = caseBlock('autoAssignTags', 'gistPush');
 
     assert.match(block, /autoTagAll\(/);
-    assert.match(block, /setIdleMessage\(m\.background\.autoAssignDone\(t\.tagged\)\)/);
+    assert.match(block, /setIdleMessage\(m\.background\.autoAssignDone\(result\.tagged\)\)/);
     assert.doesNotMatch(block, /runBgsmAgentTurn\(/);
+  });
+
+  it('keeps progress completion side effects inside their serialized jobs', () => {
+    for (const [name, nextName, markers] of [
+      ['syncIncremental', 'syncFull', ['broadcastDataAndRecommendationsChanged()', 'finalizeTrackedOnboardingSync()', 'setIdleMessage(']],
+      ['syncRescan', 'autoAssignTags', ['broadcastDataAndRecommendationsChanged()', 'setIdleMessage(']],
+      ['autoAssignTags', 'gistPush', ['broadcastDataChanged()', 'setIdleMessage(']],
+      ['gistPull', 'getStatus', ['broadcastDataChanged()', 'setIdleMessage(']],
+    ] as const) {
+      assertInsideSerializedJob(caseBlock(name, nextName), markers);
+    }
+  });
+
+  it('keeps tracked onboarding failure persistence in the background owner', () => {
+    assert.match(backgroundSource, /async function failTrackedOnboardingSync\(\): Promise<void>/);
+    assert.match(
+      caseBlock('syncIncremental', 'syncFull'),
+      /if \(!\(await authStore\.hasToken\(\)\)\) \{\s*await failTrackedOnboardingSync\(\);\s*return \{ ok: false/,
+    );
+    assert.match(
+      caseBlock('syncFull', 'syncRescan'),
+      /if \(!\(await authStore\.hasToken\(\)\)\) \{\s*await failTrackedOnboardingSync\(\);\s*return \{ ok: false/,
+    );
+    const handleFailure = backgroundSource.slice(backgroundSource.indexOf('async function handle('));
+    assert.match(
+      handleFailure,
+      /catch \(e\) \{\s*if \(req\.type === "syncIncremental" \|\| req\.type === "syncFull"\) \{\s*await failTrackedOnboardingSync\(\);/,
+    );
   });
 
   it('keeps local auto-tagging out of every automatic sync/backfill path', () => {

--- a/tests/unit/background-watch-refresh.test.ts
+++ b/tests/unit/background-watch-refresh.test.ts
@@ -121,6 +121,7 @@ function inboxSnapshot(overrides: Partial<WatchNotificationSnapshot> = {}): Watc
     matchedCount: 1,
     pageCount: 1,
     truncated: false,
+    nextPage: null,
     notModified: false,
     before: new Date(NOW).toISOString(),
     fetchedAt: new Date(NOW).toISOString(),
@@ -250,9 +251,12 @@ function harness(input: {
       replaceScope: watchStore.replaceWatchScope,
       recordScopeFailure: watchStore.recordWatchScopeFailure,
       replaceInbox: watchStore.replaceWatchInbox,
+      appendHistory: watchStore.appendWatchInboxHistory,
+      markLoaded: watchStore.markWatchInboxLoaded,
       getNotificationThread: watchStore.getWatchNotificationThread,
       revalidateInbox: watchStore.revalidateWatchInbox,
       recordInboxFailure: watchStore.recordWatchInboxFailure,
+      recordHistoryFailure: watchStore.recordWatchHistoryFailure,
       disconnectInbox: input.disconnectInbox ?? watchStore.disconnectWatchInbox,
       applyThreadMutation: watchStore.applyWatchThreadMutation,
       clearData: watchStore.clearWatchData,
@@ -369,6 +373,11 @@ describe('Watch background refresh coordinator', () => {
         candidateCount: 0,
         matchedCount: 0,
         truncated: false,
+        newerThan: null,
+        historyBefore: null,
+        historyNextPage: null,
+        historyExhausted: true,
+        historyErrorCode: null,
       },
     });
     const mutateNotification = vi.fn(async ({ threadId }: { threadId: string }) => {
@@ -410,6 +419,11 @@ describe('Watch background refresh coordinator', () => {
         candidateCount: 0,
         matchedCount: 0,
         truncated: false,
+        newerThan: null,
+        historyBefore: null,
+        historyNextPage: null,
+        historyExhausted: true,
+        historyErrorCode: null,
       },
     });
     const mutateNotification = vi.fn(async () => {
@@ -636,6 +650,128 @@ describe('Watch background refresh coordinator', () => {
     expect((await watchStore.queryStoredWatchInbox({ accountLogin: ACCOUNT })).threads).toHaveLength(1);
     expect(h.broadcastChanged).toHaveBeenCalledTimes(1);
   });
+
+  it('loads older Notifications from the persisted frozen epoch without advancing head refresh state', async () => {
+    const historyBefore = new Date(NOW).toISOString();
+    let request = 0;
+    const fetchNotifications = vi.fn(async () => {
+      request++;
+      return request === 1
+        ? inboxSnapshot({
+          threads: [thread('new')],
+          truncated: true,
+          nextPage: 11,
+          before: historyBefore,
+        })
+        : inboxSnapshot({
+          threads: [thread('old')],
+          pageCount: 2,
+          truncated: false,
+          nextPage: null,
+          before: historyBefore,
+        });
+    });
+    const h = harness({ fetchNotifications });
+
+    await h.coordinator.refresh();
+    const headState = await watchStore.getWatchState(ACCOUNT);
+    const result = await h.coordinator.loadOlder();
+
+    expect(fetchNotifications).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      token: 'watch-token',
+      before: historyBefore,
+      startPage: 11,
+      maxPages: 2,
+    }));
+    expect(result.addedCount).toBe(1);
+    expect(result.hasMore).toBe(false);
+    const stored = await watchStore.queryStoredWatchInbox({ accountLogin: ACCOUNT });
+    expect(stored.threads.map((item) => item.id).sort()).toEqual(['new', 'old']);
+    expect(stored.state?.inbox.lastSuccessfulAt).toBe(headState?.inbox.lastSuccessfulAt);
+    expect(stored.state?.inbox.historyBefore).toBe(historyBefore);
+    expect(stored.state?.inbox.historyNextPage).toBeNull();
+    expect(stored.state?.inbox.historyExhausted).toBe(true);
+    expect(stored.state?.inbox.truncated).toBe(false);
+  });
+
+  it('keeps the historical cursor retryable when an older-page request fails', async () => {
+    let request = 0;
+    const fetchNotifications = vi.fn(async () => {
+      request++;
+      if (request === 1) {
+        return inboxSnapshot({ truncated: true, nextPage: 11 });
+      }
+      throw new GitHubWatchError('rate_limited');
+    });
+    const h = harness({ fetchNotifications });
+    await h.coordinator.refresh();
+
+    await expect(h.coordinator.loadOlder()).rejects.toMatchObject({ code: 'rate_limited' });
+
+    const state = await watchStore.getWatchState(ACCOUNT);
+    expect(state?.inbox.errorCode).toBeNull();
+    expect(state?.inbox.historyNextPage).toBe(11);
+    expect(state?.inbox.historyExhausted).toBe(false);
+    expect(state?.inbox.historyErrorCode).toBe('rate_limited');
+  });
+
+  it('rejects a malformed persisted history page before issuing a request', async () => {
+    await watchStore.replaceWatchInbox({
+      accountLogin: ACCOUNT,
+      threads: [thread()],
+      attemptedAt: new Date(NOW).toISOString(),
+      lastModified: null,
+      nextAllowedAt: null,
+      candidateCount: 1,
+      truncated: true,
+      historyBefore: new Date(NOW).toISOString(),
+      historyNextPage: 11,
+      mode: 'replace',
+    });
+    const stored = await db.watchState.get('singleton');
+    if (!stored) throw new Error('Expected seeded Watch state.');
+    await db.watchState.put({
+      ...stored,
+      inbox: {
+        ...stored.inbox,
+        historyNextPage: 1.5,
+        historyExhausted: false,
+      },
+    });
+    const h = harness();
+
+    await expect(h.coordinator.loadOlder()).rejects.toMatchObject({ code: 'invalid_pagination' });
+
+    expect(h.fetchNotifications).not.toHaveBeenCalled();
+    expect((await watchStore.getWatchState(ACCOUNT))?.inbox.historyErrorCode)
+      .toBe('invalid_pagination');
+  });
+
+  it('merges unvalidated head polls without advancing the visible-load watermark', async () => {
+    let clock = NOW;
+    let request = 0;
+    const fetchNotifications = vi.fn(async () => {
+      request++;
+      return inboxSnapshot({
+        threads: [thread(String(request))],
+        lastModified: null,
+        before: new Date(clock).toISOString(),
+        fetchedAt: new Date(clock).toISOString(),
+      });
+    });
+    const h = harness({ fetchNotifications, now: () => clock });
+    await h.coordinator.refresh();
+    const acknowledgedAt = await h.coordinator.markLoaded();
+
+    clock += 61_000;
+    await h.coordinator.refreshInbox();
+
+    const stored = await watchStore.queryStoredWatchInbox({ accountLogin: ACCOUNT });
+    expect(stored.threads.map((item) => item.id).sort()).toEqual(['1', '2']);
+    expect(stored.state?.inbox.lastModified).toBeNull();
+    expect(stored.state?.inbox.newerThan).toBe(acknowledgedAt);
+  });
+
   it('refreshes native membership but skips Notifications during Inbox cooldown', async () => {
     await watchStore.replaceWatchScope({
       accountLogin: ACCOUNT,

--- a/tests/unit/extension-manager-runtime.test.ts
+++ b/tests/unit/extension-manager-runtime.test.ts
@@ -127,6 +127,21 @@ describe('ExtensionManagerRuntime', () => {
     ]);
   });
 
+  it('maps Watch history and visible-load commands to dedicated envelopes', async () => {
+    const historyResult = { addedCount: 2, hasMore: true, status: {} };
+    adapterMocks.bgCall
+      .mockResolvedValueOnce(historyResult)
+      .mockResolvedValueOnce('2026-08-16T12:00:00.000Z');
+    const runtime = new ExtensionManagerRuntime();
+
+    await expect(runtime.loadOlderWatch()).resolves.toBe(historyResult);
+    await expect(runtime.markWatchLoaded()).resolves.toBe('2026-08-16T12:00:00.000Z');
+    expect(adapterMocks.bgCall.mock.calls).toEqual([
+      ['loadOlderWatchInbox'],
+      ['markWatchInboxLoaded'],
+    ]);
+  });
+
   it('maps lightweight preferences and strips extension-only account fields', async () => {
     const runtime = new ExtensionManagerRuntime();
     await expect(runtime.getAccount()).resolves.toEqual({

--- a/tests/unit/github-watch-sources.test.ts
+++ b/tests/unit/github-watch-sources.test.ts
@@ -228,6 +228,7 @@ describe('GitHub Watch API sources', () => {
     expect(result.lastModified).toBe('Wed, 05 Aug 2026 03:04:05 GMT');
     expect(result.pollIntervalSeconds).toBe(90);
     expect(result.truncated).toBe(false);
+    expect(result.nextPage).toBeNull();
     expect(result.threads.map((thread) => [thread.id, thread.reason, thread.subjectType]))
       .toEqual([
         ['1', 'future_reason', 'PullRequest'],
@@ -260,6 +261,7 @@ describe('GitHub Watch API sources', () => {
     });
 
     expect(result.notModified).toBe(true);
+    expect(result.nextPage).toBeNull();
     expect(result.threads).toEqual([]);
     expect(result.lastModified).toBe('Wed, 05 Aug 2026 03:04:05 GMT');
     expect(result.pollIntervalSeconds).toBe(120);
@@ -365,9 +367,60 @@ describe('GitHub Watch API sources', () => {
 
     expect(result.pageCount).toBe(3);
     expect(result.truncated).toBe(true);
+    expect(result.nextPage).toBe(4);
     expect(result.candidateCount).toBe(3);
     expect(fetchImpl).toHaveBeenCalledTimes(3);
   });
+
+  it('resumes a frozen Notifications epoch from its persisted next page', async () => {
+    const calls: Array<{ page: number; before: string | null; validator: string | null }> = [];
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      const url = new URL(String(input));
+      const page = Number(url.searchParams.get('page'));
+      calls.push({
+        page,
+        before: url.searchParams.get('before'),
+        validator: new Headers(init?.headers).get('if-modified-since'),
+      });
+      return jsonResponse([notification(String(page))], {
+        headers: {
+          link: `<https://api.github.com/notifications?all=true&participating=false&per_page=50&before=${encodeURIComponent(NOW)}&page=${page + 1}>; rel="next"`,
+        },
+      });
+    });
+
+    const result = await fetchGitHubNotifications({
+      token: 'classic_notifications',
+      before: NOW,
+      startPage: 11,
+      maxPages: 2,
+      lastModified: 'Wed, 05 Aug 2026 03:04:05 GMT',
+      fetchImpl,
+      now: () => NOW,
+    });
+
+    expect(calls).toEqual([
+      { page: 11, before: NOW, validator: null },
+      { page: 12, before: NOW, validator: null },
+    ]);
+    expect(result.nextPage).toBe(13);
+    expect(result.truncated).toBe(true);
+    expect(result.threads.map((item) => item.id)).toEqual(['11', '12']);
+  });
+
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1])(
+    'rejects malformed persisted Notifications page %s before fetching',
+    async (startPage) => {
+      const fetchImpl = vi.fn<typeof fetch>();
+      await expect(fetchGitHubNotifications({
+        token: 'classic_notifications',
+        before: NOW,
+        startPage,
+        fetchImpl,
+      })).rejects.toMatchObject({ code: 'invalid_pagination' });
+      expect(fetchImpl).not.toHaveBeenCalled();
+    },
+  );
 
   it('classifies malformed thread payloads with a stable error code', async () => {
     const fetchImpl = vi.fn<typeof fetch>(async () => jsonResponse([{ id: 'bad' }]));

--- a/tests/unit/logic.test.ts
+++ b/tests/unit/logic.test.ts
@@ -248,20 +248,25 @@ describe('Stars refresh policy', () => {
 });
 
 describe('Manager auto-sync gate', () => {
-  it('empty library without in-flight job triggers full sync', () => {
-    assert.equal(pickInitialSyncAction({ hasToken: true, inFlight: false }, 0), 'syncFull');
+  it('empty library without a Stars sync triggers full sync', () => {
+    assert.equal(pickInitialSyncAction({ hasToken: true, starsSyncInFlight: false }, 0), 'syncFull');
   });
 
-  it('existing library without in-flight job triggers incremental sync', () => {
-    assert.equal(pickInitialSyncAction({ hasToken: true, inFlight: false }, 12), 'syncIncremental');
+  it('existing library without a Stars sync triggers incremental sync', () => {
+    assert.equal(pickInitialSyncAction({ hasToken: true, starsSyncInFlight: false }, 12), 'syncIncremental');
   });
 
-  it('existing in-flight job blocks duplicate auto-sync on reopen', () => {
-    assert.equal(pickInitialSyncAction({ hasToken: true, inFlight: true }, 12), null);
+  it('unrelated background work does not block Stars startup', () => {
+    const watchOnlyStatus = { hasToken: true, inFlight: true, starsSyncInFlight: false };
+    assert.equal(pickInitialSyncAction(watchOnlyStatus, 12), 'syncIncremental');
+  });
+
+  it('an existing Stars sync blocks duplicate auto-sync on reopen', () => {
+    assert.equal(pickInitialSyncAction({ hasToken: true, starsSyncInFlight: true }, 12), null);
   });
 
   it('no token blocks auto-sync', () => {
-    assert.equal(pickInitialSyncAction({ hasToken: false, inFlight: false }, 12), null);
+    assert.equal(pickInitialSyncAction({ hasToken: false, starsSyncInFlight: false }, 12), null);
   });
 });
 

--- a/tests/unit/manager-panel-coach-auto-tags.test.tsx
+++ b/tests/unit/manager-panel-coach-auto-tags.test.tsx
@@ -158,6 +158,8 @@ function status(stage: SyncStatus['onboardingStage']): SyncStatus {
     backfills: {},
     activeBackfillId: null,
     inFlight: true,
+    progressInFlight: false,
+    starsSyncInFlight: true,
     organizeJobActive: false,
   };
 }

--- a/tests/unit/manager-panel-unstar.test.tsx
+++ b/tests/unit/manager-panel-unstar.test.tsx
@@ -163,12 +163,12 @@ vi.mock('@/ui/hooks/use-theme', () => ({
 }));
 
 vi.mock('@/ui/hooks/use-watch-inbox', () => ({
-  useWatchInbox: () => ({
+  useWatchInbox: ({ active = true }: { active?: boolean } = {}) => ({
     unreadOnly: true,
     setUnreadOnly: vi.fn(),
     collapsedRepositories: {},
     updateRepositoryCollapse: vi.fn(),
-    result: { unreadCount: 3, status: { inboxStatus: 'fresh' } },
+    result: active ? { unreadCount: 3, status: { inboxStatus: 'fresh' } } : null,
     loading: false,
     refreshing: false,
     error: null,
@@ -176,9 +176,9 @@ vi.mock('@/ui/hooks/use-watch-inbox', () => ({
     reload: vi.fn(),
   }),
 }));
-vi.mock('@/ui/hooks/use-radar', () => {
-  const radar = {
-    result: null,
+vi.mock('@/ui/hooks/use-radar', () => ({
+  useRadar: ({ active = true }: { active?: boolean } = {}) => ({
+    result: active ? { unseenCount: 4 } : null,
     view: 'feed' as const,
     setView: managerMocks.radarSetView,
     loading: false,
@@ -192,12 +192,11 @@ vi.mock('@/ui/hooks/use-radar', () => {
     setFavorite: vi.fn(),
     addTag: vi.fn(),
     dismiss: vi.fn(),
-  };
-  return { useRadar: () => radar };
-});
+  }),
+}));
 
 vi.mock('@/ui/hooks/use-manager-surface-badges', () => ({
-  useManagerSurfaceBadges: () => ({ watchUnreadCount: 3, radarUnseenCount: 0 }),
+  useManagerSurfaceBadges: () => ({ watchUnreadCount: 0, radarUnseenCount: 0 }),
 }));
 
 
@@ -266,12 +265,18 @@ vi.mock('@/ui/components/Toolbar', () => ({
     surface,
     onSurfaceChange,
     watchUnreadCount,
+    radarUnseenCount,
   }: {
     surface: 'stars' | 'watch' | 'radar';
     onSurfaceChange: (surface: 'stars' | 'watch' | 'radar') => void;
     watchUnreadCount: number;
+    radarUnseenCount: number;
   }) => (
-    <div data-testid="toolbar" data-watch-unread={watchUnreadCount}>
+    <div
+      data-testid="toolbar"
+      data-watch-unread={watchUnreadCount}
+      data-radar-unseen={radarUnseenCount}
+    >
       <button type="button" data-testid="stars-surface" onClick={() => onSurfaceChange('stars')}>
         Stars
       </button>
@@ -419,6 +424,14 @@ afterEach(() => {
 });
 
 describe('ManagerPanel unstar flow', () => {
+  it('starts Watch and Following resources on the initial Stars surface', () => {
+    const { container } = mountPanel();
+    const toolbar = container.querySelector('[data-testid="toolbar"]');
+
+    expect(toolbar?.getAttribute('data-watch-unread')).toBe('3');
+    expect(toolbar?.getAttribute('data-radar-unseen')).toBe('4');
+  });
+
   it('keeps row action commands stable across unrelated Manager surface rerenders', () => {
     const { container } = mountPanel();
     const initial = managerMocks.starsTableProps.at(-1);

--- a/tests/unit/manager-runtime-driven-ui.test.tsx
+++ b/tests/unit/manager-runtime-driven-ui.test.tsx
@@ -68,6 +68,8 @@ function createRuntime(resources: ManagerRuntime['resources'] = {
     getWatchRepositoryDetail: unused,
     getWatchSubjectDetail: unused,
     refreshWatch: unused,
+    loadOlderWatch: unused,
+    markWatchLoaded: async () => null,
     markWatchThreadsRead: unused,
     markWatchThreadsDone: unused,
     updateWatchCollapse: async () => {},

--- a/tests/unit/manager-sync-actions.test.tsx
+++ b/tests/unit/manager-sync-actions.test.tsx
@@ -28,6 +28,8 @@ function baseStatus(patch: Partial<SyncStatus> = {}): SyncStatus {
     backfills,
     activeBackfillId: null,
     inFlight: false,
+    progressInFlight: false,
+    starsSyncInFlight: false,
     organizeJobActive: false,
     ...patch,
   };
@@ -174,18 +176,27 @@ describe('useManagerSyncActions', () => {
     expect(storageListeners).toHaveLength(0);
   });
 
-  it('runs the initial sync and advances onboarding after data appears', async () => {
+  it('runs initial sync during unrelated work and uses the background terminal stage', async () => {
     const refreshStars = vi.fn();
-    const queryGrandTotals = [0, 3];
-    sendMessage.mockImplementation((message: { type: string }) => {
+    let onboardingStage: SyncStatus['onboardingStage'] = 'awaiting_sync';
+    sendMessage.mockImplementation((message: { type: string; stage?: SyncStatus['onboardingStage'] }) => {
       if (message.type === 'getStatus') {
-        return ok(baseStatus({ hasToken: true, onboardingStage: 'awaiting_sync' }));
+        return ok(baseStatus({
+          hasToken: true,
+          onboardingStage,
+          inFlight: true,
+          starsSyncInFlight: false,
+        }));
       }
-      if (message.type === 'query') {
-        return ok({ grandTotal: queryGrandTotals.shift() ?? 3 });
+      if (message.type === 'query') return ok({ grandTotal: 0 });
+      if (message.type === 'setOnboardingStage') {
+        onboardingStage = message.stage ?? onboardingStage;
+        return ok();
       }
-      if (message.type === 'setOnboardingStage') return ok();
-      if (message.type === 'syncFull') return ok();
+      if (message.type === 'syncFull') {
+        onboardingStage = 'coach';
+        return ok();
+      }
       throw new Error(`Unexpected message: ${message.type}`);
     });
 
@@ -199,13 +210,18 @@ describe('useManagerSyncActions', () => {
     });
 
     expect(sendMessage).toHaveBeenCalledWith({ type: 'setOnboardingStage', stage: 'syncing' });
-    expect(sendMessage).toHaveBeenCalledWith({ type: 'setOnboardingStage', stage: 'coach' });
+    expect(sendMessage).not.toHaveBeenCalledWith({ type: 'setOnboardingStage', stage: 'coach' });
   });
 
   it('keeps sync failure visible and marks onboarding as failed', async () => {
     sendMessage.mockImplementation((message: { type: string }) => {
       if (message.type === 'getStatus') {
-        return ok(baseStatus({ hasToken: true, onboardingStage: 'awaiting_sync', inFlight: true }));
+        return ok(baseStatus({
+          hasToken: true,
+          onboardingStage: 'awaiting_sync',
+          inFlight: true,
+          starsSyncInFlight: true,
+        }));
       }
       if (message.type === 'setOnboardingStage') return ok();
       if (message.type === 'syncFull') return fail('network-down');

--- a/tests/unit/onboarding-first-run.test.ts
+++ b/tests/unit/onboarding-first-run.test.ts
@@ -19,6 +19,8 @@ function status(patch: Partial<SyncStatus> = {}): SyncStatus {
     backfills: {},
     activeBackfillId: null,
     inFlight: false,
+    progressInFlight: false,
+    starsSyncInFlight: false,
     organizeJobActive: false,
     ...patch,
   };
@@ -62,18 +64,23 @@ describe('onboarding first-run invariants', () => {
       hasToken: true,
       onboardingStage: 'syncing',
       inFlight: true,
+      progressInFlight: true,
+      starsSyncInFlight: true,
     });
     const snapshot = status({
       progress: { phase: 'idle', done: 0, total: null, message: '' },
       hasToken: true,
       onboardingStage: 'syncing',
-      inFlight: false,
+      inFlight: true,
+      progressInFlight: true,
+      starsSyncInFlight: true,
     });
 
     const merged = mergeStatusSnapshot(current, snapshot);
     assert.deepEqual(merged?.progress, current.progress);
     assert.equal(merged?.onboardingStage, 'syncing');
     assert.equal(merged?.inFlight, true);
+    assert.equal(merged?.progressInFlight, true);
   });
 
   it('turns onboarding stage patches into normalized terminal/runtime status', () => {
@@ -82,12 +89,20 @@ describe('onboarding first-run invariants', () => {
       hasToken: true,
       onboardingStage: 'syncing',
       inFlight: true,
+      progressInFlight: true,
+      starsSyncInFlight: true,
     });
 
-    const failed = mergeStatusPatch(syncing, { onboardingStage: 'sync_failed', inFlight: false });
+    const failed = mergeStatusPatch(syncing, {
+      onboardingStage: 'sync_failed',
+      inFlight: false,
+      progressInFlight: false,
+      starsSyncInFlight: false,
+    });
     assert.equal(failed.onboardingStage, 'sync_failed');
     assert.equal(failed.seenOnboarding, false);
     assert.equal(failed.inFlight, false);
+    assert.equal(failed.progressInFlight, false);
     assert.deepEqual(failed.progress, syncing.progress);
 
     const done = mergeStatusPatch(failed, { onboardingStage: 'done' });

--- a/tests/unit/use-watch-inbox.test.tsx
+++ b/tests/unit/use-watch-inbox.test.tsx
@@ -101,14 +101,40 @@ function cooldownResponse(
       candidateCount: totalCount,
       matchedCount: totalCount,
       truncated: false,
+      newerThan: null,
+      historyBefore: '2026-08-05T11:59:00Z',
+      historyNextPage: null,
+      historyExhausted: true,
+      historyErrorCode: null,
     },
   };
   return response;
 }
 
-function WatchProbe({ initialActive = true }: { initialActive?: boolean } = {}) {
+function loadedResponse(
+  totalCount: number,
+  newerThan: string,
+  historyNextPage: number | null = 11,
+): WatchInboxQueryResponse {
+  const response = cooldownResponse(totalCount, '2026-08-05T12:00:00Z');
+  response.status.inboxStatus = 'fresh';
+  response.status.state!.inbox.nextAllowedAt = null;
+  response.status.state!.inbox.newerThan = newerThan;
+  response.status.state!.inbox.historyNextPage = historyNextPage;
+  response.status.state!.inbox.historyExhausted = historyNextPage === null;
+  return response;
+}
+
+function WatchProbe({
+  initialActive = true,
+  initialVisible = false,
+}: {
+  initialActive?: boolean;
+  initialVisible?: boolean;
+} = {}) {
   const [active, setActive] = useState(initialActive);
-  const inbox = useWatchInbox({ active });
+  const [visible, setVisible] = useState(initialVisible);
+  const inbox = useWatchInbox({ active, visible });
   return (
     <div>
       <button type="button" data-testid="activate" onClick={() => setActive(true)}>
@@ -116,6 +142,12 @@ function WatchProbe({ initialActive = true }: { initialActive?: boolean } = {}) 
       </button>
       <button type="button" data-testid="deactivate" onClick={() => setActive(false)}>
         Deactivate
+      </button>
+      <button type="button" data-testid="show" onClick={() => setVisible(true)}>
+        Show Watch
+      </button>
+      <button type="button" data-testid="hide" onClick={() => setVisible(false)}>
+        Hide Watch
       </button>
       <button type="button" data-testid="all" onClick={() => inbox.setUnreadOnly(false)}>
         All
@@ -125,6 +157,9 @@ function WatchProbe({ initialActive = true }: { initialActive?: boolean } = {}) 
       </button>
       <button type="button" data-testid="refresh" onClick={() => void inbox.refresh()}>
         Refresh
+      </button>
+      <button type="button" data-testid="load-older" onClick={() => void inbox.loadOlder()}>
+        Load older
       </button>
       <button
         type="button"
@@ -158,6 +193,9 @@ function WatchProbe({ initialActive = true }: { initialActive?: boolean } = {}) 
       <span data-testid="active">{active ? 'active' : 'dormant'}</span>
       <span data-testid="loading">{inbox.loading ? 'loading' : 'ready'}</span>
       <span data-testid="count">{inbox.result?.totalCount ?? 'none'}</span>
+      <span data-testid="boundary">{inbox.newerThan ?? 'none'}</span>
+      <span data-testid="loading-older">{inbox.loadingOlder ? 'loading' : 'ready'}</span>
+      <span data-testid="load-older-error">{inbox.loadOlderError ? 'error' : 'none'}</span>
       <span data-testid="collapsed">
         {Object.keys(inbox.collapsedRepositories).length}
       </span>
@@ -171,7 +209,7 @@ function WatchProbe({ initialActive = true }: { initialActive?: boolean } = {}) 
   );
 }
 
-function Harness(props: { initialActive?: boolean } = {}) {
+function Harness(props: { initialActive?: boolean; initialVisible?: boolean } = {}) {
   return <ManagerRuntimeProvider runtime={runtime}><WatchProbe {...props} /></ManagerRuntimeProvider>;
 }
 
@@ -256,6 +294,95 @@ describe('useWatchInbox', () => {
     expect(watchMocks.bgCall).toHaveBeenCalledTimes(1);
     expect(container.querySelector('[data-testid="loading"]')?.textContent).toBe('ready');
     expect(container.querySelector('[data-testid="count"]')?.textContent).toBe('1');
+  });
+
+  it('holds the previous Watch-load boundary stable for one visible visit', async () => {
+    const firstBoundary = '2026-08-04T10:00:00.000Z';
+    const nextBoundary = '2026-08-05T10:00:00.000Z';
+    let queryCount = 0;
+    watchMocks.bgCall.mockImplementation((type: string) => {
+      if (type === 'markWatchInboxLoaded') return Promise.resolve(nextBoundary);
+      if (type === 'queryWatchInbox') {
+        queryCount++;
+        return Promise.resolve(loadedResponse(
+          2,
+          queryCount === 1 ? firstBoundary : nextBoundary,
+        ));
+      }
+      throw new Error(`Unexpected request: ${type}`);
+    });
+    const container = mountReact(<Harness initialVisible />, mountedRoots);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-testid="boundary"]')?.textContent).toBe(firstBoundary);
+    expect(watchMocks.bgCall.mock.calls.filter(([type]) => type === 'markWatchInboxLoaded'))
+      .toHaveLength(1);
+
+    await act(async () => {
+      runtimeListeners[0]?.({ type: 'watchChanged' });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-testid="boundary"]')?.textContent).toBe(firstBoundary);
+
+    await click(container.querySelector<HTMLButtonElement>('[data-testid="hide"]')!);
+    await click(container.querySelector<HTMLButtonElement>('[data-testid="show"]')!);
+    expect(container.querySelector('[data-testid="boundary"]')?.textContent).toBe(nextBoundary);
+    expect(watchMocks.bgCall.mock.calls.filter(([type]) => type === 'markWatchInboxLoaded'))
+      .toHaveLength(2);
+  });
+
+  it('loads an older page and then reloads the saved Watch projection', async () => {
+    const older = deferred<unknown>();
+    let queryCount = 0;
+    watchMocks.bgCall.mockImplementation((type: string) => {
+      if (type === 'queryWatchInbox') {
+        queryCount++;
+        return Promise.resolve(loadedResponse(queryCount, '2026-08-04T10:00:00.000Z'));
+      }
+      if (type === 'loadOlderWatchInbox') return older.promise;
+      throw new Error(`Unexpected request: ${type}`);
+    });
+    const container = mountReact(<Harness />, mountedRoots);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await click(container.querySelector<HTMLButtonElement>('[data-testid="load-older"]')!);
+    expect(container.querySelector('[data-testid="loading-older"]')?.textContent).toBe('loading');
+    await act(async () => {
+      older.resolve({});
+      await older.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(queryCount).toBe(2);
+    expect(container.querySelector('[data-testid="count"]')?.textContent).toBe('2');
+    expect(container.querySelector('[data-testid="loading-older"]')?.textContent).toBe('ready');
+    expect(container.querySelector('[data-testid="load-older-error"]')?.textContent).toBe('none');
+  });
+
+  it('restores a persisted historical-load failure on a new hook mount', async () => {
+    const persistedFailure = loadedResponse(1, '2026-08-04T10:00:00.000Z');
+    persistedFailure.status.state!.inbox.historyErrorCode = 'rate_limited';
+    watchMocks.bgCall.mockImplementation((type: string) => {
+      if (type === 'queryWatchInbox') return Promise.resolve(persistedFailure);
+      throw new Error(`Unexpected request: ${type}`);
+    });
+
+    const container = mountReact(<Harness />, mountedRoots);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('[data-testid="load-older-error"]')?.textContent)
+      .toBe('error');
   });
 
   it('clears dormant cached rows on credential change and visibly reloads on activation', async () => {

--- a/tests/unit/watch-inbox-presentation.test.ts
+++ b/tests/unit/watch-inbox-presentation.test.ts
@@ -104,6 +104,11 @@ function queryResponse(): WatchInboxQueryResponse {
           candidateCount: 4,
           matchedCount: 4,
           truncated: false,
+          newerThan: null,
+          historyBefore: '2026-08-05T12:00:00Z',
+          historyNextPage: null,
+          historyExhausted: true,
+          historyErrorCode: null,
         },
       },
     },
@@ -170,44 +175,37 @@ describe('Watch inbox presentation filters', () => {
 });
 
 describe('Watch inbox flat rows', () => {
-  const groups: WatchInboxProjection['groups'] = [{
-    repositoryFullName: 'owner/alpha',
-    repositoryHtmlUrl: 'https://github.com/owner/alpha',
-    repositoryOwnerLogin: 'owner',
-    repositoryOwnerAvatarUrl: null,
-    latestUpdatedAt: threads[1].updatedAt,
-    threads: [threads[0], threads[1]],
-  }, {
-    repositoryFullName: 'owner/security',
-    repositoryHtmlUrl: 'https://github.com/owner/security',
-    repositoryOwnerLogin: 'owner',
-    repositoryOwnerAvatarUrl: null,
-    latestUpdatedAt: threads[2].updatedAt,
-    threads: [threads[2]],
-  }];
+  const timelineThreads: GitHubNotificationThread[] = [
+    { ...threads[2], updatedAt: '2026-08-05T12:00:00Z' },
+    { ...threads[1], updatedAt: '2026-08-05T11:00:00Z' },
+    { ...threads[0], updatedAt: '2026-08-04T12:00:00Z' },
+  ];
 
-  it('emits one stable header/thread stream and excludes collapsed repository threads', () => {
-    const rows = buildWatchInboxRows(groups, new Set(['owner/alpha']));
+  it('emits day, repository, and thread rows while excluding collapsed threads', () => {
+    const rows = buildWatchInboxRows(timelineThreads, new Set(['owner/security']));
 
     expect(rows.map((row) => row.key)).toEqual([
-      'repository:owner/alpha',
-      'thread:1',
-      'thread:2',
-      'repository:owner/security',
+      'day:2026-08-05',
+      'repository:2026-08-05:owner/security',
+      'thread:3',
+      'repository:2026-08-05:owner/alpha',
+      'day:2026-08-04',
+      'repository:2026-08-04:owner/alpha',
     ]);
     expect(rows.filter((row) => row.kind === 'thread').map((row) => row.thread.id))
-      .toEqual(['1', '2']);
-    expect(buildWatchInboxRows(groups, new Set()).map((row) => row.kind))
-      .toEqual(['repository', 'repository']);
+      .toEqual(['3']);
   });
 
-  it('finds adjacent logical threads across repository header boundaries', () => {
-    const rows = buildWatchInboxRows(groups, new Set(['owner/alpha', 'owner/security']));
+  it('finds adjacent logical threads across repository and day boundaries', () => {
+    const rows = buildWatchInboxRows(
+      timelineThreads,
+      new Set(['owner/alpha', 'owner/security']),
+    );
 
-    expect(adjacentWatchThreadRowIndex(rows, '2', 'ArrowDown')).toBe(4);
-    expect(adjacentWatchThreadRowIndex(rows, '3', 'ArrowUp')).toBe(2);
-    expect(adjacentWatchThreadRowIndex(rows, '2', 'Home')).toBe(1);
-    expect(adjacentWatchThreadRowIndex(rows, '1', 'End')).toBe(4);
+    expect(adjacentWatchThreadRowIndex(rows, '2', 'ArrowDown')).toBe(7);
+    expect(adjacentWatchThreadRowIndex(rows, '1', 'ArrowUp')).toBe(4);
+    expect(adjacentWatchThreadRowIndex(rows, '2', 'Home')).toBe(2);
+    expect(adjacentWatchThreadRowIndex(rows, '3', 'End')).toBe(7);
   });
 });
 

--- a/tests/unit/watch-inbox.test.tsx
+++ b/tests/unit/watch-inbox.test.tsx
@@ -100,6 +100,11 @@ function result(overrides: Partial<WatchInboxQueryResponse> = {}): WatchInboxQue
           candidateCount: threads.length,
           matchedCount: threads.length,
           truncated: false,
+          newerThan: null,
+          historyBefore: '2026-08-05T00:00:00Z',
+          historyNextPage: null,
+          historyExhausted: true,
+          historyErrorCode: null,
         },
       },
     },
@@ -161,13 +166,17 @@ function renderInbox(props: Partial<React.ComponentProps<typeof WatchInbox>> = {
     <ManagerRuntimeProvider runtime={runtime}>
       <WatchInbox
         result={result()}
+        newerThan={null}
         loading={false}
         refreshing={false}
+        loadingOlder={false}
+        loadOlderError={false}
         error={null}
         unreadOnly
         onUnreadOnlyChange={vi.fn()}
         onRefresh={vi.fn()}
         onRetryQuery={vi.fn()}
+        onLoadOlder={vi.fn()}
         onOpenOptions={vi.fn()}
         onOpenMainTokenOptions={vi.fn()}
         actionPending={null}
@@ -227,7 +236,7 @@ describe('WatchInbox', () => {
     expect(container.querySelector('[data-watch-thread-list]')
       ?.closest('[data-surface-work-canvas="watch"]')).not.toBeNull();
     expect(container.querySelector('[data-surface-list-end="timeline"]')?.textContent)
-      .toContain('End of current snapshot · 1 thread');
+      .toContain('All caught up · 1 thread');
 
     await click(findButtonByText(commandBar!, 'All'));
     const refresh = Array.from(commandBar?.querySelectorAll<HTMLButtonElement>('button') ?? [])
@@ -242,11 +251,76 @@ describe('WatchInbox', () => {
   it('uses an info tone when the fetched window is truncated', () => {
     const truncated = result();
     truncated.status.state!.inbox.truncated = true;
+    truncated.status.state!.inbox.historyNextPage = 11;
+    truncated.status.state!.inbox.historyExhausted = false;
     const container = renderInbox({ result: truncated });
     const marker = container.querySelector<HTMLElement>('[data-surface-list-end="timeline"]');
 
     expect(marker?.textContent).toContain('End of current window · older threads may exist');
     expect(marker?.getAttribute('data-surface-list-end-tone')).toBe('info');
+  });
+
+  it('groups threads by day and marks only updates after the prior visible load', () => {
+    const timelineResult = result({
+      threads: [
+        thread(1, { updatedAt: '2026-08-05T12:00:00Z' }),
+        thread(2, { updatedAt: '2026-08-04T12:00:00Z' }),
+      ],
+    });
+    const container = renderInbox({
+      result: timelineResult,
+      newerThan: '2026-08-05T11:30:00Z',
+    });
+
+    expect(Array.from(container.querySelectorAll('[data-watch-day]'), (node) => (
+      node.getAttribute('data-watch-day')
+    ))).toEqual(['2026-08-05', '2026-08-04']);
+    expect(container.querySelector('[data-watch-thread-row="1"]')?.getAttribute('data-watch-new'))
+      .toBe('true');
+    expect(container.querySelector('[data-watch-thread-row="2"]')?.hasAttribute('data-watch-new'))
+      .toBe(false);
+    expect(container.textContent).toContain('New');
+  });
+
+  it('loads history when intersection arrives after the scroll that revealed the sentinel', async () => {
+    let revealSentinel = () => {};
+    vi.stubGlobal('IntersectionObserver', class {
+      constructor(callback: (entries: Array<{ isIntersecting: boolean }>) => void) {
+        revealSentinel = () => callback([{ isIntersecting: true }]);
+      }
+      observe() {}
+      disconnect() {}
+    });
+    const paged = result();
+    paged.status.state!.inbox.truncated = true;
+    paged.status.state!.inbox.historyNextPage = 11;
+    paged.status.state!.inbox.historyExhausted = false;
+    const onLoadOlder = vi.fn();
+
+    const container = renderInbox({ result: paged, onLoadOlder });
+    await act(async () => { await Promise.resolve(); });
+    expect(onLoadOlder).not.toHaveBeenCalled();
+
+    await act(async () => { window.dispatchEvent(new Event('scroll')); });
+    expect(onLoadOlder).not.toHaveBeenCalled();
+    await act(async () => { revealSentinel(); });
+
+    expect(container.querySelector('[data-watch-history-sentinel="more"]')).not.toBeNull();
+    expect(onLoadOlder).toHaveBeenCalledOnce();
+  });
+
+  it('keeps failed historical loads retryable without hiding saved rows', async () => {
+    const paged = result();
+    paged.status.state!.inbox.truncated = true;
+    paged.status.state!.inbox.historyNextPage = 11;
+    paged.status.state!.inbox.historyExhausted = false;
+    const onLoadOlder = vi.fn();
+    const container = renderInbox({ result: paged, loadOlderError: true, onLoadOlder });
+
+    expect(container.textContent).toContain('Your saved timeline is unchanged.');
+    expect(container.textContent).toContain('Thread 0');
+    await click(findButtonByText(container, 'Retry'));
+    expect(onLoadOlder).toHaveBeenCalledOnce();
   });
 
   it('distinguishes a query failure from missing main-token setup', () => {


### PR DESCRIPTION
## Summary

- add paged Watch Inbox history and visit markers while keeping routine refresh bounded
- distinguish Stars sync from unrelated serialized background work
- persist first-run sync success and failure in the background so reloads recover the correct UI state
- cover Watch history, task-specific activity, onboarding recovery, and runtime behavior

## Verification

- `pnpm typecheck`
- `pnpm test:logic`
- `pnpm test:regressions`
- `pnpm build`
- `pnpm test:runtime`
- `pnpm test:smoke`
- Ego Browser first-run sync and reload smoke

## Not tested

- forced overlap against a live authenticated GitHub account