### PR TITLE
fix(edge): refresh clean release worker identity

### DIFF
--- a/scripts/package-manifest-closure.mjs
+++ b/scripts/package-manifest-closure.mjs
@@ -9,9 +9,9 @@ export const RELEASE_WORKER_BASELINE = Object.freeze({
   sha256: '902c0726442c96d00674910ae245ade7f1ad153ac4bbe742d3a3e366d7b41ea2',
 });
 export const EDGE_RELEASE_WORKER_BASELINE = Object.freeze({
-  relativePath: 'assets/index.ts-Byps2g7n.js',
-  bytes: WORKER_BYTE_CEILING,
-  sha256: '7b8c0ec9b60e7ee8c78f2c935e35192d37c0b7a5a2b2e566d347ad1ac7b9e21b',
+  relativePath: 'assets/index.ts-BpdUArVM.js',
+  bytes: 748_582,
+  sha256: '22478177c6493c22ae09fa730d24d0d72cd221b4c48fc543fc99b7e0ba457642',
 });
 
 const SHA256 = /^[0-9a-f]{64}$/u;

--- a/tests/unit/edge-platform-contracts.test.mjs
+++ b/tests/unit/edge-platform-contracts.test.mjs
@@ -213,9 +213,9 @@ test('uses one full-product manifest across Edge, Chrome, and Firefox', () => {
 
 test('uses an exact Edge worker baseline with the full-product identity shape', () => {
   assert.deepEqual(EDGE_RELEASE_WORKER_BASELINE, {
-    relativePath: 'assets/index.ts-Byps2g7n.js',
-    bytes: 741_693,
-    sha256: '7b8c0ec9b60e7ee8c78f2c935e35192d37c0b7a5a2b2e566d347ad1ac7b9e21b',
+    relativePath: 'assets/index.ts-BpdUArVM.js',
+    bytes: 748_582,
+    sha256: '22478177c6493c22ae09fa730d24d0d72cd221b4c48fc543fc99b7e0ba457642',
   });
   assert.deepEqual(Object.keys(EDGE_RELEASE_WORKER_BASELINE).sort(), ['bytes', 'relativePath', 'sha256']);
   const worker = {


### PR DESCRIPTION
## Problem
The Edge worker baseline merged in PR #72 matched a build made from an unrelated dirty worktree. A fresh package from committed `master` correctly failed with `worker_byte_ceiling_exceeded`, so that baseline could never approve the actual clean release package.

## Decision
Refresh only `EDGE_RELEASE_WORKER_BASELINE` and its exact regression fixture from the clean committed Edge bundle. The Chrome baseline remains unchanged.

Approved Edge worker identity:
- path: `assets/index.ts-BpdUArVM.js`
- bytes: `748582`
- SHA-256: `22478177c6493c22ae09fa730d24d0d72cd221b4c48fc543fc99b7e0ba457642`

## Check
- Passed: 44 focused Edge/evidence/package tests
- Passed: `pnpm typecheck`
- Passed: clean `GSM_APPROVED_RELEASE_VERSION=2.0.1 pnpm package:edge`
- Produced: Edge ZIP, checksum, and schema-version 4 provisional evidence
- Not run: real Microsoft Edge release smoke; Edge is not installed locally

## Risk
Narrow release-gate correction. No product runtime, manifest, permission, storage, or Chrome baseline behavior changes.