### PR TITLE
build: add aggregate target command

### DIFF
--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -80,6 +80,14 @@ EDGE_EXECUTABLE="/path/to/Microsoft Edge" pnpm test:smoke:edge
 
 The Edge target is a build, package, and browser identity only: it ships the same full product as Chrome, including Gist sync, Cubby, AI Providers, and Provider-backed Organize. Its build writes to `dist-edge/`, and `pnpm package:edge` writes `artifacts/edge/`. The real-browser smoke runs the shared full-product scenarios and requires an explicit Microsoft Edge executable that reports an `Edg/<version>` identity; Chrome substitution is never Edge release proof.
 
+Build every maintained output with one command:
+
+```bash
+pnpm build:all
+```
+
+This writes the production Chrome extension to `dist/`, Firefox to `dist-firefox/`, Edge to `dist-edge/`, and the public demo to `dist-demo/`. It does not create store-upload ZIP files; use the target-specific `package:chrome`, `package:firefox`, or `package:edge` command for those artifacts.
+
 ## Debug Cubby Agent
 
 When investigating Cubby Agent diagnostics, Provider events, or recovery behavior, do not modify the release build to expose temporary debug state. Use the repository's development entry points.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,14 @@ EDGE_EXECUTABLE="/path/to/Microsoft Edge" pnpm test:smoke:edge
 
 Edge 目标只是构建、打包和浏览器身份：它提供与 Chrome 相同的完整产品，包括 Gist 同步、Cubby、AI Provider 和 Provider 驱动的 Organize。构建输出位于 `dist-edge/`，`pnpm package:edge` 输出到 `artifacts/edge/`。真实浏览器 smoke 运行共享的完整产品场景，必须使用报告 `Edg/<version>` 身份的 Microsoft Edge 可执行文件；发布证据不能用 Chrome 代替。
 
+用一个命令构建所有维护中的输出：
+
+```bash
+pnpm build:all
+```
+
+该命令会将生产版 Chrome 扩展写入 `dist/`、Firefox 扩展写入 `dist-firefox/`、Edge 扩展写入 `dist-edge/`，并将公开 Demo 写入 `dist-demo/`。它不会生成用于上传商店的 ZIP；如需上传产物，请分别运行 `package:chrome`、`package:firefox` 或 `package:edge`。
+
 ## 调试 Cubby Agent
 
 检查 Cubby Agent 的开发诊断、Provider 事件或恢复行为时，不要修改发布构建来临时暴露调试状态。使用仓库提供的开发入口。

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build:firefox": "node scripts/build-firefox-extension.mjs",
     "build:edge": "node scripts/build-edge-extension.mjs",
     "build:demo": "tsc --noEmit && vite build --config vite.demo.config.ts && node scripts/verify-demo-artifacts.mjs demo",
+    "build:all": "pnpm build:firefox && pnpm build:edge && pnpm build:demo",
     "verify:artifact-isolation": "node scripts/verify-demo-artifacts.mjs both",
     "test:demo:browser": "node tests/runtime/demo-browser-smoke.mjs",
     "package:extension": "node scripts/package-extension.mjs",


### PR DESCRIPTION
## Problem
The repository has separate build commands for Chrome, Firefox, Edge, and the public Demo, so producing every maintained output requires remembering multiple commands and their order.

## Decision
Add `pnpm build:all` as a fail-fast sequential shortcut. It reuses the existing target build paths and documents the four generated directories in both English and Chinese contributor guides. Store-upload ZIP packaging remains separate through `package:chrome`, `package:firefox`, and `package:edge`.

## Check
- `pnpm build:all` passed.
- Chrome production output was written to `dist/`.
- Firefox output was written to `dist-firefox/`.
- Edge output was written to `dist-edge/`.
- Public Demo output was written to `dist-demo/`.
- Demo artifact isolation passed.
- `git diff --check` passed.
- Read-only scope review reported no findings.

Not tested: store ZIP packaging, browser smoke tests, and the full `pnpm test` suite.

## Risk
Low. This adds a package script and bilingual contributor documentation only. Existing individual build and package commands are unchanged. The commands run sequentially with `&&`, so a failed target stops the aggregate build and avoids ambiguous partial success.

## Evidence
Commit `9531db4`; aggregate build completed successfully on the exact PR source.