### PR TITLE
chore(release): prepare 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-github-stars-manager",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Manage your GitHub starred repos: tag, note, filter, search across thousands of stars. UI injected into the stars page.",
   "packageManager": "pnpm@10.33.2",
   "devEngines": {

--- a/scripts/package-manifest-closure.mjs
+++ b/scripts/package-manifest-closure.mjs
@@ -2,16 +2,16 @@ import { createHash } from 'node:crypto';
 import { lstatSync, realpathSync } from 'node:fs';
 import path from 'node:path';
 
-export const WORKER_BYTE_CEILING = 741_693;
+export const WORKER_BYTE_CEILING = 778_162;
 export const RELEASE_WORKER_BASELINE = Object.freeze({
-  relativePath: 'assets/index.ts-CYGIhXwD.js',
+  relativePath: 'assets/index.ts-Csveizju.js',
   bytes: WORKER_BYTE_CEILING,
-  sha256: '902c0726442c96d00674910ae245ade7f1ad153ac4bbe742d3a3e366d7b41ea2',
+  sha256: 'dd7f255324a446c39832af8abaf02b82dffedbe9185d8fc459ba50698faba326',
 });
 export const EDGE_RELEASE_WORKER_BASELINE = Object.freeze({
-  relativePath: 'assets/index.ts-BpdUArVM.js',
-  bytes: 748_582,
-  sha256: '22478177c6493c22ae09fa730d24d0d72cd221b4c48fc543fc99b7e0ba457642',
+  relativePath: 'assets/index.ts-BlPycEBq.js',
+  bytes: WORKER_BYTE_CEILING,
+  sha256: '4989563e1fc5bc9fb24bbd8a45930d16739ca474b6212f86846c01c09b386613',
 });
 
 const SHA256 = /^[0-9a-f]{64}$/u;

--- a/tests/unit/edge-platform-contracts.test.mjs
+++ b/tests/unit/edge-platform-contracts.test.mjs
@@ -213,9 +213,9 @@ test('uses one full-product manifest across Edge, Chrome, and Firefox', () => {
 
 test('uses an exact Edge worker baseline with the full-product identity shape', () => {
   assert.deepEqual(EDGE_RELEASE_WORKER_BASELINE, {
-    relativePath: 'assets/index.ts-BpdUArVM.js',
-    bytes: 748_582,
-    sha256: '22478177c6493c22ae09fa730d24d0d72cd221b4c48fc543fc99b7e0ba457642',
+    relativePath: 'assets/index.ts-BlPycEBq.js',
+    bytes: 778_162,
+    sha256: '4989563e1fc5bc9fb24bbd8a45930d16739ca474b6212f86846c01c09b386613',
   });
   assert.deepEqual(Object.keys(EDGE_RELEASE_WORKER_BASELINE).sort(), ['bytes', 'relativePath', 'sha256']);
   const worker = {

--- a/tests/unit/package-manifest-closure.test.mjs
+++ b/tests/unit/package-manifest-closure.test.mjs
@@ -212,7 +212,7 @@ test('measures bundle identities and enforces the frozen release worker exactly'
     ...RELEASE_WORKER_BASELINE,
     kib: RELEASE_WORKER_BASELINE.bytes / 1024,
   };
-  assert.equal(exact.bytes, 741_693);
+  assert.equal(exact.bytes, 778_162);
   assert.equal(WORKER_BYTE_CEILING, exact.bytes);
   assert.equal(enforceWorkerByteCeiling(exact).withinCeiling, true);
   assert.deepEqual(enforceWorkerReleaseBaseline(exact), exact);


### PR DESCRIPTION
## Problem
The repository source and generated extension manifests still identify the next release as 2.0.1. The merged Radar work also changes the deterministic service-worker bundles, so the release identity snapshots must be refreshed before packaging 2.0.2.

## Decision
- Bump the package version to 2.0.2; all Chrome, Edge, and Firefox manifests inherit this version.
- Refresh the frozen Chrome/Firefox and Edge worker identities to the deterministic 2.0.2 production bundles.
- Update the focused identity-contract expectations without changing runtime behavior.

## Check
- `pnpm test` — passed: 224 files, 3,428 tests.
- `pnpm typecheck` — passed.
- Focused package/manifest tests — passed: 36 tests.
- `pnpm build:all` — passed.
- `pnpm check:firefox-output` — passed.
- `pnpm check:edge-output` — passed.
- `pnpm lint:firefox` — passed: 0 errors, 0 notices, 5 reviewed warnings.
- Chrome, Edge, and Firefox 2.0.2 packages generated; all ZIP and Firefox source checksums verified.
- Not tested: store dashboard upload, review, signing/publication, and live authenticated browser flows.

## Risk
- Uploading Chrome 2.0.2 will replace the currently pending Chrome 2.0.1 submission and start a new review.
- This PR intentionally raises the frozen worker baseline to the measured 2.0.2 bundles; the package gate remains exact and fail-closed.
- No permissions, host permissions, storage schema, or product API changes are included.

## Evidence
- `artifacts/better-github-stars-manager-2.0.2.zip`
- `artifacts/edge/better-github-stars-manager-edge-2.0.2.zip`
- `artifacts/firefox/better-github-stars-manager-firefox-2.0.2.zip`
- `artifacts/firefox/better-github-stars-manager-firefox-2.0.2-source.zip`