### PR TITLE
feat: configure Following history and keep demo unindexed

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -159,7 +159,7 @@ Watch Inbox requires the optional `notifications` scope on your Classic Personal
 
 Following and For You offer two discovery paths:
 
-- **Following activity**: Review public Star activity from people you follow over the last 30 days, with controls to search, hide items, star repositories, add favorites, and assign tags
+- **Following activity**: Review public Star activity from people you follow over the last 30 days by default, or choose 30, 60, or 90 days in Preferences. Search and hide activity, star repositories, add favorites, and assign tags. Longer windows can take more time, GitHub API quota, and local storage, and are more likely to return partial results
 - **For You**: Choose seeds from your existing Stars, fetch candidates through GitHub's public Search API, filter them, and recommend the results
 
 For You excludes repositories you currently star, archived repositories, and forks. It uses supported GitHub APIs and does not reproduce GitHub Explore's private recommendation system. See [How For You recommendations work](docs/en/for-you-recommendation-strategy.md) for candidate sources, scoring, and daily refresh behavior.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Watch Inbox 需要 Classic Personal Access Token (PAT) 的可选 `notifications`
 
 Following 与 For You 帮助你发现更多项目：
 
-- **关注动态**：读取你关注的人的最近 30 天的公开 Star 活动，并支持搜索、隐藏、Star、收藏和添加标签
+- **关注动态**：默认读取你关注的人的最近 30 天公开 Star 活动；可在偏好设置切换为 30、60 或 90 天，并支持搜索、隐藏、Star、收藏和添加标签。范围越长，刷新耗时、GitHub API 配额和本地存储占用可能越高，也更容易出现部分结果
 - **为你推荐**：从现有 Stars 选择数据，通过 GitHub 公开 Search 获取筛选后再推送给你
 
 For You 会排除你已 Star 的仓库、Archived 仓库和 Fork。它使用 GitHub 支持的公开接口，不复刻 GitHub Explore 的私有推荐系统。候选来源、评分和每日刷新规则见 [For You 推荐如何工作](docs/zh/for-you-recommendation-strategy.md)。

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="color-scheme" content="light dark" />
+    <!-- The Demo host must stay out of search results so it never competes with betterstars.app for brand queries. -->
+    <meta name="robots" content="noindex, nofollow" />
     <meta
       name="description"
       content="Explore Better GitHub Stars Manager with fixed synthetic data and no GitHub connection."

--- a/src/api/github-radar-source.ts
+++ b/src/api/github-radar-source.ts
@@ -4,11 +4,11 @@ import {
   normalizeRadarActivity,
   RADAR_MAX_FOLLOWING,
   RADAR_STARS_PER_FOLLOWER,
-  RADAR_WINDOW_DAYS,
   type RadarActivityRecord,
   type RadarPartialReason,
 } from '@/radar/radar-model';
 import type { RadarSourceSnapshot } from '@/radar/radar-contract';
+import { DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS } from '@/preferences';
 
 const GRAPHQL_URL = 'https://api.github.com/graphql';
 const FOLLOWING_PAGE_SIZE = 100;
