### PR TITLE
fix(manager): harden Agent, Radar, and Watch recovery

### DIFF
--- a/src/api/github-radar-source.ts
+++ b/src/api/github-radar-source.ts
@@ -18,6 +18,8 @@ const DEFAULT_STARS_PER_FOLLOWER = RADAR_STARS_PER_FOLLOWER;
 const DEFAULT_RATE_LIMIT_LOW_WATER = 50;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const DEFAULT_DEADLINE_MS = 120_000;
+const REQUEST_MAX_ATTEMPTS = 3;
+const REQUEST_RETRY_BASE_DELAY_MS = 500;
 
 const FOLLOWING_QUERY = `
   query RadarFollowing($cursor: String) {
@@ -188,6 +190,35 @@ function responseError(response: Response): GitHubRadarError {
     return new GitHubRadarError('github_unavailable', { status: response.status });
   }
   return new GitHubRadarError('invalid_response', { status: response.status });
+}
+
+async function retryTransientRequest<T>(
+  request: () => Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  for (let attempt = 1; attempt <= REQUEST_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      return await request();
+    } catch (error) {
+      const retryable = error instanceof GitHubRadarError
+        && (error.code === 'github_unavailable' || error.code === 'network_error');
+      if (!retryable || attempt === REQUEST_MAX_ATTEMPTS) throw error;
+
+      if (signal?.aborted) throw new GitHubRadarError('request_aborted');
+      await new Promise<void>((resolve, reject) => {
+        const onAbort = () => {
+          clearTimeout(timer);
+          reject(new GitHubRadarError('request_aborted'));
+        };
+        const timer = setTimeout(() => {
+          signal?.removeEventListener('abort', onAbort);
+          resolve();
+        }, REQUEST_RETRY_BASE_DELAY_MS * attempt);
+        signal?.addEventListener('abort', onAbort, { once: true });
+      });
+    }
+  }
+  throw new GitHubRadarError('github_unavailable');
 }
 
 async function fetchGraphql(
@@ -546,7 +577,10 @@ export async function fetchGitHubRadar(
   const partialReasons = new Set<RadarPartialReason>();
 
   while (hasNextPage && followingLogins.length < maxFollowing) {
-    const page = await fetchFollowingPage(fetchImpl, token, cursor, requestOptions());
+    const page = await retryTransientRequest(
+      () => fetchFollowingPage(fetchImpl, token, cursor, requestOptions()),
+      options.signal,
+    );
     if (accountLogin !== null && accountLogin !== page.accountLogin) {
       throw new GitHubRadarError('invalid_response');
     }
@@ -586,14 +620,17 @@ export async function fetchGitHubRadar(
     const targets = pending.slice(0, batchSize);
     let batch: ActivityBatch;
     try {
-      batch = await fetchActivityBatch(
-        fetchImpl,
-        token,
-        accountLogin,
-        targets,
-        starsPerFollower,
-        cutoffMillis,
-        requestOptions(),
+      batch = await retryTransientRequest(
+        () => fetchActivityBatch(
+          fetchImpl,
+          token,
+          accountLogin,
+          targets,
+          starsPerFollower,
+          cutoffMillis,
+          requestOptions(),
+        ),
+        options.signal,
       );
     } catch (error) {
       if (error instanceof GitHubRadarError && error.code === 'deadline_exceeded') {

--- a/src/ui/components/AgentHost.tsx
+++ b/src/ui/components/AgentHost.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
+import { canonicalJson } from '@/agent-harness/canonical-json';
 import type { BgsmAgentConversationCandidate } from '@/bgsm-agent/conversation-binding';
 import type { LaunchCandidateContract } from '@/bgsm-agent/scope';
 import { useI18n } from '@/i18n';
@@ -90,18 +91,22 @@ export function AgentHost({
     m.agentPanel,
     uiPresentation,
   ]);
-  const candidateContextKey = conversationCandidateContextKey(chatCandidate);
+  const candidateContextKey = useMemo(
+    () => conversationCandidateContextKey(chatCandidate),
+    [chatCandidate],
+  );
   const previousCandidateContextKeyRef = useRef(candidateContextKey);
-  const pendingCandidateContextKeyRef = useRef<string | null>(null);
+  const pendingCandidateContextKeyRef = useRef<string | null>(candidateContextKey);
   const pendingContextKey = candidateContextKey !== previousCandidateContextKeyRef.current
     ? candidateContextKey
     : pendingCandidateContextKeyRef.current;
-  const boundContextKey = agent.conversationBinding
+  const boundContextKey = useMemo(() => agent.conversationBinding
     ? conversationCandidateContextKey(agent.conversationBinding.candidateContract)
-    : null;
+    : null, [agent.conversationBinding]);
   // Organize ownership implies !canSwitchSession; while a candidate is blocked,
   // the effect cannot consume its pending switch before ownership releases and rerenders.
-  const blockedConversationCandidate = !organizeView.capabilities.canSwitchSession
+  const blockedConversationCandidate = agent.conversationBinding
+    && !organizeView.capabilities.canSwitchSession
     && pendingContextKey !== null
     && pendingContextKey !== boundContextKey
     ? chatCandidate
@@ -116,7 +121,7 @@ export function AgentHost({
     const queuedCandidateContextKey = pendingCandidateContextKeyRef.current;
     if (!queuedCandidateContextKey) return;
     if (!agent.conversationBinding) {
-      if (uiPresentation.sessionPolicy.canSwitchSession) {
+      if (agent.sessionReady && uiPresentation.sessionPolicy.canSwitchSession) {
         pendingCandidateContextKeyRef.current = null;
       }
       return;
@@ -137,6 +142,7 @@ export function AgentHost({
     agent.activeSessionId,
     agent.conversationBinding,
     agent.createSession,
+    agent.sessionReady,
     candidateContextKey,
     uiPresentation.sessionPolicy.canSwitchSession,
   ]);
@@ -162,9 +168,7 @@ export function AgentHost({
 }
 
 function conversationCandidateContextKey(candidate: BgsmAgentConversationCandidate): string {
-  return candidate.kind === 'selected_repository'
-    ? `selected_repository:${candidate.selectedRepositoryIdHint}`
-    : 'current_view';
+  return canonicalJson(candidate);
 }
 
 function resolveToolbarStatus(

--- a/src/ui/hooks/use-radar-activity-resource.ts
+++ b/src/ui/hooks/use-radar-activity-resource.ts
@@ -14,6 +14,8 @@ export function useRadarActivityResource(active: boolean) {
   const loadedRef = useRef(false);
   const generation = useRef(0);
   const refreshingRef = useRef(false);
+  const refreshEpoch = useRef(0);
+  const initialRefreshAttemptedRef = useRef(false);
   const cooldownProbeRef = useRef<{ deadline: string | null; attempts: number }>({
     deadline: null,
     attempts: 0,
@@ -25,6 +27,7 @@ export function useRadarActivityResource(active: boolean) {
     return () => {
       mountedRef.current = false;
       generation.current += 1;
+      refreshEpoch.current += 1;
     };
   }, []);
 
@@ -62,7 +65,9 @@ export function useRadarActivityResource(active: boolean) {
   useEffect(() => {
     if (!active) {
       generation.current += 1;
+      refreshEpoch.current += 1;
       setLoading(false);
+      setRefreshing(false);
       return;
     }
     void reload(loadedRef.current);
@@ -70,7 +75,9 @@ export function useRadarActivityResource(active: boolean) {
 
   const invalidateCredentials = useCallback(() => {
     generation.current += 1;
+    refreshEpoch.current += 1;
     loadedRef.current = false;
+    initialRefreshAttemptedRef.current = false;
     setResult(null);
     setError(null);
     setLoading(activeRef.current);
@@ -101,23 +108,44 @@ export function useRadarActivityResource(active: boolean) {
 
   const refresh = useCallback(async () => {
     if (!mountedRef.current || refreshingRef.current) return;
+    const requestEpoch = refreshEpoch.current;
+    const isCurrent = () => mountedRef.current && activeRef.current
+      && refreshEpoch.current === requestEpoch;
     refreshingRef.current = true;
+    initialRefreshAttemptedRef.current = true;
     setRefreshing(true);
     setError(null);
     try {
       const refreshResult = await runtime.refreshRadar();
+      if (!isCurrent()) return;
       await reload(true);
-      if (mountedRef.current && !refreshResult.published && refreshResult.status.errorCode) {
+      if (!isCurrent()) return;
+      if (!refreshResult.published && refreshResult.status.errorCode) {
         setError('refresh');
       }
     } catch {
+      if (!isCurrent()) return;
       await reload(true);
-      if (mountedRef.current) setError('refresh');
+      if (isCurrent()) setError('refresh');
     } finally {
       refreshingRef.current = false;
       if (mountedRef.current) setRefreshing(false);
     }
   }, [reload, runtime]);
+
+  useEffect(() => {
+    const status = result?.status;
+    if (
+      !active
+      || refreshing
+      || refreshingRef.current
+      || status?.refreshing === true
+      || initialRefreshAttemptedRef.current
+      || !status?.hasMainToken
+      || status.snapshotStatus !== 'never_loaded'
+    ) return;
+    void refresh();
+  }, [active, refresh, refreshing, result]);
 
   const markSeen = useCallback((activityIds: readonly string[]) => {
     const ids = [...new Set(activityIds)];

--- a/src/ui/hooks/use-watch-inbox.ts
+++ b/src/ui/hooks/use-watch-inbox.ts
@@ -8,6 +8,8 @@ import {
 import type { WatchCollapsedRepositorySignatures } from '@/types';
 import type { WatchThreadActionPending } from '@/ui/watch-inbox-types';
 
+const WATCH_EAGER_HISTORY_MAX_PAGE = 20;
+
 export function useWatchInbox({
   active = true,
   visible = false,
@@ -224,6 +226,26 @@ export function useWatchInbox({
       if (mountedRef.current) setLoadingOlder(false);
     }
   }, [load, runtime]);
+
+  const historyInbox = result?.status.state?.inbox ?? null;
+  const historyNextPage = historyInbox?.historyNextPage ?? null;
+  const shouldEagerlyLoadOlder = active
+    && visible
+    && historyNextPage != null
+    && historyNextPage <= WATCH_EAGER_HISTORY_MAX_PAGE
+    && historyInbox?.historyExhausted !== true
+    && historyInbox?.historyErrorCode == null
+    && error === null
+    && !refreshing
+    && result?.status.refreshing !== true
+    && !loadingOlder
+    && !loadOlderError;
+  useEffect(() => {
+    if (!shouldEagerlyLoadOlder) return;
+    // Pages 1-20 cover about 1,000 GitHub notification candidates. Fill that
+    // range on a visible visit; only larger histories need manual pagination.
+    void loadOlder();
+  }, [historyNextPage, loadOlder, shouldEagerlyLoadOlder]);
 
   const actionAccountLogin = result?.status.accountLogin ?? null;
 

--- a/tests/runtime/extension-browser-smoke.mjs
+++ b/tests/runtime/extension-browser-smoke.mjs
@@ -1050,7 +1050,7 @@ async function seedWatchAndRadarFixture(extId) {
         truncated: true,
         newerThan: '2026-08-05T12:00:00.000Z',
         historyBefore: '2026-08-05T12:05:00.000Z',
-        historyNextPage: 11,
+        historyNextPage: 21, // Exercise manual history beyond eager pages 1-20.
         historyExhausted: false,
         historyErrorCode: null,
       },

--- a/tests/unit/agent-host-repository-selection.test.tsx
+++ b/tests/unit/agent-host-repository-selection.test.tsx
@@ -11,7 +11,10 @@ import { parseScopeFingerprint } from '@/bgsm-agent/scope';
 import type { BgsmAgentTurnInput } from '@/bgsm-agent/session';
 import { AgentHost } from '@/ui/components/AgentHost';
 import type { BgsmAgentTurnHandlers } from '@/utils/messaging';
-import type { AgentSessionCommitResult } from '@/storage/agent-session-store';
+import type {
+  AgentSessionCommitResult,
+  LoadedAgentSession,
+} from '@/storage/agent-session-store';
 import {
   cleanupMountedRootsAndBody,
   click,
@@ -21,6 +24,12 @@ import {
 
 const messagingMocks = vi.hoisted(() => ({
   startBgsmAgentTurn: vi.fn(),
+  inspectCatalog: vi.fn(),
+  inspectActive: vi.fn(),
+  loadSession: vi.fn(),
+  getOrCreateSession: vi.fn(),
+  createSession: vi.fn(),
+  retryDraft: vi.fn(),
 }));
 const presentationMocks = vi.hoisted(() => ({
   ownsWorkbench: false,
@@ -34,6 +43,12 @@ vi.mock('@/utils/messaging', async (importOriginal) => {
   return {
     ...actual,
     startBgsmAgentTurn: messagingMocks.startBgsmAgentTurn,
+    inspectBgsmAgentSessionCatalog: messagingMocks.inspectCatalog,
+    inspectActiveBgsmAgentSessionTurn: messagingMocks.inspectActive,
+    loadDurableBgsmAgentSession: messagingMocks.loadSession,
+    getOrCreateInitialDurableBgsmAgentSession: messagingMocks.getOrCreateSession,
+    createDurableBgsmAgentSession: messagingMocks.createSession,
+    readDurableAgentRetryDraftCandidate: messagingMocks.retryDraft,
   };
 });
 
@@ -87,6 +102,17 @@ beforeEach(() => {
   presentationMocks.ownsWorkbench = false;
   workbenchMocks.releaseOwnership = null;
   messagingMocks.startBgsmAgentTurn.mockReset();
+  messagingMocks.inspectCatalog.mockReset();
+  messagingMocks.inspectActive.mockReset();
+  messagingMocks.inspectActive.mockResolvedValue(null);
+  messagingMocks.loadSession.mockReset();
+  messagingMocks.getOrCreateSession.mockReset();
+  messagingMocks.createSession.mockReset();
+  messagingMocks.createSession.mockImplementation(async (sessionId: string) => (
+    loadedEmptySession(sessionId)
+  ));
+  messagingMocks.retryDraft.mockReset();
+  messagingMocks.retryDraft.mockResolvedValue(null);
   messagingMocks.startBgsmAgentTurn.mockImplementation((
     input: BgsmAgentTurnInput,
     handlers: BgsmAgentTurnHandlers,
@@ -120,6 +146,46 @@ describe('AgentHost repository selection', () => {
     expect(turn.input.binding).toBeUndefined();
     expect(turn.input.baseRevision).toBe(0);
     expect(turn.input.history).toEqual([]);
+  });
+
+  it('starts a fresh conversation when the selected repository differs from the hydrated conversation', async () => {
+    const staleView = currentView('');
+    const hydrated = loadedBoundSession(
+      'session-stale-current-view',
+      conversationBinding(staleView, 'h'),
+    );
+    enableDurableSessions(hydrated);
+
+    const container = await mountHarness(selectedRepository('owner/repo-b'));
+    await flushEffects();
+
+    await expectSessionCount(container, 2);
+    expect(composerText(container)).toContain('owner/repo-b');
+    const turn = await sendPrompt(container, 'Inspect the selected repository');
+    expect(turn.input.sessionId).not.toBe(hydrated.session.id);
+    expect(turn.input.baseRevision).toBe(0);
+    expect(turn.input.candidateContract).toEqual(selectedRepository('owner/repo-b'));
+    expect(turn.input.binding).toBeUndefined();
+  });
+
+  it('starts a fresh conversation when the tag-filtered view differs from the hydrated conversation', async () => {
+    const staleView = currentView('');
+    const hydrated = loadedBoundSession(
+      'session-stale-unfiltered-view',
+      conversationBinding(staleView, 'i'),
+    );
+    enableDurableSessions(hydrated);
+    const taggedView = currentView('', ['agents']);
+
+    const container = await mountHarness(taggedView);
+    await flushEffects();
+
+    await expectSessionCount(container, 2);
+    const turn = await sendPrompt(container, 'Inspect the tagged view');
+    expect(turn.input.sessionId).not.toBe(hydrated.session.id);
+    expect(turn.input.baseRevision).toBe(0);
+    expect(turn.input.candidateContract).toEqual(taggedView);
+    expect(turn.input.binding).toBeUndefined();
   });
 
   it('starts a fresh conversation when an idle bound repository changes', async () => {
@@ -186,22 +252,22 @@ describe('AgentHost repository selection', () => {
     expect(container.querySelector<HTMLTextAreaElement>('textarea')?.disabled).toBe(false);
   });
 
-  it('does not rotate a bound current-view conversation when its filters change', async () => {
-    const initialView = currentView('alpha');
+  it('starts a fresh conversation when bound current-view tags change', async () => {
+    const initialView = currentView('');
     const container = await mountHarness(initialView);
     const first = await sendPrompt(container, 'Inspect this view');
-    const binding = conversationBinding(initialView, 'c');
-    await bindAndComplete(first, binding);
+    await bindAndComplete(first, conversationBinding(initialView, 'c'));
 
-    await click(actionButton(container, 'update-current-view'));
+    await click(actionButton(container, 'select-tag-agents'));
     await flushEffects();
 
-    await expectSessionCount(container, 1);
-    const second = await sendPrompt(container, 'Continue inspecting this view');
-    expect(second.input.sessionId).toBe(first.input.sessionId);
-    expect(second.input.baseRevision).toBe(1);
-    expect(second.input.candidateContract).toBeUndefined();
-    expect(second.input.binding).toEqual(binding);
+    await expectSessionCount(container, 2);
+    const second = await sendPrompt(container, 'Inspect the tagged view');
+    expect(second.input.sessionId).not.toBe(first.input.sessionId);
+    expect(second.input.baseRevision).toBe(0);
+    expect(second.input.history).toEqual([]);
+    expect(second.input.candidateContract).toEqual(currentView('', ['agents']));
+    expect(second.input.binding).toBeUndefined();
   });
 });
 
@@ -225,10 +291,10 @@ function Harness({ initialCandidate }: { initialCandidate: BgsmAgentConversation
       </button>
       <button
         type="button"
-        data-testid="update-current-view"
-        onClick={() => setCandidate(currentView('beta'))}
+        data-testid="select-tag-agents"
+        onClick={() => setCandidate(currentView('', ['agents']))}
       >
-        Update view
+        Select agents tag
       </button>
       <AgentHost
         open
@@ -400,13 +466,16 @@ function selectedRepository(selectedRepositoryIdHint: string): BgsmAgentConversa
   return { kind: 'selected_repository', selectedRepositoryIdHint };
 }
 
-function currentView(query: string): BgsmAgentConversationCandidate {
+function currentView(
+  query: string,
+  tags: readonly string[] = [],
+): BgsmAgentConversationCandidate {
   return {
     kind: 'current_view',
     filter: {
       query,
       languages: [],
-      tags: [],
+      tags,
       tagMode: 'any',
       showTombstone: false,
       onlyFavorite: false,
@@ -417,6 +486,47 @@ function currentView(query: string): BgsmAgentConversationCandidate {
       sortDir: 'desc',
     },
   };
+}
+
+function loadedBoundSession(
+  id: string,
+  binding: BgsmAgentConversationBinding,
+): LoadedAgentSession {
+  return {
+    session: { id, revision: 1, binding },
+    transcript: { sessionId: id, messages: [], nextBeforeSequence: null },
+    summary: { id, title: 'Previous conversation', createdAt: 1, updatedAt: 1 },
+    lastAppliedTurnAttemptId: `${id}:attempt`,
+    appliedTurnReceipts: [],
+  };
+}
+
+function loadedEmptySession(id: string): LoadedAgentSession {
+  return {
+    session: { id, revision: 0 },
+    transcript: { sessionId: id, messages: [], nextBeforeSequence: null },
+    summary: { id, title: '', createdAt: 1, updatedAt: 1 },
+    lastAppliedTurnAttemptId: null,
+    appliedTurnReceipts: [],
+  };
+}
+
+function enableDurableSessions(hydrated: LoadedAgentSession): void {
+  messagingMocks.inspectCatalog.mockResolvedValue({
+    summaries: [hydrated.summary],
+    corruptions: [],
+  });
+  messagingMocks.loadSession.mockResolvedValue(hydrated);
+  messagingMocks.getOrCreateSession.mockResolvedValue(hydrated);
+  vi.stubGlobal('chrome', {
+    runtime: { sendMessage: vi.fn() },
+    storage: {
+      local: {
+        get: vi.fn(async () => ({})),
+        set: vi.fn(async () => {}),
+      },
+    },
+  });
 }
 
 function actionButton(container: HTMLElement, testId: string): HTMLButtonElement {

--- a/tests/unit/github-radar-source.test.ts
+++ b/tests/unit/github-radar-source.test.ts
@@ -194,6 +194,144 @@ describe('GitHub Radar source', () => {
     expect(new Headers(calls[0]?.init.headers).get('authorization')).toBe('Bearer secret');
   });
 
+  it('retries only the failed Following page after a transient GitHub failure', async () => {
+    vi.useFakeTimers();
+    try {
+      const followingCursors: unknown[] = [];
+      let secondPageAttempts = 0;
+      const fetchImpl = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body)) as {
+          query: string;
+          variables: Record<string, unknown>;
+        };
+        if (body.query.includes('RadarFollowing')) {
+          followingCursors.push(body.variables.cursor);
+          if (body.variables.cursor === null) {
+            return jsonResponse(followingEnvelope({
+              logins: ['alice'],
+              totalCount: 2,
+              hasNextPage: true,
+              endCursor: 'following-page-2',
+            }));
+          }
+          secondPageAttempts += 1;
+          if (secondPageAttempts === 1) return new Response('', { status: 503 });
+          return jsonResponse(followingEnvelope({ logins: ['bob'], totalCount: 2 }));
+        }
+        return jsonResponse(activityEnvelope([
+          { login: 'alice', edges: [] },
+          { login: 'bob', edges: [] },
+        ]));
+      }) as typeof fetch;
+
+      const result = fetchGitHubRadar({ token: 'token', fetchImpl, now: () => NOW });
+      await vi.advanceTimersByTimeAsync(500);
+      const snapshot = await result;
+
+      expect(followingCursors).toEqual([null, 'following-page-2', 'following-page-2']);
+      expect(snapshot.scannedFollowingCount).toBe(2);
+      expect(fetchImpl).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retries only the failed activity batch after a transient network failure', async () => {
+    vi.useFakeTimers();
+    try {
+      const logins = ['one', 'two', 'three', 'four', 'five', 'six'];
+      const activityVariables: Record<string, unknown>[] = [];
+      let followingRequests = 0;
+      let finalBatchAttempts = 0;
+      const fetchImpl = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body)) as {
+          query: string;
+          variables: Record<string, unknown>;
+        };
+        if (body.query.includes('RadarFollowing')) {
+          followingRequests += 1;
+          return jsonResponse(followingEnvelope({ logins }));
+        }
+        activityVariables.push(body.variables);
+        const batchLogins = Object.entries(body.variables)
+          .filter(([name]) => name.startsWith('login'))
+          .map(([, login]) => String(login));
+        if (batchLogins.length === 1) {
+          finalBatchAttempts += 1;
+          if (finalBatchAttempts === 1) throw new TypeError('synthetic network failure');
+        }
+        return jsonResponse(activityEnvelope(batchLogins.map((login) => ({ login, edges: [] }))));
+      }) as typeof fetch;
+
+      const result = fetchGitHubRadar({ token: 'token', fetchImpl, now: () => NOW });
+      await vi.advanceTimersByTimeAsync(500);
+      const snapshot = await result;
+
+      expect(followingRequests).toBe(1);
+      expect(activityVariables).toHaveLength(3);
+      expect(activityVariables[1]).toEqual({ login0: 'six', cursor0: null });
+      expect(activityVariables[2]).toEqual(activityVariables[1]);
+      expect(snapshot.batchCount).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('bounds persistent transient failures to three attempts', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn(async () => new Response('', { status: 503 })) as typeof fetch;
+      const rejection = expect(fetchGitHubRadar({ token: 'token', fetchImpl, now: () => NOW }))
+        .rejects.toMatchObject({ code: 'github_unavailable', status: 503 });
+
+      await vi.advanceTimersByTimeAsync(1_500);
+      await rejection;
+      expect(fetchImpl).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('re-evaluates the global deadline before a transient retry', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn(async () => new Response('', { status: 503 })) as typeof fetch;
+      const rejection = expect(fetchGitHubRadar({
+        token: 'token',
+        fetchImpl,
+        now: () => NOW,
+        deadlineMs: 100,
+      })).rejects.toMatchObject({ code: 'deadline_exceeded' });
+
+      await vi.advanceTimersByTimeAsync(500);
+      await rejection;
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('preserves caller abort while waiting to retry a transient failure', async () => {
+    vi.useFakeTimers();
+    try {
+      const controller = new AbortController();
+      const fetchImpl = vi.fn(async () => new Response('', { status: 503 })) as typeof fetch;
+      const rejection = expect(fetchGitHubRadar({
+        token: 'token',
+        fetchImpl,
+        now: () => NOW,
+        signal: controller.signal,
+      })).rejects.toMatchObject({ code: 'request_aborted' });
+
+      await vi.advanceTimersByTimeAsync(0);
+      controller.abort();
+      await rejection;
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps valid activity aliases when a followed account is missing', async () => {
     let request = 0;
     const fetchImpl = vi.fn(async () => {
@@ -474,6 +612,8 @@ describe('GitHub Radar source', () => {
         code: 'rate_limited',
         status: 403,
       });
+
+    expect(rateLimitedFetch).toHaveBeenCalledTimes(1);
 
     const controller = new AbortController();
     controller.abort();

--- a/tests/unit/use-radar.test.tsx
+++ b/tests/unit/use-radar.test.tsx
@@ -312,9 +312,164 @@ describe('useRadar', () => {
     });
 
     expect(radarMocks.bgCall).toHaveBeenCalledTimes(2);
+    expect(radarMocks.bgCall.mock.calls.some(([type]) => type === 'refreshRadar')).toBe(false);
     expect(container.querySelector('[data-testid="loading"]')?.textContent).toBe('ready');
     expect(container.querySelector('[data-testid="recommendation-loading"]')?.textContent)
       .toBe('ready');
+  });
+
+  it('automatically scans a configured first-use projection and reloads authoritative activity', async () => {
+    const firstUse = response({ snapshotStatus: 'never_loaded' });
+    const authoritative = {
+      ...response(),
+      activities: [unseenActivity],
+      unseenCount: 1,
+    };
+    let radarQueries = 0;
+    radarMocks.bgCall.mockImplementation((type: string) => {
+      if (type === 'queryRadar') {
+        radarQueries += 1;
+        return Promise.resolve(radarQueries === 1 ? firstUse : authoritative);
+      }
+      if (type === 'queryRecommendations') return Promise.resolve(recommendationResponse());
+      if (type === 'refreshRadar') return Promise.resolve(refreshResponse());
+      throw new Error(`Unexpected request: ${type}`);
+    });
+
+    const container = mountReact(<Harness />, mountedRoots);
+    await settle();
+    await settle();
+
+    expect(radarMocks.bgCall.mock.calls.filter(([type]) => type === 'refreshRadar')).toHaveLength(1);
+    expect(radarQueries).toBe(2);
+    expect(container.querySelector('[data-testid="status"]')?.textContent).toBe('fresh');
+    expect(container.querySelector('[data-testid="unseen"]')?.textContent).toBe('1');
+  });
+
+  it('does not start a first-use scan while the background is already refreshing', async () => {
+    radarMocks.bgCall.mockImplementation((type: string) => {
+      if (type === 'queryRadar') {
+        return Promise.resolve(response({ snapshotStatus: 'never_loaded', refreshing: true }));
+      }
+      if (type === 'queryRecommendations') return Promise.resolve(recommendationResponse());
+      throw new Error(`Unexpected request: ${type}`);
+    });
+
+    const container = mountReact(<Harness />, mountedRoots);
+    await settle();
+    await settle();
+
+    expect(radarMocks.bgCall.mock.calls.filter(([type]) => type === 'refreshRadar')).toHaveLength(0);
+    expect(container.querySelector('[data-testid="refreshing"]')?.textContent).toBe('refreshing');
+  });
+
+  it('ignores a first-use refresh completion after credentials invalidate the projection', async () => {
+    const pendingRefresh = deferred<RadarRefreshResult>();
+    let radarQueries = 0;
+    radarMocks.bgCall.mockImplementation((type: string) => {
+      if (type === 'queryRadar') {
+        radarQueries += 1;
+        return Promise.resolve(radarQueries === 1 ? response({ snapshotStatus: 'never_loaded' }) : response());
+      }
+      if (type === 'queryRecommendations') return Promise.resolve(recommendationResponse());
+      if (type === 'refreshRadar') return pendingRefresh.promise;
+      throw new Error(`Unexpected request: ${type}`);
+    });
+
+    const container = mountReact(<Harness />, mountedRoots);
+    await settle();
+    await settle();
+    expect(radarMocks.bgCall.mock.calls.filter(([type]) => type === 'refreshRadar')).toHaveLength(1);
+
+    act(() => {
+      storageListeners[0]?.({
+        gsm_github_credentials: { oldValue: { accountLogin: 'a' }, newValue: { accountLogin: 'b' } },
+      }, 'local');
+    });
+    await settle();
+    await settle();
+    expect(container.querySelector('[data-testid="status"]')?.textContent).toBe('fresh');
+
+    await act(async () => {
+      pendingRefresh.resolve(refreshResponse({
+        published: false,
+        status: response({ snapshotStatus: 'error', errorCode: 'network_error' }).status,
+      }));
+      await pendingRefresh.promise;
+      await Promise.resolve();
+    });
+    await settle();
+
+    expect(radarQueries).toBe(2);
+    expect(radarMocks.bgCall.mock.calls.filter(([type]) => type === 'refreshRadar')).toHaveLength(1);
+    expect(container.querySelector('[data-testid="status"]')?.textContent).toBe('fresh');
+    expect(container.querySelector('[data-testid="error"]')?.textContent).toBe('none');
+  });
+
+  it('does not repeat the first-use scan when publication leaves the projection never loaded', async () => {
+    const firstUse = response({ snapshotStatus: 'never_loaded' });
+    let radarQueries = 0;
+    radarMocks.bgCall.mockImplementation((type: string) => {
+      if (type === 'queryRadar') {
+        radarQueries += 1;
+        return Promise.resolve(firstUse);
+      }
+      if (type === 'queryRecommendations') return Promise.resolve(recommendationResponse());
+      if (type === 'refreshRadar') {
+        return Promise.resolve(refreshResponse({ published: false, status: firstUse.status }));
+      }
+      throw new Error(`Unexpected request: ${type}`);
+    });
+
+    const container = mountReact(<Harness />, mountedRoots);
+    await settle();
+    await settle();
+    await settle();
+
+    expect(radarMocks.bgCall.mock.calls.filter(([type]) => type === 'refreshRadar')).toHaveLength(1);
+    expect(radarQueries).toBe(2);
+    expect(container.querySelector('[data-testid="status"]')?.textContent).toBe('never_loaded');
+
+    await act(async () => {
+      runtimeListeners[0]?.({ type: 'radarChanged' });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(radarQueries).toBe(3);
+    expect(radarMocks.bgCall.mock.calls.filter(([type]) => type === 'refreshRadar')).toHaveLength(1);
+  });
+
+  it('allows one new first-use scan after credentials invalidate the projection', async () => {
+    const firstUse = response({ snapshotStatus: 'never_loaded' });
+    let radarQueries = 0;
+    radarMocks.bgCall.mockImplementation((type: string) => {
+      if (type === 'queryRadar') {
+        radarQueries += 1;
+        return Promise.resolve(firstUse);
+      }
+      if (type === 'queryRecommendations') return Promise.resolve(recommendationResponse());
+      if (type === 'refreshRadar') {
+        return Promise.resolve(refreshResponse({ published: false, status: firstUse.status }));
+      }
+      throw new Error(`Unexpected request: ${type}`);
+    });
+
+    mountReact(<Harness />, mountedRoots);
+    await settle();
+    await settle();
+    expect(radarMocks.bgCall.mock.calls.filter(([type]) => type === 'refreshRadar')).toHaveLength(1);
+
+    act(() => {
+      storageListeners[0]?.({
+        gsm_github_credentials: { oldValue: { accountLogin: 'a' }, newValue: { accountLogin: 'b' } },
+      }, 'local');
+    });
+    await settle();
+    await settle();
+
+    expect(radarMocks.bgCall.mock.calls.filter(([type]) => type === 'refreshRadar')).toHaveLength(2);
+    expect(radarQueries).toBe(4);
   });
 
   it('clears both account-bound projections when credential reloads fail', async () => {

--- a/tests/unit/use-watch-inbox.test.tsx
+++ b/tests/unit/use-watch-inbox.test.tsx
@@ -307,6 +307,7 @@ describe('useWatchInbox', () => {
         return Promise.resolve(loadedResponse(
           2,
           queryCount === 1 ? firstBoundary : nextBoundary,
+          null,
         ));
       }
       throw new Error(`Unexpected request: ${type}`);
@@ -335,6 +336,57 @@ describe('useWatchInbox', () => {
       .toHaveLength(2);
   });
 
+  it('fills up to 1,000 notification candidates when Watch is visible', async () => {
+    let historyNextPage = 11;
+    let totalCount = 500;
+    let queryCount = 0;
+    let historyLoadCount = 0;
+    const loadedPages: number[] = [];
+    const historyLoads = Array.from({ length: 5 }, () => deferred<unknown>());
+    watchMocks.bgCall.mockImplementation((type: string) => {
+      if (type === 'markWatchInboxLoaded') {
+        return Promise.resolve('2026-08-05T12:00:00.000Z');
+      }
+      if (type === 'queryWatchInbox') {
+        queryCount += 1;
+        return Promise.resolve(loadedResponse(
+          totalCount,
+          '2026-08-04T10:00:00.000Z',
+          historyNextPage,
+        ));
+      }
+      if (type === 'loadOlderWatchInbox') {
+        loadedPages.push(historyNextPage);
+        return historyLoads[historyLoadCount++]!.promise;
+      }
+      throw new Error(`Unexpected request: ${type}`);
+    });
+
+    const container = mountReact(<Harness initialVisible />, mountedRoots);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(historyLoadCount).toBe(1);
+
+    for (const [index, historyLoad] of historyLoads.entries()) {
+      await act(async () => {
+        historyNextPage += 2;
+        totalCount += 100;
+        historyLoad.resolve({});
+        await historyLoad.promise;
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(historyLoadCount).toBe(Math.min(index + 2, historyLoads.length));
+    }
+
+    expect(queryCount).toBe(6);
+    expect(loadedPages).toEqual([11, 13, 15, 17, 19]);
+    expect(container.querySelector('[data-testid="count"]')?.textContent).toBe('1000');
+    expect(container.querySelector('[data-testid="loading-older"]')?.textContent).toBe('ready');
+  });
+
   it('loads an older page and then reloads the saved Watch projection', async () => {
     const older = deferred<unknown>();
     let queryCount = 0;
@@ -351,6 +403,7 @@ describe('useWatchInbox', () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+    expect(watchMocks.bgCall).not.toHaveBeenCalledWith('loadOlderWatchInbox');
 
     await click(container.querySelector<HTMLButtonElement>('[data-testid="load-older"]')!);
     expect(container.querySelector('[data-testid="loading-older"]')?.textContent).toBe('loading');
@@ -367,15 +420,18 @@ describe('useWatchInbox', () => {
     expect(container.querySelector('[data-testid="load-older-error"]')?.textContent).toBe('none');
   });
 
-  it('restores a persisted historical-load failure on a new hook mount', async () => {
+  it('shows a persisted history failure without automatically retrying it', async () => {
     const persistedFailure = loadedResponse(1, '2026-08-04T10:00:00.000Z');
     persistedFailure.status.state!.inbox.historyErrorCode = 'rate_limited';
     watchMocks.bgCall.mockImplementation((type: string) => {
       if (type === 'queryWatchInbox') return Promise.resolve(persistedFailure);
+      if (type === 'markWatchInboxLoaded') {
+        return Promise.resolve('2026-08-05T12:00:00.000Z');
+      }
       throw new Error(`Unexpected request: ${type}`);
     });
 
-    const container = mountReact(<Harness />, mountedRoots);
+    const container = mountReact(<Harness initialVisible />, mountedRoots);
     await act(async () => {
       await Promise.resolve();
       await Promise.resolve();
@@ -383,6 +439,7 @@ describe('useWatchInbox', () => {
 
     expect(container.querySelector('[data-testid="load-older-error"]')?.textContent)
       .toBe('error');
+    expect(watchMocks.bgCall).not.toHaveBeenCalledWith('loadOlderWatchInbox');
   });
 
   it('clears dormant cached rows on credential change and visibly reloads on activation', async () => {


### PR DESCRIPTION
## Problem / 问题

Manager async recovery had three user-visible gaps:

- Agent could keep a hydrated conversation whose complete repository or current-view candidate no longer matched the selected context.
- Radar first use required a manual refresh, and one transient page or activity-batch failure discarded progress from the current scan.
- Watch histories beyond the initial 500 notification candidates required repeated manual pagination even for ordinary libraries.

Related issue / 关联 Issue: N/A

## Decision / 方案

- Key Agent conversation handoff by the canonical full candidate, and wait for durable session readiness before consuming a pending switch.
- Retry only the failed Radar request, up to three attempts with bounded abort-aware delay; automatically run one configured first-use scan and fence stale completions after credential changes.
- While Watch is visible, automatically continue history through page 20 (about 1,000 candidates); preserve manual continuation beyond that boundary and stop eager loading on hidden, refresh, exhaustion, or error states.
- Keep permissions, IndexedDB schemas, persisted config shapes, and release metadata unchanged.

## Verification / 验证

Tested / 已验证：

- `pnpm typecheck`
- `pnpm exec vitest run tests/unit/use-watch-inbox.test.tsx` — 21/21 passed
- `pnpm test:logic` — 195 files / 2,505 tests passed
- `pnpm build`
- `pnpm test` — 223 files / 3,291 tests plus runtime checks passed
- `git diff --check`

Not tested / 未验证：

- Authenticated GitHub Radar retry behavior against live transient failures
- Authenticated Watch history pagination against a live account
- Manual Agent and Watch interaction in an installed extension build

## Risk / 风险

- Radar may issue up to two additional requests for a transiently failed page or batch; retries remain bounded and preserve abort/deadline behavior.
- A visible Watch visit may issue up to five additional two-page history batches before leaving the remaining cursor manual.
- Agent now rotates to a fresh session for any canonical candidate change, including current-view tag/filter changes.
- No permission, storage-schema, migration, or cross-browser manifest changes.

## Visual evidence / 视觉证据

N/A — no styling or layout changes. The changed behavior is covered by hook, source, and component regression tests.

## Checklist / 检查清单

- [x] The diff addresses one focused manager recovery problem and contains no unrelated formatting work / 改动只解决 Manager 恢复状态问题，不含无关格式化
- [x] New behavior and bug fixes have suitable behavior tests / 新行为和 Bug 修复有合适的行为测试
- [x] `pnpm typecheck` and the smallest relevant tests pass / `pnpm typecheck` 和适用的最小测试已通过
- [x] English and Chinese documentation match user-visible behavior changes, when applicable / 本次无需要同步的发布文档
- [ ] UI changes were verified in the real extension surface, when applicable / 未在安装后的真实扩展页面手动验证
- [x] The diff contains no generated output, credentials, private data, personal information, or copied external work-item text / 改动不含生成文件、凭据、私人数据、个人信息或外部工作项原文
- [x] Tested and untested scope is stated accurately / 已准确说明验证和未验证范围