@@ -548,7 +548,7 @@ export async function fetchGitHubRadar(
   const now = options.now?.() ?? new Date();
   const nowMillis = now.getTime();
   if (!Number.isFinite(nowMillis)) throw new GitHubRadarError('invalid_response');
-  const windowDays = positiveInteger(options.windowDays, RADAR_WINDOW_DAYS);
+  const windowDays = positiveInteger(options.windowDays, DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS);
   const maxFollowing = positiveInteger(options.maxFollowing, DEFAULT_MAX_FOLLOWING);
   const batchSize = Math.min(
     positiveInteger(options.batchSize, DEFAULT_BATCH_SIZE),
@@ -674,6 +674,7 @@ export async function fetchGitHubRadar(
 
   return {
     accountLogin: accountLogin.toLocaleLowerCase('en-US'),
+    windowDays,
     activities: dedupeRadarActivities(activities),
     fetchedAt: now.toISOString(),
     followingCount,

--- a/src/auth/auth-store.ts
+++ b/src/auth/auth-store.ts
@@ -13,9 +13,11 @@ import {
 } from "@/onboarding/state";
 import {
   DEFAULT_AUTO_TAG_LIMIT,
+  DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS,
   DEFAULT_LIBRARY_VIEW_PREFS,
   DEFAULT_LOCALE,
   DEFAULT_MIN_TOPIC_REPO_COUNT,
+  normalizeFollowingHistoryWindowDays,
   normalizeLibraryViewPrefs,
   normalizeAutoTagLimit,
   normalizeMaxTagsPerRepo,
@@ -108,6 +110,7 @@ const DEFAULT_CONFIG: Config = {
   githubCredentialStatus: null,
   watchNotificationsEnabled: false,
   watchCollapsedRepositories: {},
+  radarWindowDays: DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS,
   agentProvider: {
     provider: "openai",
     protocol: null,
@@ -231,6 +234,7 @@ function mergeStoredConfig(stored: Partial<Config>): Config {
     autoTagAgentPromptSeen: stored.autoTagAgentPromptSeen === true,
     storeRatingPrompt: normalizeStoreRatingPromptState(stored.storeRatingPrompt),
     maxTagsPerRepo: maxTagsPerRepo ?? DEFAULT_CONFIG.maxTagsPerRepo,
+    radarWindowDays: normalizeFollowingHistoryWindowDays(stored.radarWindowDays),
     watchCollapsedRepositories: normalizeWatchCollapsedRepositories(
       stored.watchCollapsedRepositories,
     ),
@@ -322,6 +326,7 @@ function withNormalizedConfig(config: Config): Config {
     autoTagLimit: normalizeAutoTagLimit(config.autoTagLimit),
     maxTagsPerRepo: normalizeMaxTagsPerRepo(config.maxTagsPerRepo, config.autoTagLimit),
     minTopicRepoCount: normalizeMinTopicRepoCount(config.minTopicRepoCount),
+    radarWindowDays: normalizeFollowingHistoryWindowDays(config.radarWindowDays),
     libraryView: normalizeLibraryViewPrefs(config.libraryView),
     starsPanelDefaultEnabled: normalizeStarsPanelDefaultEnabled(config.starsPanelDefaultEnabled),
     columnLayoutMode: normalizeColumnLayoutMode(config.columnLayoutMode),

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -405,18 +405,26 @@ function badgeCredentialUnchanged(
 }
 
 async function queryManagerSurfaceBadgeCounts(): Promise<ManagerSurfaceBadgeCounts> {
-  const credential = await authStore.getGitHubCredentialSnapshot();
+  const [credential, config] = await Promise.all([
+    authStore.getGitHubCredentialSnapshot(),
+    authStore.getConfig(),
+  ]);
   const accountLogin = badgeAccountLogin(credential);
   if (!accountLogin || !credential.mainToken) return EMPTY_MANAGER_SURFACE_BADGE_COUNTS;
 
+  const countedAt = Date.now();
   const [watchUnreadCount, radarUnseenCount] = await Promise.all([
     watchStore.countUnreadWatchThreads(accountLogin),
-    radarStore.countUnseenRadarActivities(accountLogin),
+    radarStore.countUnseenRadarActivities(accountLogin, countedAt, config.radarWindowDays),
   ]);
-  const latestCredential = await authStore.getGitHubCredentialSnapshot();
-  if (!badgeCredentialUnchanged(credential, latestCredential)) {
-    return EMPTY_MANAGER_SURFACE_BADGE_COUNTS;
-  }
+  const [latestCredential, latestConfig] = await Promise.all([
+    authStore.getGitHubCredentialSnapshot(),
+    authStore.getConfig(),
+  ]);
+  if (
+    !badgeCredentialUnchanged(credential, latestCredential)
+    || config.radarWindowDays !== latestConfig.radarWindowDays
+  ) return EMPTY_MANAGER_SURFACE_BADGE_COUNTS;
   return { watchUnreadCount, radarUnseenCount };
 }
 const recommendationRefreshCoordinator = createRecommendationRefreshCoordinator({

--- a/src/background/radar-refresh.ts
+++ b/src/background/radar-refresh.ts
@@ -1,4 +1,5 @@
 import type { GitHubCredentialSnapshot, authStore } from '@/auth/auth-store';
+import type { FollowingHistoryWindowDays } from '@/types';
 import { fetchGitHubRadar } from '@/api/github-radar-source';
 import {
   GitHubRadarError,
@@ -25,7 +26,7 @@ import {
 
 const DEFAULT_RATE_LIMIT_COOLDOWN_MS = 15 * 60 * 1_000;
 
-type RadarAuth = Pick<typeof authStore, 'getGitHubCredentialSnapshot'>;
+type RadarAuth = Pick<typeof authStore, 'getGitHubCredentialSnapshot' | 'getConfig'>;
 type AuthSnapshot = GitHubCredentialSnapshot;
 
 type RadarRefreshOutcome = Readonly<{ published: boolean }>;
@@ -82,6 +83,10 @@ export function createRadarRefreshCoordinator(
     return dependencies.auth.getGitHubCredentialSnapshot();
   }
 
+  async function readWindowDays(): Promise<FollowingHistoryWindowDays> {
+    return (await dependencies.auth.getConfig()).radarWindowDays;
+  }
+
   async function sameCredentials(snapshot: AuthSnapshot): Promise<boolean> {
     const latest = await readAuth();
     return latest.accountLogin === snapshot.accountLogin
@@ -89,18 +94,27 @@ export function createRadarRefreshCoordinator(
       && latest.mainIdentity === snapshot.mainIdentity;
   }
 
+  async function sameRequest(
+    snapshot: AuthSnapshot,
+    windowDays: FollowingHistoryWindowDays,
+  ): Promise<boolean> {
+    return await sameCredentials(snapshot) && await readWindowDays() === windowDays;
+  }
+
   async function statusForAuth(
     auth: AuthSnapshot,
     refreshing: boolean,
     stateOverride?: RadarStateRecord | null,
+    windowDaysOverride?: FollowingHistoryWindowDays,
   ): Promise<RadarStatus> {
+    const windowDays = windowDaysOverride ?? await readWindowDays();
     const hasMainToken = !!(auth.accountLogin && auth.mainToken);
     const state = stateOverride !== undefined
       ? stateOverride
       : hasMainToken && auth.accountLogin
         ? await dependencies.store.getState(auth.accountLogin)
         : null;
-    return makeRadarStatus(auth.accountLogin, hasMainToken, refreshing, state, now());
+    return makeRadarStatus(auth.accountLogin, hasMainToken, refreshing, state, now(), windowDays);
   }
 
   async function reconcileAccount(): Promise<void> {
@@ -121,31 +135,35 @@ export function createRadarRefreshCoordinator(
 
   async function query(): Promise<RadarQueryResponse> {
     await reconcileAccount();
-    const auth = await readAuth();
+    const [auth, windowDays] = await Promise.all([readAuth(), readWindowDays()]);
     const accountLogin = auth.accountLogin && auth.mainToken ? auth.accountLogin : null;
+    const queriedAt = now();
     const [activities, state] = await Promise.all([
       accountLogin
-        ? dependencies.store.listActivities(accountLogin, now())
+        ? dependencies.store.listActivities(accountLogin, queriedAt, windowDays)
         : Promise.resolve([] as RadarActivityPresentation[]),
       accountLogin ? dependencies.store.getState(accountLogin) : Promise.resolve(null),
     ]);
-    const latest = await readAuth();
-    if (identity(auth) !== identity(latest)) {
+    const [latest, latestWindowDays] = await Promise.all([readAuth(), readWindowDays()]);
+    if (identity(auth) !== identity(latest) || windowDays !== latestWindowDays) {
       return {
         activities: [],
         unseenCount: 0,
-        status: await statusForAuth(latest, inFlight !== null),
+        status: await statusForAuth(latest, inFlight !== null, undefined, latestWindowDays),
       };
     }
     return {
       activities,
       unseenCount: activities.reduce((count, activity) => count + (activity.seen ? 0 : 1), 0),
-      status: await statusForAuth(auth, inFlight !== null, state),
+      status: await statusForAuth(auth, inFlight !== null, state, windowDays),
     };
   }
 
-  async function performRefresh(auth: AuthSnapshot): Promise<RadarRefreshOutcome> {
-    if (!auth.accountLogin || !auth.mainToken || !await sameCredentials(auth)) {
+  async function performRefresh(
+    auth: AuthSnapshot,
+    windowDays: FollowingHistoryWindowDays,
+  ): Promise<RadarRefreshOutcome> {
+    if (!auth.accountLogin || !auth.mainToken || !await sameRequest(auth, windowDays)) {
       return { published: false };
     }
     const attemptedAt = now();
@@ -163,17 +181,23 @@ export function createRadarRefreshCoordinator(
       const snapshot = await dependencies.fetchRadar({
         token: auth.mainToken,
         now: () => new Date(attemptedAt),
+        windowDays,
       });
-      if (snapshot.accountLogin.trim().toLocaleLowerCase('en-US')
-        !== auth.accountLogin.trim().toLocaleLowerCase('en-US')) {
+      if (
+        snapshot.windowDays !== windowDays
+        || snapshot.accountLogin.trim().toLocaleLowerCase('en-US')
+          !== auth.accountLogin.trim().toLocaleLowerCase('en-US')
+      ) {
         throw new GitHubRadarError('invalid_response');
       }
-      if (!await sameCredentials(auth)) return { published: false };
+      if (!await sameRequest(auth, windowDays)) return { published: false };
       await dependencies.store.commitSnapshot(snapshot);
+      // Config can change while the IndexedDB commit yields; never announce that stale result.
+      if (!await sameRequest(auth, windowDays)) return { published: false };
       dependencies.broadcastChanged();
       return { published: true };
     } catch (error) {
-      if (await sameCredentials(auth)) {
+      if (await sameRequest(auth, windowDays)) {
         await dependencies.store.recordFailure(
           auth.accountLogin,
           stableErrorCode(error),
@@ -187,21 +211,21 @@ export function createRadarRefreshCoordinator(
 
   async function refresh(): Promise<RadarRefreshResult> {
     await reconcileAccount();
-    const requestedAuth = await readAuth();
-    const requestedIdentity = identity(requestedAuth);
+    const [requestedAuth, windowDays] = await Promise.all([readAuth(), readWindowDays()]);
+    const requestedIdentity = JSON.stringify([identity(requestedAuth), windowDays]);
     const current = inFlight;
     if (current) {
       if (current.identity === requestedIdentity) return current.promise;
       try {
         await current.promise;
       } catch {
-        // A changed credential identity gets its own isolated attempt.
+        // A changed credential or history window gets its own isolated attempt.
       }
       if (inFlight === current) inFlight = null;
       return refresh();
     }
 
-    const operation = dependencies.runSerialized(() => performRefresh(requestedAuth));
+    const operation = dependencies.runSerialized(() => performRefresh(requestedAuth, windowDays));
     const promise = operation.then(async (outcome) => ({
       ...outcome,
       status: await statusForAuth(await readAuth(), false),

--- a/src/demo/fixtures/index.ts
+++ b/src/demo/fixtures/index.ts
@@ -410,6 +410,7 @@ const ACCOUNT: ManagerAccount = {
 const PREFERENCES: ManagerPreferences = {
   theme: 'light',
   locale: 'en',
+  radarWindowDays: 60,
   libraryView: {
     version: 1,
     filters: {

--- a/src/demo/fixtures/index.ts
+++ b/src/demo/fixtures/index.ts
@@ -333,6 +333,7 @@ const RADAR_STATE: RadarStateRecord = {
   accountLogin: ACCOUNT_LOGIN,
   lastAttemptAt: beforeNow(1),
   lastSuccessfulAt: beforeNow(1),
+  windowDays: 60,
   errorCode: null,
   nextAllowedAt: null,
   activityCount: RADAR_ACTIVITIES.length,

--- a/src/demo/runtime/index.ts
+++ b/src/demo/runtime/index.ts
@@ -645,6 +645,7 @@ class DemoManagerRuntime implements ManagerRuntime {
     return projectRadarActivities({
       accountLogin: this.accountLogin(),
       nowMillis: this.state.now,
+      windowDays: this.state.radarState.windowDays ?? 60,
       activities: this.state.radarActivities,
       stars: this.state.stars,
       tags: this.state.tags,
@@ -660,6 +661,7 @@ class DemoManagerRuntime implements ManagerRuntime {
       accountLogin: this.accountLogin(),
       hasMainToken: true,
       refreshing: false,
+      windowDays: this.state.radarState.windowDays ?? 60,
       snapshotStatus: this.state.radarState.partialReasons.length > 0 ? 'partial' : 'fresh',
       errorCode: this.state.radarState.errorCode,
       state: cloneMutable(this.state.radarState),

--- a/src/demo/runtime/index.ts
+++ b/src/demo/runtime/index.ts
@@ -10,6 +10,10 @@ import {
   type ManagerSurfaceBadgeCounts,
   type WatchRepositoryDetail,
 } from '@/runtime/manager-runtime';
+import {
+  DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS,
+  normalizeFollowingHistoryWindowDays,
+} from '@/preferences';
 import { projectStarsQuery, type StarsQueryParams, type StarsQueryResult } from '@/stars/stars-query';
 import { projectWatchInbox, normalizeRepositoryFullName, type WatchSubjectDetail } from '@/watch/watch-model';
 import type {
@@ -166,6 +170,9 @@ class DemoManagerRuntime implements ManagerRuntime {
     const next = {
       ...this.state.preferences,
       ...cloneMutable(patch),
+      radarWindowDays: normalizeFollowingHistoryWindowDays(
+        patch.radarWindowDays ?? this.state.preferences.radarWindowDays,
+      ),
     } satisfies ManagerPreferences;
     if (JSON.stringify(this.state.preferences) !== JSON.stringify(next)) {
       this.state.preferences = next;
@@ -464,6 +471,7 @@ class DemoManagerRuntime implements ManagerRuntime {
     const now = timestamp(this.state.now);
     this.state.radarState.lastAttemptAt = now;
     this.state.radarState.lastSuccessfulAt = now;
+    this.state.radarState.windowDays = this.radarWindowDays();
     this.state.radarState.batchCount++;
     this.state.radarState.activityCount = this.state.radarActivities.length;
     this.publish('radar');
@@ -641,11 +649,17 @@ class DemoManagerRuntime implements ManagerRuntime {
     };
   }
 
+  private radarWindowDays() {
+    return normalizeFollowingHistoryWindowDays(
+      this.state.preferences.radarWindowDays ?? DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS,
+    );
+  }
+
   private projectRadar() {
     return projectRadarActivities({
       accountLogin: this.accountLogin(),
       nowMillis: this.state.now,
-      windowDays: this.state.radarState.windowDays ?? 60,
+      windowDays: this.radarWindowDays(),
       activities: this.state.radarActivities,
       stars: this.state.stars,
       tags: this.state.tags,
@@ -657,12 +671,17 @@ class DemoManagerRuntime implements ManagerRuntime {
   }
 
   private radarStatus(): RadarStatus {
+    const windowDays = this.radarWindowDays();
     return {
       accountLogin: this.accountLogin(),
       hasMainToken: true,
       refreshing: false,
-      windowDays: this.state.radarState.windowDays ?? 60,
-      snapshotStatus: this.state.radarState.partialReasons.length > 0 ? 'partial' : 'fresh',
+      windowDays,
+      snapshotStatus: this.state.radarState.windowDays !== windowDays
+        ? 'stale'
+        : this.state.radarState.partialReasons.length > 0
+          ? 'partial'
+          : 'fresh',
       errorCode: this.state.radarState.errorCode,
       state: cloneMutable(this.state.radarState),
     };

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -239,9 +239,9 @@ export interface MessageCatalog {
     permissionTitle: string;
     permissionBody: string;
     emptyTitle: string;
-    emptyBody: string;
+    emptyBody: (windowDays: number) => string;
     filteredEmptyTitle: string;
-    filteredEmptyBody: string;
+    filteredEmptyBody: (windowDays: number) => string;
     searchPlaceholder: string;
     clearSearch: string;
     searchResultCount: (count: number) => string;
@@ -251,18 +251,18 @@ export interface MessageCatalog {
     statusPartial: string;
     statusCooldown: (time: string) => string;
     statusPermission: string;
-    listEndActivities: (count: number) => string;
-    listEndProjects: (count: number) => string;
+    listEndActivities: (windowDays: number, count: number) => string;
+    listEndProjects: (windowDays: number, count: number) => string;
     listEndMatches: (count: number) => string;
     listEndPartial: string;
     listEndSaved: (count: number) => string;
     freshSummary: (activities: number, following: number) => string;
     partialSnapshot: (count: number) => string;
-    partialReason: (reason: RadarPartialReason) => string;
+    partialReason: (reason: RadarPartialReason, windowDays: number) => string;
     staleSnapshot: string;
     cooldownUntil: (time: string) => string;
     snapshotAt: (time: string) => string;
-    publicActivityOnly: string;
+    publicActivityOnly: (windowDays: number) => string;
     actorStarred: string;
     openActorProfile: (actor: string) => string;
     inLibrary: string;
@@ -933,6 +933,10 @@ export interface MessageCatalog {
     agentStorageClearFailed: (error: string) => string;
     agentStorageRetry: string;
     behaviorHeading: string;
+    followingHistoryWindowLabel: string;
+    followingHistoryWindowHint: string;
+    followingHistoryWindowRisk: string;
+    followingHistoryWindowOption: (days: number) => string;
     maxTagsPerRepoLabel: string;
     maxTagsPerRepoHint: string;
     minTopicRepoCountLabel: string;
@@ -1379,9 +1383,9 @@ const messages: Record<Locale, MessageCatalog> = {
       permissionBody:
         "Following Radar needs the read:user scope on the GitHub Classic PAT. Stars, tags, Gist, and sync are unaffected.",
       emptyTitle: "No recent stars",
-      emptyBody: "No star activity was found in the last 30 days.",
+      emptyBody: (windowDays) => `No star activity was found in the last ${windowDays} days.`,
       filteredEmptyTitle: "No activity from selected sources",
-      filteredEmptyBody: "Adjust Following and Me to show recent stars from the last 30 days.",
+      filteredEmptyBody: (windowDays) => `Adjust Following and Me to show recent stars from the last ${windowDays} days.`,
       searchPlaceholder: "Search people or repositories",
       clearSearch: "Clear Following search",
       searchResultCount: (count) => `${count} matching ${count === 1 ? "activity" : "activities"}`,
@@ -1391,23 +1395,23 @@ const messages: Record<Locale, MessageCatalog> = {
       statusPartial: "Partial results · some activity may be missing",
       statusCooldown: (time) => `Scan available at ${time}`,
       statusPermission: "Following needs access to your following graph",
-      listEndActivities: (count) => `End of 30-day window · ${count} ${count === 1 ? "activity" : "activities"}`,
-      listEndProjects: (count) => `End of 30-day window · ${count} ${count === 1 ? "project" : "projects"}`,
+      listEndActivities: (windowDays, count) => `End of ${windowDays}-day window · ${count} ${count === 1 ? "activity" : "activities"}`,
+      listEndProjects: (windowDays, count) => `End of ${windowDays}-day window · ${count} ${count === 1 ? "project" : "projects"}`,
       listEndMatches: (count) => `End of matching results · ${count}`,
       listEndPartial: "End of fetched results · some activity may be missing",
       listEndSaved: (count) => `End of saved activity · ${count} ${count === 1 ? "item" : "items"}`,
       freshSummary: (activities, following) => `${activities} activities · ${following} following`,
       partialSnapshot: (count) =>
         `Partial snapshot — ${count} known ${count === 1 ? "gap" : "gaps"}`,
-      partialReason: (reason) => ({
-        github_star_list_truncated: "Some accounts could not be paged to the end of the 30-day window.",
+      partialReason: (reason, windowDays) => ({
+        github_star_list_truncated: `Some accounts could not be paged to the end of the ${windowDays}-day window.`,
         private_activity_omitted: "Private followed-star activity was omitted.",
         following_scan_truncated: "Not every followed account could be scanned.",
       })[reason],
       staleSnapshot: "Showing the last successful snapshot because the latest scan failed or is stale.",
       cooldownUntil: (time) => `GitHub rate limit reached. Scanning unlocks at ${time}.`,
       snapshotAt: (time) => `Snapshot checked ${time}`,
-      publicActivityOnly: "Public stars · last 30 days",
+      publicActivityOnly: (windowDays) => `Public stars · last ${windowDays} days`,
       actorStarred: "starred",
       openActorProfile: (actor) => `Open @${actor} on GitHub`,
       inLibrary: "in your library",
@@ -2208,6 +2212,12 @@ const messages: Record<Locale, MessageCatalog> = {
       agentStorageClearFailed: (error) => `Tool cache could not be cleared: ${error}`,
       agentStorageRetry: "Try again",
       behaviorHeading: "4. Preferences",
+      followingHistoryWindowLabel: "Following history",
+      followingHistoryWindowHint:
+        "Choose how much public Star activity to scan from accounts you follow. Changes apply on the next scan.",
+      followingHistoryWindowRisk:
+        "Longer windows can use more GitHub API quota, take longer to refresh, store more data locally, and are more likely to return partial results when GitHub or the scan budget limits the request.",
+      followingHistoryWindowOption: (days) => `${days} days`,
       maxTagsPerRepoLabel: "Max automatic tags per repo",
       maxTagsPerRepoHint:
         "Auto Tags uses this limit. In Chat, Cubby may add at most this many tags to a repository per turn; Organize uses the lower of this value and its 5-tag safety cap.",
@@ -2696,9 +2706,9 @@ const messages: Record<Locale, MessageCatalog> = {
       permissionBody:
         "Following Radar 需要 GitHub Classic PAT 的 read:user scope。Stars、标签、Gist 和同步不受影响。",
       emptyTitle: "暂无近期 Star",
-      emptyBody: "最近 30 天未发现 Star 动态。",
+      emptyBody: (windowDays) => `最近 ${windowDays} 天未发现 Star 动态。`,
       filteredEmptyTitle: "所选来源没有动态",
-      filteredEmptyBody: "调整“关注的人”和“我”，查看最近 30 天的 Star 动态。",
+      filteredEmptyBody: (windowDays) => `调整“关注的人”和“我”，查看最近 ${windowDays} 天的 Star 动态。`,
       searchPlaceholder: "搜索人物或仓库",
       clearSearch: "清除 Following 搜索",
       searchResultCount: (count) => `匹配 ${count} 条动态`,
@@ -2708,22 +2718,22 @@ const messages: Record<Locale, MessageCatalog> = {
       statusPartial: "部分结果 · 可能缺少部分动态",
       statusCooldown: (time) => `可在 ${time} 后扫描`,
       statusPermission: "Following 需要读取关注关系的权限",
-      listEndActivities: (count) => `30 天窗口末尾 · 共 ${count} 条动态`,
-      listEndProjects: (count) => `30 天窗口末尾 · 共 ${count} 个项目`,
+      listEndActivities: (windowDays, count) => `${windowDays} 天窗口末尾 · 共 ${count} 条动态`,
+      listEndProjects: (windowDays, count) => `${windowDays} 天窗口末尾 · 共 ${count} 个项目`,
       listEndMatches: (count) => `匹配结果末尾 · 共 ${count} 项`,
       listEndPartial: "已获取结果末尾 · 可能缺少部分动态",
       listEndSaved: (count) => `已保存动态末尾 · 共 ${count} 项`,
       freshSummary: (activities, following) => `${activities} 条动态 · 关注 ${following} 人`,
       partialSnapshot: (count) => `部分快照 · ${count} 个已知缺口`,
-      partialReason: (reason) => ({
-        github_star_list_truncated: "部分账号未能翻页到 30 天窗口末尾。",
+      partialReason: (reason, windowDays) => ({
+        github_star_list_truncated: `部分账号未能翻页到 ${windowDays} 天窗口末尾。`,
         private_activity_omitted: "已省略关注账号的私有 Star 动态。",
         following_scan_truncated: "未能扫描全部关注账号。",
       })[reason],
       staleSnapshot: "最近一次扫描失败或快照已过期，当前显示上一次成功快照。",
       cooldownUntil: (time) => `已触发 GitHub 速率限制，${time} 后可再次扫描。`,
       snapshotAt: (time) => `快照检查于 ${time}`,
-      publicActivityOnly: "公开 Star · 最近 30 天",
+      publicActivityOnly: (windowDays) => `公开 Star · 最近 ${windowDays} 天`,
       actorStarred: "Star 了",
       openActorProfile: (actor) => `在 GitHub 打开 @${actor} 的主页`,
       inLibrary: "已在你的 Stars 中",
@@ -3525,6 +3535,12 @@ const messages: Record<Locale, MessageCatalog> = {
       agentStorageClearFailed: (error) => `无法清理工具缓存：${error}`,
       agentStorageRetry: "重试",
       behaviorHeading: "4. 偏好设置",
+      followingHistoryWindowLabel: "Following 历史范围",
+      followingHistoryWindowHint:
+        "选择扫描所关注账号最近多少天的公开 Star 动态；更改后在下次扫描生效。",
+      followingHistoryWindowRisk:
+        "范围越长，GitHub API 配额、刷新时间和本地存储占用越高；达到 GitHub 限制或单次扫描预算时，可能只返回部分结果。",
+      followingHistoryWindowOption: (days) => `${days} 天`,
       maxTagsPerRepoLabel: "每个仓库最多自动标签数",
       maxTagsPerRepoHint:
         "Auto Tags 使用此上限；聊天中 Cubby 每轮最多为单个仓库新增这么多个标签；整理功能取此值与 5 个标签安全上限中的较小值。",

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -36,16 +36,27 @@ import { Textarea } from "@/ui/shadcn/textarea";
 import { Separator } from "@/ui/shadcn/separator";
 import { Input } from "@/ui/shadcn/input";
 import { Checkbox } from "@/ui/shadcn/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/ui/shadcn/select";
 import { cn } from "@/lib/utils";
 import { REPO_URL } from "@/lib/links";
 import { useImeBufferedInput } from "@/ui/hooks/use-ime-input";
 import { useI18n } from "@/i18n";
+import type { FollowingHistoryWindowDays } from '@/types';
 import {
   DEFAULT_AUTO_TAG_LIMIT,
+  DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS,
+  FOLLOWING_HISTORY_WINDOW_OPTIONS,
   DEFAULT_MIN_TOPIC_REPO_COUNT,
   MAX_AUTO_TAG_LIMIT,
   MIN_AUTO_TAG_LIMIT,
   normalizeMaxTagsPerRepo,
+  normalizeFollowingHistoryWindowDays,
   normalizeMinTopicRepoCount,
 } from "@/preferences";
 import {
@@ -98,10 +109,16 @@ export function Options() {
   const [theme, setTheme] = useState<"dark" | "light">("dark");
   const [agentSettingsSnapshot, setAgentSettingsSnapshot] =
     useState<OptionsAgentSettingsSnapshot>(DEFAULT_OPTIONS_AGENT_SETTINGS_SNAPSHOT);
+  const [radarWindowDays, setRadarWindowDays] = useState<FollowingHistoryWindowDays>(
+    DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS,
+  );
   const [maxTagsPerRepo, setMaxTagsPerRepo] = useState<string>(String(DEFAULT_AUTO_TAG_LIMIT));
   const [minTopicRepoCount, setMinTopicRepoCount] = useState<string>(String(DEFAULT_MIN_TOPIC_REPO_COUNT));
   const persistedMaxTagsPerRepoRef = useRef(String(DEFAULT_AUTO_TAG_LIMIT));
   const persistedMinTopicRepoCountRef = useRef(String(DEFAULT_MIN_TOPIC_REPO_COUNT));
+  const persistedRadarWindowDaysRef = useRef<FollowingHistoryWindowDays>(
+    DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS,
+  );
   const [starsPanelDefaultEnabled, setStarsPanelDefaultEnabled] = useState(true);
   const [tokenBusy, setTokenBusy] = useState(false);
   const [syncStatus, setSyncStatus] = useState<SyncStatus | null>(null);
@@ -127,10 +144,12 @@ export function Options() {
     setGistId(c.gistId);
     setTheme(c.theme);
     setAgentSettingsSnapshot({ providerConfig: c.agentProvider });
+    setRadarWindowDays(c.radarWindowDays);
     setMaxTagsPerRepo(String(c.maxTagsPerRepo));
     setMinTopicRepoCount(String(c.minTopicRepoCount));
     persistedMaxTagsPerRepoRef.current = String(c.maxTagsPerRepo);
     persistedMinTopicRepoCountRef.current = String(c.minTopicRepoCount);
+    persistedRadarWindowDaysRef.current = c.radarWindowDays;
     setStarsPanelDefaultEnabled(c.starsPanelDefaultEnabled);
     setSyncStatus((current) => mergeStatusSnapshot(current, status));
   };
@@ -211,6 +230,18 @@ export function Options() {
     document.documentElement.classList.toggle("dark", next === "dark");
   };
 
+
+  const saveRadarWindowDays = async (raw: string) => {
+    const next = normalizeFollowingHistoryWindowDays(raw);
+    setRadarWindowDays(next);
+    try {
+      await authStore.update({ radarWindowDays: next });
+      persistedRadarWindowDaysRef.current = next;
+    } catch (error) {
+      setRadarWindowDays(persistedRadarWindowDaysRef.current);
+      setMsg({ kind: "err", text: translateError(error, m) });
+    }
+  };
   const saveMaxTagsPerRepo = async (raw: string) => {
     const next = normalizeMaxTagsPerRepo(raw);
     setMaxTagsPerRepo(String(next)); // clamp the field back to a legal value
@@ -299,6 +330,7 @@ export function Options() {
           JSON.stringify(newCfg?.agentProvider ?? null) &&
         oldCfg?.maxTagsPerRepo === newCfg?.maxTagsPerRepo &&
         oldCfg?.minTopicRepoCount === newCfg?.minTopicRepoCount &&
+        oldCfg?.radarWindowDays === newCfg?.radarWindowDays &&
         oldCfg?.starsPanelDefaultEnabled === newCfg?.starsPanelDefaultEnabled &&
         JSON.stringify(oldCfg?.storeRatingPrompt ?? null) ===
           JSON.stringify(newCfg?.storeRatingPrompt ?? null);
@@ -572,6 +604,47 @@ export function Options() {
       <section className="mt-6">
         <h2 className="text-base font-medium">{m.options.behaviorHeading}</h2>
         <div className="mt-3 grid gap-4 rounded-lg border border-border bg-muted/20 p-4">
+          <div className="grid gap-1.5">
+            <label
+              id="following-history-window-label"
+              htmlFor="following-history-window"
+              className="text-sm font-medium text-foreground"
+            >
+              {m.options.followingHistoryWindowLabel}
+            </label>
+            <p id="following-history-window-hint" className="gsm-body-note">
+              {m.options.followingHistoryWindowHint}
+            </p>
+            <Select
+              value={String(radarWindowDays)}
+              onValueChange={(value) => void saveRadarWindowDays(value)}
+            >
+              <SelectTrigger
+                id="following-history-window"
+                data-testid="following-history-window"
+                aria-labelledby="following-history-window-label"
+                aria-describedby="following-history-window-hint following-history-window-risk"
+                className="w-36"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {FOLLOWING_HISTORY_WINDOW_OPTIONS.map((days) => (
+                  <SelectItem key={days} value={String(days)}>
+                    {m.options.followingHistoryWindowOption(days)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p
+              id="following-history-window-risk"
+              className="flex items-start gap-2 text-xs leading-5 text-muted-foreground"
+            >
+              <AlertTriangle className="mt-0.5 size-3.5 shrink-0 text-warning" aria-hidden="true" />
+              <span>{m.options.followingHistoryWindowRisk}</span>
+            </p>
+          </div>
+
           <NumericPrefField
             id="max-tags-per-repo"
             label={m.options.maxTagsPerRepoLabel}

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -1,5 +1,6 @@
 import type {
   LibraryViewPrefs,
+  FollowingHistoryWindowDays,
   LibraryViewSortDir,
   Locale,
   LibraryViewSortKey,
@@ -12,6 +13,8 @@ export const MIN_AUTO_TAG_LIMIT = 1;
 export const MAX_AUTO_TAG_LIMIT = 50;
 export const DEFAULT_MIN_TOPIC_REPO_COUNT = 3;
 export const MAX_WATCH_COLLAPSED_REPOSITORIES = 100;
+export const FOLLOWING_HISTORY_WINDOW_OPTIONS = [30, 60, 90] as const satisfies readonly FollowingHistoryWindowDays[];
+export const DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS: FollowingHistoryWindowDays = 30;
 
 const SORT_KEYS: readonly LibraryViewSortKey[] = [
   'starred_at',
@@ -71,6 +74,16 @@ export function normalizeMinTopicRepoCount(value: unknown): number {
     return DEFAULT_MIN_TOPIC_REPO_COUNT;
   }
   return normalizeIntegerPreference(value, DEFAULT_MIN_TOPIC_REPO_COUNT);
+}
+
+export function normalizeFollowingHistoryWindowDays(
+  value: unknown,
+): FollowingHistoryWindowDays {
+  const parsed = typeof value === 'string' && value.trim() !== '' ? Number(value) : value;
+  return typeof parsed === 'number'
+    && FOLLOWING_HISTORY_WINDOW_OPTIONS.includes(parsed as FollowingHistoryWindowDays)
+    ? parsed as FollowingHistoryWindowDays
+    : DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS;
 }
 
 function uniqueStrings(value: unknown): string[] {

--- a/src/radar/radar-contract.ts
+++ b/src/radar/radar-contract.ts
@@ -19,6 +19,7 @@ export interface RadarStatus {
   accountLogin: string | null;
   hasMainToken: boolean;
   refreshing: boolean;
+  windowDays: number;
   snapshotStatus: RadarSnapshotStatus;
   errorCode: RadarErrorCode | null;
   state: RadarStateRecord | null;
@@ -38,6 +39,7 @@ export interface RadarRefreshResult {
 export interface RadarSourceSnapshot {
   accountLogin: string;
   activities: RadarActivityRecord[];
+  windowDays: number;
   fetchedAt: string;
   followingCount: number;
   scannedFollowingCount: number;

--- a/src/radar/radar-model.ts
+++ b/src/radar/radar-model.ts
@@ -5,7 +5,6 @@ import {
 
 export const RADAR_STARS_PER_FOLLOWER = 30;
 export const RADAR_MAX_FOLLOWING = 200;
-export const RADAR_WINDOW_DAYS = 30;
 export const RADAR_PARTIAL_REASONS = [
   'github_star_list_truncated',
   'private_activity_omitted',
@@ -108,6 +107,8 @@ export interface RadarStateRecord {
   accountLogin: string;
   lastAttemptAt: string | null;
   lastSuccessfulAt: string | null;
+  /** Window used to build the latest successful snapshot; null for legacy or empty state. */
+  windowDays: number | null;
   errorCode: RadarErrorCode | null;
   nextAllowedAt: string | null;
   activityCount: number;

--- a/src/radar/radar-projector.ts
+++ b/src/radar/radar-projector.ts
@@ -4,7 +4,6 @@ import {
   normalizeRadarActivity,
   normalizeRadarAvatarUrl,
   normalizeRadarRepositoryTopics,
-  RADAR_WINDOW_DAYS,
   sortRadarActivities,
   type RadarActivityPresentation,
   type RadarActivityRecord,
@@ -15,6 +14,7 @@ import { canonicalTagKey, excludedCanonicalTagKeys, visibleTagNames } from '@/ta
 export type RadarProjectionSource = Readonly<{
   accountLogin: string;
   nowMillis: number;
+  windowDays: number;
   activities: readonly RadarActivityRecord[];
   stars: readonly Star[];
   tags: readonly Tag[];
@@ -71,9 +71,16 @@ function ownStarPresentation(
 
 export function projectRadarActivities(source: RadarProjectionSource): RadarActivityPresentation[] {
   const accountLogin = source.accountLogin.trim().toLocaleLowerCase('en-US');
+  const cutoffMillis = source.nowMillis - source.windowDays * 24 * 60 * 60 * 1_000;
   const storedActivities = dedupeRadarActivities(source.activities)
-    .filter((activity) => activity.accountLogin === accountLogin && activity.dismissedAt === null);
-  const cutoffMillis = source.nowMillis - RADAR_WINDOW_DAYS * 24 * 60 * 60 * 1_000;
+    .filter((activity) => {
+      const starredAt = timestamp(activity.starredAt);
+      return activity.accountLogin === accountLogin
+        && activity.dismissedAt === null
+        && starredAt !== null
+        && starredAt >= cutoffMillis
+        && starredAt <= source.nowMillis;
+    });
   const ownStars = source.stars.filter((star) => {
     const starredAt = timestamp(star.starred_at);
     return !star.tombstone

--- a/src/runtime/extension-manager-runtime.ts
+++ b/src/runtime/extension-manager-runtime.ts
@@ -43,6 +43,7 @@ function preferencesFromConfig(config: Config): ManagerPreferences {
   return {
     theme: config.theme,
     locale: config.locale,
+    radarWindowDays: config.radarWindowDays,
     libraryView: config.libraryView,
     watchCollapsedRepositories: config.watchCollapsedRepositories,
     columnLayoutMode: config.columnLayoutMode,

--- a/src/runtime/manager-runtime.ts
+++ b/src/runtime/manager-runtime.ts
@@ -44,6 +44,7 @@ export type ManagerPreferences = Readonly<Pick<
   | 'locale'
   | 'libraryView'
   | 'watchCollapsedRepositories'
+  | 'radarWindowDays'
   | 'columnLayoutMode'
   | 'customColumnLayout'
 >>;

--- a/src/storage/radar-store.ts
+++ b/src/storage/radar-store.ts
@@ -15,6 +15,7 @@ import type {
   RadarStatus,
 } from '@/radar/radar-contract';
 import { db } from './db';
+import { DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS } from '@/preferences';
 
 const RADAR_STATE_ID = 'singleton' as const;
 const RADAR_STALE_AFTER_MS = 30 * 60 * 1_000;
@@ -33,6 +34,7 @@ function emptyState(accountLogin: string, lastAttemptAt = now()): RadarStateReco
     accountLogin: accountKey(accountLogin),
     lastAttemptAt,
     lastSuccessfulAt: null,
+    windowDays: null,
     errorCode: null,
     nextAllowedAt: null,
     activityCount: 0,
@@ -64,16 +66,26 @@ function stateForAccount(
 
 export async function countUnseenRadarActivities(
   accountLogin: string | null | undefined,
+  nowMillis = Date.now(),
+  windowDays = DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS,
 ): Promise<number> {
   if (!accountLogin?.trim()) return 0;
   const key = accountKey(accountLogin);
+  const cutoffMillis = nowMillis - windowDays * 24 * 60 * 60 * 1_000;
   return db.transaction('r', db.radarActivities, db.radarState, async () => {
     const state = await db.radarState.get(RADAR_STATE_ID);
     if (state?.accountLogin !== key) return 0;
     return db.radarActivities
       .where('accountLogin')
       .equals(key)
-      .filter((activity) => activity.dismissedAt === null && storedSeenAt(activity.seenAt) === null)
+      .filter((activity) => {
+        const starredAt = timestamp(activity.starredAt);
+        return activity.dismissedAt === null
+          && storedSeenAt(activity.seenAt) === null
+          && starredAt !== null
+          && starredAt >= cutoffMillis
+          && starredAt <= nowMillis;
+      })
       .count();
   });
 }
@@ -138,6 +150,7 @@ export async function commitRadarSnapshot(snapshot: RadarSourceSnapshot): Promis
       accountLogin,
       lastAttemptAt: attemptAt,
       lastSuccessfulAt: snapshot.fetchedAt,
+      windowDays: snapshot.windowDays,
       errorCode: null,
       nextAllowedAt: null,
       activityCount: activities.length,
@@ -230,6 +243,7 @@ export async function clearRadarData(): Promise<void> {
 export async function listRadarActivities(
   accountLogin: string,
   nowMillis = Date.now(),
+  windowDays = DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS,
 ): Promise<RadarActivityPresentation[]> {
   const key = accountKey(accountLogin);
   const [activities, stars, tags, tagMeta] = await Promise.all([
@@ -241,6 +255,7 @@ export async function listRadarActivities(
   return projectRadarActivities({
     accountLogin: key,
     nowMillis,
+    windowDays,
     activities,
     stars,
     tags,
@@ -252,15 +267,18 @@ export async function listRadarActivities(
 export function radarSnapshotStatus(
   state: RadarStateRecord | null,
   nowMillis = Date.now(),
+  windowDays = DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS,
 ): RadarSnapshotStatus {
   if (!state) return 'never_loaded';
   const nextAllowedAt = timestamp(state.nextAllowedAt);
   if (nextAllowedAt !== null && nextAllowedAt > nowMillis) return 'cooldown';
   const lastSuccessfulAt = timestamp(state.lastSuccessfulAt);
   if (lastSuccessfulAt === null) return state.errorCode !== null ? 'error' : 'never_loaded';
-  if (state.errorCode !== null || nowMillis - lastSuccessfulAt > RADAR_STALE_AFTER_MS) {
-    return 'stale';
-  }
+  if (
+    state.windowDays !== windowDays
+    || state.errorCode !== null
+    || nowMillis - lastSuccessfulAt > RADAR_STALE_AFTER_MS
+  ) return 'stale';
   if (state.partialReasons.length > 0) return 'partial';
   return 'fresh';
 }
@@ -271,14 +289,16 @@ export function makeRadarStatus(
   refreshing: boolean,
   state: RadarStateRecord | null,
   nowMillis = Date.now(),
+  windowDays = DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS,
 ): RadarStatus {
   return {
     accountLogin: accountLogin ? accountKey(accountLogin) : null,
     hasMainToken,
     refreshing,
+    windowDays,
     snapshotStatus: !hasMainToken
       ? 'not_configured'
-      : radarSnapshotStatus(state, nowMillis),
+      : radarSnapshotStatus(state, nowMillis, windowDays),
     errorCode: state?.errorCode ?? null,
     state,
   };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,8 @@ import type { AgentDataDisclosureAcceptance } from '@/bgsm-agent/disclosure';
 
 export type Locale = 'en' | 'zh-CN';
 
+export type FollowingHistoryWindowDays = 30 | 60 | 90;
+
 export type OnboardingStage =
   | 'needs_token'
   | 'awaiting_sync'
@@ -386,6 +388,8 @@ export interface Config {
   maxTagsPerRepo: number;
   /** Minimum repos that must share a topic/tag before automated organization uses it. */
   minTopicRepoCount: number;
+  /** Number of recent days included in Following activity. */
+  radarWindowDays: FollowingHistoryWindowDays;
   /** Durable library view intent for filters and primary sort. */
   libraryView: LibraryViewPrefs;
   /** Whether your own GitHub stars page should open the overlay panel by default. */

--- a/src/ui/components/Radar.tsx
+++ b/src/ui/components/Radar.tsx
@@ -269,7 +269,7 @@ export function Radar({
       <RadarEmptyState
         icon={<Check className="size-4" />}
         title={m.radar.emptyTitle}
-        text={m.radar.emptyBody}
+        text={m.radar.emptyBody(status.windowDays)}
         tone="success"
       />,
     );
@@ -289,8 +289,8 @@ export function Radar({
       : queryActive
         ? m.radar.listEndMatches(visibleResultCount)
         : view === 'feed'
-          ? m.radar.listEndActivities(visibleResultCount)
-          : m.radar.listEndProjects(visibleResultCount);
+          ? m.radar.listEndActivities(status.windowDays, visibleResultCount)
+          : m.radar.listEndProjects(status.windowDays, visibleResultCount);
   const renderRadarRow = (index: number) => {
     if (view === 'feed') {
       const searchResult = activitySearchResults[index];
@@ -337,7 +337,7 @@ export function Radar({
             <AlertTriangle className="mt-0.5 size-3.5 shrink-0 text-warning" aria-hidden="true" />
             <span className="min-w-0">
               {m.radar.statusPartial}:{' '}
-              {state.partialReasons.map(m.radar.partialReason).join(' ')}
+              {state.partialReasons.map((reason) => m.radar.partialReason(reason, status.windowDays)).join(' ')}
             </span>
             <button
               type="button"
@@ -354,7 +354,7 @@ export function Radar({
         <RadarEmptyState
           icon={<ListFilter className="size-4" />}
           title={m.radar.filteredEmptyTitle}
-          text={m.radar.filteredEmptyBody}
+          text={m.radar.filteredEmptyBody(status.windowDays)}
         />
       ) : visibleResultCount === 0 && queryActive ? (
         <RadarEmptyState

--- a/src/ui/components/RadarCommandBar.tsx
+++ b/src/ui/components/RadarCommandBar.tsx
@@ -15,6 +15,7 @@ import { Button } from '@/ui/shadcn/button';
 import { Input } from '@/ui/shadcn/input';
 import { Spinner } from '@/ui/shadcn/spinner';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/shadcn/tooltip';
+import { DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS } from '@/preferences';
 
 export function RadarEmptyState({
   icon,
@@ -296,7 +297,11 @@ export function RadarCommandBar({
         )}
         <span className="inline-flex min-w-0 items-center gap-2 text-[10px] text-muted-foreground max-[700px]:basis-full">
           <Clock3 className="size-3 shrink-0" aria-hidden="true" />
-          <span className="truncate">{m.radar.publicActivityOnly}</span>
+          <span className="truncate">
+            {m.radar.publicActivityOnly(
+              result?.status.windowDays ?? DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS,
+            )}
+          </span>
         </span>
         <span className="min-w-0 flex-1 max-[700px]:hidden" />
         <RadarCommandBarActions

--- a/tests/preferences-persistence.test.ts
+++ b/tests/preferences-persistence.test.ts
@@ -43,6 +43,7 @@ describe('preferences persistence', () => {
 
     assert.equal(await authStore.getLocale(), 'zh-CN');
     assert.equal((await authStore.getConfig()).locale, 'zh-CN');
+    assert.equal((await authStore.getConfig()).radarWindowDays, 30);
   });
 
   it('normalizes and persists legacy preference fields', async () => {
@@ -53,6 +54,7 @@ describe('preferences persistence', () => {
 
     storageBacking[CONFIG_STORAGE_KEY] = {
       autoTagLimit: 7,
+      radarWindowDays: 360,
       libraryView: {
         version: 1,
         filters: {
@@ -75,6 +77,7 @@ describe('preferences persistence', () => {
     const legacyConfig = await authStore.getConfig();
     assert.equal(legacyConfig.maxTagsPerRepo, 7);
     assert.equal(legacyConfig.minTopicRepoCount, 3);
+    assert.equal(legacyConfig.radarWindowDays, 30);
     assert.equal(legacyConfig.libraryView.filters.onlyArchived, true);
 
     useFilterStore.getState().applyLibraryViewPrefs(legacyConfig.libraryView, 'vue');
@@ -87,11 +90,13 @@ describe('preferences persistence', () => {
 
     await authStore.updateAutoTagPolicy({ maxTagsPerRepo: 4, minTopicRepoCount: 3 });
     await authStore.updateLibraryViewPrefs(hydratedPrefs);
+    await authStore.update({ radarWindowDays: 90 });
 
     const storedConfig = storageBacking[CONFIG_STORAGE_KEY] as Config;
     assert.equal(storedConfig.autoTagLimit, 4);
     assert.equal(storedConfig.maxTagsPerRepo, 4);
     assert.equal(storedConfig.minTopicRepoCount, 3);
+    assert.equal(storedConfig.radarWindowDays, 90);
     assert.deepEqual(storedConfig.libraryView, hydratedPrefs);
   });
 

--- a/tests/regressions/storage/projector-wrapper-parity.test.ts
+++ b/tests/regressions/storage/projector-wrapper-parity.test.ts
@@ -25,7 +25,6 @@ import type { Star, Tag, TagMeta } from '@/types';
 const NOW = '2026-08-16T12:00:00.000Z';
 const RECENT = '2026-08-15T12:00:00.000Z';
 const OLDER = '2026-08-10T12:00:00.000Z';
-const EXPIRED = '2026-07-01T12:00:00.000Z';
 
 const DEFAULT_FILTER: StarsQueryParams['filter'] = {
   query: '',
@@ -222,7 +221,7 @@ describe('storage-neutral projector parity', () => {
       stargazers_count: 55,
     });
     const followedStar = star('Owner/Followed', {
-      starred_at: EXPIRED,
+      starred_at: '2026-06-01T12:00:00.000Z',
       topics: ['local-topic', 'blocked-topic'],
       stargazers_count: 321,
     });
@@ -249,6 +248,7 @@ describe('storage-neutral projector parity', () => {
     const source = {
       accountLogin: ' VIEWER ',
       nowMillis: Date.parse(NOW),
+      windowDays: 60,
       activities: await db.radarActivities.where('accountLogin').equals('viewer').toArray(),
       stars: await db.stars.toArray(),
       tags: await db.tags.toArray(),

--- a/tests/regressions/storage/radar-store-regression.test.ts
+++ b/tests/regressions/storage/radar-store-regression.test.ts
@@ -66,10 +66,15 @@ function activity(
   };
 }
 
-function snapshot(activities: RadarActivityRecord[], fetchedAt = SECOND): RadarSourceSnapshot {
+function snapshot(
+  activities: RadarActivityRecord[],
+  fetchedAt = SECOND,
+  windowDays = 60,
+): RadarSourceSnapshot {
   return {
     accountLogin: 'Viewer',
     activities,
+    windowDays,
     fetchedAt,
     followingCount: 4,
     scannedFollowingCount: 4,
@@ -211,8 +216,24 @@ describe('Radar snapshot storage', () => {
       .toMatchObject({ snapshotStatus: 'stale', errorCode: 'network_error' });
   });
 
+  it('marks a different selected window stale and filters saved rows immediately', async () => {
+    const nowMillis = Date.parse(SECOND);
+    const insideSixty = new Date(nowMillis - 45 * 24 * 60 * 60 * 1_000).toISOString();
+    const outsideSixty = new Date(nowMillis - 75 * 24 * 60 * 60 * 1_000).toISOString();
+    const committed = await commitRadarSnapshot(snapshot([
+      activity('inside', 'owner/inside', insideSixty),
+      activity('outside', 'owner/outside', outsideSixty),
+    ], SECOND, 90));
+
+    expect(radarSnapshotStatus(committed, nowMillis, 90)).toBe('fresh');
+    expect(radarSnapshotStatus(committed, nowMillis, 60)).toBe('stale');
+    expect((await listRadarActivities('viewer', nowMillis, 60)).map((row) => row.id))
+      .toEqual(['inside']);
+    expect(await countUnseenRadarActivities('viewer', nowMillis, 60)).toBe(1);
+  });
+
   it('projects recent live Stars as self activity without copying them into Radar storage', async () => {
-    const expiredAt = new Date(Date.parse(SECOND) - 31 * 24 * 60 * 60 * 1_000).toISOString();
+    const expiredAt = new Date(Date.parse(SECOND) - 61 * 24 * 60 * 60 * 1_000).toISOString();
     await db.stars.bulkPut([
       star('owner/recent', 77),
       { ...star('owner/expired'), starred_at: expiredAt },

--- a/tests/regressions/sync/github-stars-sync-regression.test.ts
+++ b/tests/regressions/sync/github-stars-sync-regression.test.ts
@@ -27,6 +27,7 @@ function configWithCursor(lastSyncStarredAt: string | null): Config {
     watchNotificationsEnabled: false,
     tokenCryptoMeta: null,
     watchCollapsedRepositories: {},
+    radarWindowDays: 60,
     agentProvider: {
       provider: 'openai',
       protocol: null,

--- a/tests/runtime/extension-browser-smoke.mjs
+++ b/tests/runtime/extension-browser-smoke.mjs
@@ -198,6 +198,11 @@ export async function runExtensionBrowserSmoke(options = {}) {
     await optionsFromPopup.waitForSelector('textarea', { timeout: 10_000 });
     await waitForBodyText(optionsFromPopup, 'GitHub Classic PAT');
     await assertOptionsDefaultChineseAndUseEnglish(optionsFromPopup);
+    const defaultFollowingWindow = await optionsFromPopup.$eval(
+      '[data-testid="following-history-window"]',
+      (element) => element.textContent?.trim() ?? '',
+    );
+    assert.equal(defaultFollowingWindow, '30 days');
     await assertScheduledRefreshAlarms(optionsFromPopup, false);
     ok('Watch and Radar periodic alarms were installed; ineligible recommendation alarm stayed absent');
     ok('popup and Options defaulted to Chinese, then Options switched to English for the remaining smoke flow');
@@ -870,6 +875,7 @@ async function seedWatchAndRadarFixture(extId) {
         onboardingStage: 'done',
         seenOnboarding: true,
         autoTagAgentPromptSeen: true,
+        radarWindowDays: 30,
         starsPanelDefaultEnabled: true,
       },
       [CREDENTIALS_KEY]: credentials,
@@ -1091,6 +1097,7 @@ async function seedWatchAndRadarFixture(extId) {
       accountLogin: 'smoke-user',
       lastAttemptAt: radarFetchedAt,
       lastSuccessfulAt: radarFetchedAt,
+      windowDays: 30,
       errorCode: null,
       nextAllowedAt: null,
       activityCount: 1,

--- a/tests/unit/background-radar-refresh.test.ts
+++ b/tests/unit/background-radar-refresh.test.ts
@@ -6,6 +6,7 @@ import {
 import type { GitHubCredentialSnapshot } from '@/auth/auth-store';
 import { GitHubRadarError, type RadarActivityRecord, type RadarActivityPresentation, type RadarStateRecord } from '@/radar/radar-model';
 import type { RadarSourceSnapshot } from '@/radar/radar-contract';
+import type { Config, FollowingHistoryWindowDays } from '@/types';
 
 const NOW = 1_786_000_000_000;
 
@@ -27,6 +28,7 @@ function state(overrides: Partial<RadarStateRecord> = {}): RadarStateRecord {
     accountLogin: 'viewer',
     lastAttemptAt: new Date(NOW - 1_000).toISOString(),
     lastSuccessfulAt: new Date(NOW - 1_000).toISOString(),
+    windowDays: 60,
     errorCode: null,
     nextAllowedAt: null,
     activityCount: 1,
@@ -64,6 +66,7 @@ function snapshot(overrides: Partial<RadarSourceSnapshot> = {}): RadarSourceSnap
   return {
     accountLogin: 'viewer',
     activities: [activity],
+    windowDays: 60,
     fetchedAt: new Date(NOW).toISOString(),
     followingCount: 2,
     scannedFollowingCount: 2,
@@ -93,6 +96,7 @@ function makeCoordinator(input: {
   activities?: RadarActivityPresentation[];
 } = {}) {
   let currentAuth = input.auth ?? authSnapshot();
+  let currentWindowDays: FollowingHistoryWindowDays = 60;
   const currentState = input.state === undefined ? state() : input.state;
   const events: string[] = [];
   const runSerialized: RadarRefreshCoordinatorDependencies['runSerialized'] = async <T,>(
@@ -112,8 +116,9 @@ function makeCoordinator(input: {
     runSerialized,
     auth: {
       getGitHubCredentialSnapshot: vi.fn(async () => currentAuth),
+      getConfig: vi.fn(async () => ({ radarWindowDays: currentWindowDays }) as Config),
     },
-    fetchRadar: input.fetchRadar ?? vi.fn(async () => snapshot()),
+    fetchRadar: input.fetchRadar ?? vi.fn(async (options) => snapshot({ windowDays: options.windowDays })),
     store,
     now: () => NOW,
     broadcastChanged: vi.fn(() => { events.push('broadcast'); }),
@@ -125,6 +130,7 @@ function makeCoordinator(input: {
     store,
     events,
     setAuth(next: GitHubCredentialSnapshot) { currentAuth = next; },
+    setWindowDays(next: FollowingHistoryWindowDays) { currentWindowDays = next; },
   };
 }
 
@@ -143,7 +149,57 @@ describe('Radar refresh coordinator', () => {
     expect(one).toEqual(two);
     expect(fetchRadar).toHaveBeenCalledTimes(1);
     expect(h.store.commitSnapshot).toHaveBeenCalledTimes(1);
+    expect(fetchRadar).toHaveBeenCalledWith(expect.objectContaining({ windowDays: 60 }));
     expect(h.events.at(-1)).toBe('broadcast');
+  });
+
+  it('uses the selected history window for fetch, query, and status', async () => {
+    const h = makeCoordinator();
+    h.setWindowDays(90);
+
+    const refresh = await h.coordinator.refresh();
+    const query = await h.coordinator.query();
+
+    expect(h.dependencies.fetchRadar).toHaveBeenCalledWith(expect.objectContaining({ windowDays: 90 }));
+    expect(h.store.listActivities).toHaveBeenCalledWith('viewer', NOW, 90);
+    expect(refresh.status.windowDays).toBe(90);
+    expect(query.status.windowDays).toBe(90);
+  });
+
+  it('abandons an in-flight result when the history window changes', async () => {
+    let release!: (value: RadarSourceSnapshot) => void;
+    const fetchRadar = vi.fn(() => new Promise<RadarSourceSnapshot>((resolve) => { release = resolve; }));
+    const h = makeCoordinator({ fetchRadar });
+
+    const refresh = h.coordinator.refresh();
+    while (!release) await Promise.resolve();
+    h.setWindowDays(90);
+    release(snapshot({ windowDays: 60 }));
+
+    const result = await refresh;
+    expect(result.published).toBe(false);
+    expect(h.store.commitSnapshot).not.toHaveBeenCalled();
+    expect(result.status.windowDays).toBe(90);
+  });
+
+  it('does not publish when the history window changes during snapshot commit', async () => {
+    let releaseCommit!: () => void;
+    const h = makeCoordinator();
+    h.store.commitSnapshot.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => { releaseCommit = resolve; });
+      return state();
+    });
+
+    const refresh = h.coordinator.refresh();
+    while (!releaseCommit) await Promise.resolve();
+    h.setWindowDays(90);
+    releaseCommit();
+
+    const result = await refresh;
+    expect(h.store.commitSnapshot).toHaveBeenCalledTimes(1);
+    expect(result.published).toBe(false);
+    expect(h.dependencies.broadcastChanged).not.toHaveBeenCalled();
+    expect(result.status.windowDays).toBe(90);
   });
 
   it('skips all network work while a rate-limit cooldown is active', async () => {

--- a/tests/unit/background-watch-refresh.test.ts
+++ b/tests/unit/background-watch-refresh.test.ts
@@ -28,6 +28,7 @@ function config(): Config {
     githubCredentialStatus: 'ready',
     watchCollapsedRepositories: {},
     watchNotificationsEnabled: true,
+    radarWindowDays: 60,
     watchNotificationsTokenEncrypted: 'watch-cipher',
     watchNotificationsTokenCryptoMeta: { iv: 'watch-iv', salt: 'watch-salt' },
     watchCredentialSource: 'dedicated',

--- a/tests/unit/demo-runtime.test.ts
+++ b/tests/unit/demo-runtime.test.ts
@@ -89,6 +89,35 @@ describe('DemoManagerRuntime', () => {
     });
   });
 
+  it('reprojects the selected Following window and keeps snapshot provenance stale until refresh', async () => {
+    const runtime = createDemoManagerRuntime();
+    const initial = await runtime.queryRadar();
+    const initialSelfCount = initial.activities.filter((activity) => activity.source === 'self').length;
+
+    expect(initialSelfCount).toBeGreaterThan(0);
+    expect(initial.status).toMatchObject({
+      windowDays: 60,
+      snapshotStatus: 'fresh',
+      state: { windowDays: 60 },
+    });
+
+    await runtime.updatePreferences({ radarWindowDays: 30 });
+    const narrowed = await runtime.queryRadar();
+    expect(narrowed.activities.filter((activity) => activity.source === 'self')).toHaveLength(0);
+    expect(narrowed.status).toMatchObject({
+      windowDays: 30,
+      snapshotStatus: 'stale',
+      state: { windowDays: 60 },
+    });
+
+    const refreshed = await runtime.refreshRadar();
+    expect(refreshed.status).toMatchObject({
+      windowDays: 30,
+      snapshotStatus: 'fresh',
+      state: { windowDays: 30 },
+    });
+  });
+
   it('applies the synthetic account to owned-repository queries', async () => {
     const runtime = createDemoManagerRuntime();
     const owned = await runtime.queryStars({

--- a/tests/unit/demo-shell-dom.test.tsx
+++ b/tests/unit/demo-shell-dom.test.tsx
@@ -25,6 +25,7 @@ function createLocaleSource(locale: Locale) {
   let preferences: ManagerPreferences = {
     theme: 'light',
     locale,
+    radarWindowDays: 30,
     libraryView: {
       version: 1,
       filters: {

--- a/tests/unit/extension-manager-runtime.test.ts
+++ b/tests/unit/extension-manager-runtime.test.ts
@@ -43,6 +43,7 @@ const storageRemove = vi.fn((listener: StorageListener) => storageListeners.dele
 const preferences = {
   theme: 'dark',
   locale: 'en',
+  radarWindowDays: 30,
   libraryView: DEFAULT_LIBRARY_VIEW_PREFS,
   watchCollapsedRepositories: {},
   columnLayoutMode: 'default',
@@ -52,6 +53,7 @@ const preferences = {
   | 'theme'
   | 'locale'
   | 'libraryView'
+  | 'radarWindowDays'
   | 'watchCollapsedRepositories'
   | 'columnLayoutMode'
   | 'customColumnLayout'

--- a/tests/unit/github-radar-source.test.ts
+++ b/tests/unit/github-radar-source.test.ts
@@ -507,7 +507,7 @@ describe('GitHub Radar source', () => {
     expect(snapshot.activities.at(-1)?.repositoryOwnerLogin).toBe('owner');
   });
 
-  it('pages active accounts until their activity crosses the 30-day cutoff', async () => {
+  it('pages active accounts until their activity crosses the default 30-day cutoff', async () => {
     const recentOne = new Date(NOW.getTime() - 60_000).toISOString();
     const recentTwo = new Date(NOW.getTime() - 120_000).toISOString();
     const recentThree = new Date(NOW.getTime() - 180_000).toISOString();
@@ -561,6 +561,7 @@ describe('GitHub Radar source', () => {
       'owner/three',
     ]);
     expect(snapshot.batchCount).toBe(2);
+    expect(snapshot.windowDays).toBe(30);
     expect(snapshot.partialReasons).toEqual([]);
   });
 
@@ -584,9 +585,9 @@ describe('GitHub Radar source', () => {
     expect(snapshot.partialReasons).toEqual(['github_star_list_truncated']);
   });
 
-  it('uses a rolling 30-day cutoff', async () => {
-    const recent = new Date(NOW.getTime() - 29 * 24 * 60 * 60 * 1_000).toISOString();
-    const expired = new Date(NOW.getTime() - 31 * 24 * 60 * 60 * 1_000).toISOString();
+  it('uses the selected rolling 90-day cutoff', async () => {
+    const recent = new Date(NOW.getTime() - 89 * 24 * 60 * 60 * 1_000).toISOString();
+    const expired = new Date(NOW.getTime() - 91 * 24 * 60 * 60 * 1_000).toISOString();
     let request = 0;
     const fetchImpl = vi.fn(async () => {
       request += 1;
@@ -601,9 +602,10 @@ describe('GitHub Radar source', () => {
         }]));
     }) as typeof fetch;
 
-    const snapshot = await fetchGitHubRadar({ token: 'token', fetchImpl, now: () => NOW });
+    const snapshot = await fetchGitHubRadar({ token: 'token', fetchImpl, now: () => NOW, windowDays: 90 });
 
     expect(snapshot.activities.map((activity) => activity.repositoryKey)).toEqual(['owner/recent']);
+    expect(snapshot.windowDays).toBe(90);
   });
 
   it('maps primary rate limits and caller aborts to stable error codes', async () => {

--- a/tests/unit/i18n-locale-provider.test.tsx
+++ b/tests/unit/i18n-locale-provider.test.tsx
@@ -52,6 +52,7 @@ function localePreferences(locale: Locale): ManagerPreferences {
   return {
     theme: 'dark',
     locale,
+    radarWindowDays: 30,
     libraryView: DEFAULT_LIBRARY_VIEW_PREFS,
     watchCollapsedRepositories: {},
     columnLayoutMode: 'default',

--- a/tests/unit/library-view-persistence.test.tsx
+++ b/tests/unit/library-view-persistence.test.tsx
@@ -50,6 +50,7 @@ function baseConfig(): Config {
     watchNotificationsEnabled: false,
     tokenCryptoMeta: null,
     watchCollapsedRepositories: {},
+    radarWindowDays: 60,
     agentProvider: {
       provider: 'openai',
       protocol: null,

--- a/tests/unit/manager-runtime-driven-ui.test.tsx
+++ b/tests/unit/manager-runtime-driven-ui.test.tsx
@@ -26,6 +26,7 @@ const unused = async (): Promise<never> => {
 const defaultPreferences: ManagerPreferences = {
   theme: 'dark',
   locale: 'en',
+  radarWindowDays: 30,
   libraryView: DEFAULT_LIBRARY_VIEW_PREFS,
   watchCollapsedRepositories: {},
   columnLayoutMode: 'default',

--- a/tests/unit/options-preferences.test.tsx
+++ b/tests/unit/options-preferences.test.tsx
@@ -214,6 +214,8 @@ async function setTextareaValue(textarea: HTMLTextAreaElement, value: string) {
   });
 }
 
+let originalScrollIntoViewDescriptor: PropertyDescriptor | undefined;
+
 describe('Options preferences', () => {
   beforeEach(() => {
     authMocks.getConfig.mockReset();
@@ -238,6 +240,10 @@ describe('Options preferences', () => {
     runtimeListeners.length = 0;
     permissionAddedListeners.length = 0;
     permissionRemovedListeners.length = 0;
+    originalScrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'scrollIntoView',
+    );
     Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
       configurable: true,
       value: vi.fn(),
@@ -338,7 +344,15 @@ describe('Options preferences', () => {
   afterEach(() => {
     cleanupMountedRootsAndBody(mountedRoots);
     vi.unstubAllGlobals();
-    Reflect.deleteProperty(HTMLElement.prototype, 'scrollIntoView');
+    if (originalScrollIntoViewDescriptor) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'scrollIntoView',
+        originalScrollIntoViewDescriptor,
+      );
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, 'scrollIntoView');
+    }
   });
 
   it('renders a verified stars link only for a usable token and trusted username', async () => {

--- a/tests/unit/options-preferences.test.tsx
+++ b/tests/unit/options-preferences.test.tsx
@@ -108,6 +108,7 @@ function config(overrides: Partial<Config> = {}): Config {
     githubCredentialStatus: overrides.githubCredentialStatus ?? 'ready',
     watchNotificationsEnabled: overrides.watchNotificationsEnabled ?? false,
     watchCollapsedRepositories: overrides.watchCollapsedRepositories ?? {},
+    radarWindowDays: overrides.radarWindowDays ?? 30,
     agentProvider: overrides.agentProvider
       ? {
           declaredContextWindow: overrides.agentProvider.provider === 'custom-openai-compatible'
@@ -237,6 +238,10 @@ describe('Options preferences', () => {
     runtimeListeners.length = 0;
     permissionAddedListeners.length = 0;
     permissionRemovedListeners.length = 0;
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn(),
+    });
     vi.stubGlobal('chrome', {
       runtime: {
         getManifest: vi.fn(() => ({ manifest_version: 3 })),
@@ -333,6 +338,7 @@ describe('Options preferences', () => {
   afterEach(() => {
     cleanupMountedRootsAndBody(mountedRoots);
     vi.unstubAllGlobals();
+    Reflect.deleteProperty(HTMLElement.prototype, 'scrollIntoView');
   });
 
   it('renders a verified stars link only for a usable token and trusted username', async () => {
@@ -470,6 +476,35 @@ describe('Options preferences', () => {
     expect(authMocks.recordStoreRatingNavigation).toHaveBeenCalledTimes(2);
     expect(panel?.querySelector('[data-testid="store-rating-status"]')).toBeNull();
     expect(document.querySelector('[data-testid="main-token-status"]')?.getAttribute('role')).toBe('alert');
+  });
+
+  it('shows and persists the bounded Following history choice with risk copy', async () => {
+    authMocks.getConfig.mockResolvedValue(config({ radarWindowDays: 60 }));
+    authMocks.hasToken.mockResolvedValue(true);
+
+    await renderOptions();
+
+    const trigger = document.querySelector<HTMLElement>('[data-testid="following-history-window"]');
+    expect(trigger?.textContent).toContain('60 days');
+    expect(trigger?.getAttribute('aria-describedby'))
+      .toBe('following-history-window-hint following-history-window-risk');
+    expect(document.body.textContent).toContain('Longer windows can use more GitHub API quota');
+
+    await act(async () => {
+      trigger?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      await Promise.resolve();
+    });
+    const options = [...document.querySelectorAll<HTMLElement>('[role="option"]')];
+    expect(options.map((candidate) => candidate.textContent?.trim()))
+      .toEqual(['30 days', '60 days', '90 days']);
+    const option = options.find((candidate) => candidate.textContent?.includes('90 days'));
+    expect(option).toBeDefined();
+    await act(async () => {
+      option!.click();
+      await Promise.resolve();
+    });
+
+    expect(authMocks.update).toHaveBeenCalledWith({ radarWindowDays: 90 });
   });
 
   it('normalizes and persists split auto-tag policy inputs independently', async () => {

--- a/tests/unit/preferences-normalization.test.ts
+++ b/tests/unit/preferences-normalization.test.ts
@@ -2,9 +2,12 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import {
   DEFAULT_AUTO_TAG_LIMIT,
+  DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS,
+  FOLLOWING_HISTORY_WINDOW_OPTIONS,
   DEFAULT_LIBRARY_VIEW_PREFS,
   DEFAULT_MIN_TOPIC_REPO_COUNT,
   normalizeLibraryViewPrefs,
+  normalizeFollowingHistoryWindowDays,
   normalizeMaxTagsPerRepo,
   normalizeMinTopicRepoCount,
 } from '../../src/preferences';
@@ -24,6 +27,15 @@ describe('preference normalization', () => {
     assert.equal(normalizeMinTopicRepoCount('99'), 50);
     assert.equal(normalizeMinTopicRepoCount('nope'), DEFAULT_MIN_TOPIC_REPO_COUNT);
     assert.equal(normalizeMinTopicRepoCount(Number.NaN), DEFAULT_MIN_TOPIC_REPO_COUNT);
+  });
+
+  it('accepts only supported Following history windows', () => {
+    assert.deepEqual(FOLLOWING_HISTORY_WINDOW_OPTIONS, [30, 60, 90]);
+    assert.equal(normalizeFollowingHistoryWindowDays(30), 30);
+    assert.equal(normalizeFollowingHistoryWindowDays('90'), 90);
+    assert.equal(normalizeFollowingHistoryWindowDays(undefined), DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS);
+    assert.equal(normalizeFollowingHistoryWindowDays(45), DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS);
+    assert.equal(normalizeFollowingHistoryWindowDays(360), DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS);
   });
 
   it('normalizes libraryView v1 and strips non-owned fields', () => {

--- a/tests/unit/radar-surface.test.tsx
+++ b/tests/unit/radar-surface.test.tsx
@@ -39,6 +39,7 @@ function status(overrides: Partial<RadarStatus> = {}): RadarStatus {
     accountLogin: 'viewer',
     hasMainToken: true,
     refreshing: false,
+    windowDays: 60,
     snapshotStatus: 'fresh',
     errorCode: null,
     state: {
@@ -46,6 +47,7 @@ function status(overrides: Partial<RadarStatus> = {}): RadarStatus {
       accountLogin: 'viewer',
       lastAttemptAt: '2026-08-10T12:00:00.000Z',
       lastSuccessfulAt: '2026-08-10T12:00:00.000Z',
+      windowDays: 60,
       errorCode: null,
       nextAllowedAt: null,
       activityCount: 2,
@@ -92,12 +94,12 @@ function activity(id: string, repositoryKey: string): RadarActivityPresentation 
   };
 }
 
-function radarResult(): RadarQueryResponse {
+function radarResult(statusOverrides: Partial<RadarStatus> = {}): RadarQueryResponse {
   const activities = [activity('one', 'owner/one'), activity('two', 'owner/two')];
   return {
     activities,
     unseenCount: 2,
-    status: status(),
+    status: status(statusOverrides),
   };
 }
 
@@ -224,8 +226,15 @@ describe('Radar', () => {
     expect(container.querySelectorAll('[data-radar-row]')).toHaveLength(2);
     expect(container.querySelector('[data-surface-command-bar="following"]')).not.toBeNull();
     expect(container.querySelector('[data-radar-discover-view="following"]')).not.toBeNull();
-    expect(container.textContent).toContain('End of 30-day window · 2 activities');
+    expect(container.textContent).toContain('End of 60-day window · 2 activities');
     expect(container.querySelector('[data-radar-view="for-you"]')).toBeNull();
+  });
+
+  it('renders the selected Following history window', () => {
+    const container = mount(<Radar {...surfaceProps({ result: radarResult({ windowDays: 90 }) })} />);
+
+    expect(container.textContent).toContain('Public stars · last 90 days');
+    expect(container.textContent).toContain('End of 90-day window · 2 activities');
   });
 
   it('keeps the Following command bar mounted and defers loading copy to the ribbon', () => {

--- a/tests/unit/use-radar.test.tsx
+++ b/tests/unit/use-radar.test.tsx
@@ -63,6 +63,7 @@ function response(overrides: Partial<RadarQueryResponse['status']> = {}): RadarQ
       accountLogin: 'viewer',
       hasMainToken: true,
       refreshing: false,
+      windowDays: 60,
       snapshotStatus: 'fresh',
       errorCode: null,
       state: null,

--- a/vercel.json
+++ b/vercel.json
@@ -30,6 +30,10 @@
         {
           "key": "X-Frame-Options",
           "value": "DENY"
+        },
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow"
         }
       ]
     }


### PR DESCRIPTION
## Problem

Following was fixed to a single 30-day activity window, so users could not trade API cost and refresh time for more history. The public demo also lacked explicit crawler directives and could compete with the canonical product site in search results.

## Decision

- Add a normalized `30 | 60 | 90` Following history preference with a 30-day default.
- Thread the selected window through GitHub pagination, persisted snapshot provenance, projection, status, unseen badges, and bilingual UI copy.
- Mark snapshots stale when their window differs and suppress publication when the setting changes during refresh or commit.
- Add an accessible Options selector with explicit API, duration, storage, and partial-result risk copy.
- Document the setting in English and Chinese.
- Keep the public demo accessible while adding `noindex, nofollow` in HTML and `X-Robots-Tag` in Vercel headers.
- Keep the changes as two logical commits: SEO isolation and Following configuration.

## Check

Verified:

- `pnpm typecheck`
- `pnpm test:logic` — 195 files, 2563 tests
- `pnpm test:regressions` — 20 files, 728 tests on the `master`-based Following worktree; 729 tests on the pre-publication combined integration branch
- `pnpm build`
- `pnpm test:smoke` — real Chrome 149; zero observed page, background, or uncaught errors
- Focused Following suite — 5 files, 70 tests
- Browser-driven Options verification at 1280×900 and 390×844, including 90-day persistence and warning association
- `git diff --check`

Not verified:

- Authenticated live GitHub Following refresh at 60 or 90 days
- Firefox and Microsoft Edge runtime smoke
- Live Vercel response headers after deployment

## Risk

- Longer windows can consume more GitHub API quota, take longer, store more local data, and produce partial results. The selector is bounded to 90 days and warns users explicitly.
- No Dexie schema bump or backfill is introduced; missing or invalid config normalizes to 30 days.
- Window changes during an in-flight commit are revalidated before publication.
- SEO directives apply only to the demo deployment surface.

## Evidence

- Unit coverage asserts the exact ordered choices: 30, 60, and 90 days.
- Persistence coverage verifies fresh and invalid legacy configuration defaults to 30 days.
- Refresh coverage verifies selected-window fetch/query/status behavior and the commit-gap race.
- Storage regression coverage verifies stale snapshots, immediate projection filtering, and window-aware unseen counts.
- Runtime smoke asserts the rendered Options default is `30 days`.