### PR TITLE
perf(storage): share one library snapshot across surfaces

### DIFF
--- a/src/background/query.ts
+++ b/src/background/query.ts
@@ -1,4 +1,7 @@
-import { db } from '@/storage/db';
+import {
+  invalidateLibrarySnapshot,
+  readLibrarySnapshot,
+} from '@/storage/library-projection';
 import {
   validateLaunchCandidateContract,
   type LaunchCandidateContract,
@@ -39,6 +42,7 @@ let cacheVersion = 0;
 export function invalidateCache() {
   cacheVersion++;
   cache = null;
+  invalidateLibrarySnapshot();
 }
 
 async function ensureCache(includesOwnedPublic: boolean) {
@@ -47,16 +51,15 @@ async function ensureCache(includesOwnedPublic: boolean) {
     && cache.version === cacheVersion
     && cache.includesOwnedPublic === includesOwnedPublic
   ) return cache;
-  const starsPromise = includesOwnedPublic
-    ? db.stars.toArray()
-    : db.stars.filter((star) => star.viewer_has_starred !== false).toArray();
-  const [stars, tags, tagMeta] = await Promise.all([
-    starsPromise,
-    db.tags.toArray(),
-    db.tagMeta.toArray(),
-  ]);
+  // The shared library snapshot serves every surface. This layer keeps its own
+  // entry because it additionally caches the owned-public narrowing, which only
+  // the Stars query needs.
+  const library = await readLibrarySnapshot();
+  const stars = includesOwnedPublic
+    ? library.stars
+    : library.stars.filter((star) => star.viewer_has_starred !== false);
   cache = {
-    source: { stars, tags, tagMeta },
+    source: { stars, tags: library.tags, tagMeta: library.tagMeta },
     version: cacheVersion,
     includesOwnedPublic,
   };

--- a/src/storage/library-projection.ts
+++ b/src/storage/library-projection.ts
@@ -1,0 +1,93 @@
+import { db } from '@/storage/db';
+import type { Star, Tag, TagMeta } from '@/types';
+
+/**
+ * The Stars library, tags, and tag metadata read once and shared by every
+ * surface that joins against them.
+ *
+ * Stars, Following, Watch, and For You each read all three tables
+ * independently, so opening a surface deserialized the whole library several
+ * times over. One snapshot now serves all of them.
+ *
+ * Invalidation is automatic: a Dexie middleware drops the snapshot when any of
+ * the three tables is written. Surfaces other than the Stars query never had a
+ * cache and always observed the latest rows, so tracking writes preserves their
+ * existing semantics. The Stars query keeps its own explicitly invalidated entry
+ * on top of this one, because its staleness boundary is a tested contract.
+ */
+export type LibrarySnapshot = Readonly<{
+  stars: readonly Star[];
+  tags: readonly Tag[];
+  tagMeta: readonly TagMeta[];
+}>;
+
+const LIBRARY_TABLES: Record<string, true> = {
+  stars: true,
+  tags: true,
+  tagMeta: true,
+};
+
+let snapshot: LibrarySnapshot | null = null;
+let pending: Promise<LibrarySnapshot> | null = null;
+
+/** Drop the cached snapshot. Writes do this automatically; callers rarely need it. */
+export function invalidateLibrarySnapshot(): void {
+  snapshot = null;
+  pending = null;
+}
+
+db.use({
+  stack: 'dbcore',
+  name: 'bgsm-library-snapshot-invalidation',
+  create: (downlevel) => {
+    // `create` runs on every connection, so a deleted-and-reopened database
+    // cannot serve a snapshot captured from the previous one.
+    invalidateLibrarySnapshot();
+    return {
+      ...downlevel,
+      table: (tableName) => {
+        const table = downlevel.table(tableName);
+        if (!(tableName in LIBRARY_TABLES)) return table;
+        return {
+          ...table,
+          mutate: (request) => {
+            invalidateLibrarySnapshot();
+            return table.mutate(request);
+          },
+        };
+      },
+    };
+  },
+});
+
+/**
+ * Concurrent surfaces opening at once share one read instead of racing three
+ * table scans each.
+ */
+export function readLibrarySnapshot(): Promise<LibrarySnapshot> {
+  if (snapshot) return Promise.resolve(snapshot);
+  if (pending) return pending;
+  const request = (async (): Promise<LibrarySnapshot> => {
+    const [stars, tags, tagMeta] = await Promise.all([
+      db.stars.toArray(),
+      db.tags.toArray(),
+      db.tagMeta.toArray(),
+    ]);
+    return { stars, tags, tagMeta };
+  })();
+  pending = request;
+  return request.then(
+    (result) => {
+      // A write during the read clears `pending`; that result must not be cached.
+      if (pending === request) {
+        snapshot = result;
+        pending = null;
+      }
+      return result;
+    },
+    (error) => {
+      if (pending === request) pending = null;
+      throw error;
+    },
+  );
+}

--- a/src/storage/radar-store.ts
+++ b/src/storage/radar-store.ts
@@ -20,6 +20,7 @@ import type {
   RadarStatus,
 } from '@/radar/radar-contract';
 import { db } from './db';
+import { readLibrarySnapshot } from './library-projection';
 import { DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS } from '@/preferences';
 
 const RADAR_STATE_ID = 'singleton' as const;
@@ -112,6 +113,11 @@ function stateForAccount(
   return stored ? publicState(stored) : null;
 }
 
+/** Inclusive lower bound for a rolling activity window, as a stored timestamp. */
+function windowCutoffAt(nowMillis: number, windowDays: number): string {
+  return new Date(nowMillis - windowDays * 24 * 60 * 60 * 1_000).toISOString();
+}
+
 export async function countUnseenRadarActivities(
   accountLogin: string | null | undefined,
   nowMillis = Date.now(),
@@ -119,21 +125,22 @@ export async function countUnseenRadarActivities(
 ): Promise<number> {
   if (!accountLogin?.trim()) return 0;
   const key = accountKey(accountLogin);
-  const cutoffMillis = nowMillis - windowDays * 24 * 60 * 60 * 1_000;
   return db.transaction('r', db.radarActivities, db.radarState, async () => {
     const state = await db.radarState.get(RADAR_STATE_ID);
     if (!state || accountKey(state.accountLogin) !== key) return 0;
+    // This runs on every account reconciliation, so bound it with the compound
+    // index and filter only the two fields the index cannot express.
     return db.radarActivities
-      .where('accountLogin')
-      .equals(key)
-      .filter((activity) => {
-        const starredAt = timestamp(activity.starredAt);
-        return activity.dismissedAt === null
-          && storedSeenAt(activity.seenAt) === null
-          && starredAt !== null
-          && starredAt >= cutoffMillis
-          && starredAt <= nowMillis;
-      })
+      .where('[accountLogin+starredAt]')
+      .between(
+        [key, windowCutoffAt(nowMillis, windowDays)],
+        [key, new Date(nowMillis).toISOString()],
+        true,
+        true,
+      )
+      .filter((activity) => (
+        activity.dismissedAt === null && storedSeenAt(activity.seenAt) === null
+      ))
       .count();
   });
 }
@@ -642,20 +649,28 @@ export async function listRadarActivities(
   windowDays = DEFAULT_FOLLOWING_HISTORY_WINDOW_DAYS,
 ): Promise<RadarActivityPresentation[]> {
   const key = accountKey(accountLogin);
-  const [activities, stars, tags, tagMeta] = await Promise.all([
-    db.radarActivities.where('accountLogin').equals(key).toArray(),
-    db.stars.toArray(),
-    db.tags.toArray(),
-    db.tagMeta.toArray(),
+  const [activities, library] = await Promise.all([
+    // The projector discards rows outside the window anyway, so bound the read
+    // with the compound index instead of scanning every saved row.
+    db.radarActivities
+      .where('[accountLogin+starredAt]')
+      .between(
+        [key, windowCutoffAt(nowMillis, windowDays)],
+        [key, new Date(nowMillis).toISOString()],
+        true,
+        true,
+      )
+      .toArray(),
+    readLibrarySnapshot(),
   ]);
   return projectRadarActivities({
     accountLogin: key,
     nowMillis,
     windowDays,
     activities,
-    stars,
-    tags,
-    tagMeta,
+    stars: library.stars,
+    tags: library.tags,
+    tagMeta: library.tagMeta,
   });
 }
 

--- a/src/storage/recommendation-store.ts
+++ b/src/storage/recommendation-store.ts
@@ -13,6 +13,7 @@ import {
 import { normalizeRepositoryFullName } from '@/watch/watch-model';
 import { projectRecommendations } from '@/recommendations/recommendation-projector';
 import { db } from './db';
+import { readLibrarySnapshot } from './library-projection';
 
 const RECOMMENDATION_STATE_ID = 'singleton' as const;
 const RECOMMENDATION_STALE_AFTER_MS = 24 * 60 * 60 * 1_000;
@@ -251,15 +252,15 @@ export async function recordRecommendationFailure(
 /** Query cache rows for one account, excluding ignored and already-starred repositories. */
 export async function listRecommendations(accountLogin: string): Promise<RecommendationRecord[]> {
   const key = accountKey(accountLogin);
-  const [recommendations, stars, ignores] = await Promise.all([
+  const [recommendations, library, ignores] = await Promise.all([
     db.recommendations.where('accountLogin').equals(key).toArray(),
-    db.stars.toArray(),
+    readLibrarySnapshot(),
     db.recommendationIgnores.where('accountLogin').equals(key).toArray(),
   ]);
   return projectRecommendations({
     accountLogin: key,
     recommendations,
-    stars,
+    stars: library.stars,
     ignores,
   });
 }

--- a/tests/regressions/storage/library-projection-regression.test.ts
+++ b/tests/regressions/storage/library-projection-regression.test.ts
@@ -1,0 +1,148 @@
+import 'fake-indexeddb/auto';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { db } from '@/storage/db';
+import {
+  invalidateLibrarySnapshot,
+  readLibrarySnapshot,
+} from '@/storage/library-projection';
+import type { Star, Tag, TagMeta } from '@/types';
+
+const NOW = '2026-08-10T10:00:00.000Z';
+
+function star(fullName: string, overrides: Partial<Star> = {}): Star {
+  return {
+    full_name: fullName,
+    html_url: `https://github.com/${fullName}`,
+    description: 'description',
+    language: 'TypeScript',
+    stargazers_count: 10,
+    topics: [],
+    pushed_at: NOW,
+    created_at: '2020-01-01T00:00:00Z',
+    fork: false,
+    archived: false,
+    starred_at: NOW,
+    tombstone: false,
+    synced_at: NOW,
+    ...overrides,
+  } as Star;
+}
+
+function tag(fullName: string): Tag {
+  return {
+    full_name: fullName,
+    manualTags: ['manual'],
+    autoTags: [],
+    dismissedAutoTags: [],
+    manualTagsMtime: NOW,
+    autoTagsMtime: NOW,
+    dismissedAutoTagsMtime: NOW,
+    notes: '',
+    favorite: false,
+    mtime: NOW,
+  };
+}
+
+function tagMeta(name: string): TagMeta {
+  return { name, dimension: null, color: null, excluded: false, mtime: NOW };
+}
+
+describe('Library projection snapshot', () => {
+  beforeEach(async () => {
+    await db.delete();
+    await db.open();
+    invalidateLibrarySnapshot();
+  });
+
+  afterAll(() => {
+    db.close();
+  });
+
+  it('serves repeated reads from one snapshot instance', async () => {
+    await db.stars.bulkPut([star('owner/one'), star('owner/two')]);
+
+    const first = await readLibrarySnapshot();
+    const second = await readLibrarySnapshot();
+
+    expect(second).toBe(first);
+    expect(first.stars.map((row) => row.full_name)).toEqual(['owner/one', 'owner/two']);
+  });
+
+  it('shares one read across concurrent callers', async () => {
+    await db.stars.put(star('owner/one'));
+
+    const [first, second, third] = await Promise.all([
+      readLibrarySnapshot(),
+      readLibrarySnapshot(),
+      readLibrarySnapshot(),
+    ]);
+
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+  });
+
+  it.each([
+    ['stars', async () => { await db.stars.put(star('owner/added')); }],
+    ['tags', async () => { await db.tags.put(tag('owner/added')); }],
+    ['tagMeta', async () => { await db.tagMeta.put(tagMeta('added')); }],
+  ])('drops the snapshot when %s is written', async (_label, write) => {
+    await db.stars.put(star('owner/one'));
+    const before = await readLibrarySnapshot();
+
+    await write();
+    const after = await readLibrarySnapshot();
+
+    expect(after).not.toBe(before);
+  });
+
+  it('observes deletes and clears, not only inserts', async () => {
+    await db.stars.bulkPut([star('owner/one'), star('owner/two')]);
+    expect((await readLibrarySnapshot()).stars).toHaveLength(2);
+
+    await db.stars.delete('owner/two');
+    expect((await readLibrarySnapshot()).stars.map((row) => row.full_name)).toEqual(['owner/one']);
+
+    await db.stars.clear();
+    expect((await readLibrarySnapshot()).stars).toEqual([]);
+  });
+
+  it('keeps a write during an in-flight read out of the cache', async () => {
+    await db.stars.put(star('owner/one'));
+
+    const inFlight = readLibrarySnapshot();
+    await db.stars.put(star('owner/two'));
+    await inFlight;
+
+    // The interleaved write invalidated the pending result, so the next read
+    // must go back to IndexedDB rather than serve the stale snapshot.
+    const next = await readLibrarySnapshot();
+    expect(next.stars.map((row) => row.full_name).sort()).toEqual(['owner/one', 'owner/two']);
+  });
+
+  it('does not drop the snapshot when an unrelated table is written', async () => {
+    await db.stars.put(star('owner/one'));
+    const before = await readLibrarySnapshot();
+
+    await db.radarActivities.put({
+      id: 'activity-1',
+      accountLogin: 'viewer',
+      actorLogin: 'friend',
+      actorAvatarUrl: null,
+      repositoryKey: 'owner/one',
+      repositoryFullName: 'owner/one',
+      repositoryDisplayName: 'owner/one',
+      repositoryHtmlUrl: 'https://github.com/owner/one',
+      repositoryDescription: '',
+      repositoryLanguage: null,
+      repositoryLanguageColor: null,
+      repositoryTopics: [],
+      repositoryStargazerCount: 0,
+      viewerHadStarred: false,
+      starredAt: NOW,
+      dismissedAt: null,
+      seenAt: null,
+    });
+
+    expect(await readLibrarySnapshot()).toBe(before);
+  });
+});

--- a/tests/regressions/storage/radar-store-regression.test.ts
+++ b/tests/regressions/storage/radar-store-regression.test.ts
@@ -245,6 +245,31 @@ describe('Radar snapshot storage', () => {
     expect(await countUnseenRadarActivities('viewer', nowMillis, 60)).toBe(1);
   });
 
+  it('bounds window reads at the cutoff and at now, inclusive', async () => {
+    const nowMillis = Date.parse(SECOND);
+    const day = 24 * 60 * 60 * 1_000;
+    const atCutoff = new Date(nowMillis - 60 * day).toISOString();
+    const justInside = new Date(nowMillis - 60 * day + 1_000).toISOString();
+    const justOutside = new Date(nowMillis - 60 * day - 1_000).toISOString();
+    const atNow = new Date(nowMillis).toISOString();
+    const future = new Date(nowMillis + 1_000).toISOString();
+    await commitRadarSnapshot(snapshot([
+      activity('at-cutoff', 'owner/at-cutoff', atCutoff),
+      activity('just-inside', 'owner/just-inside', justInside),
+      activity('just-outside', 'owner/just-outside', justOutside),
+      activity('at-now', 'owner/at-now', atNow),
+      activity('future', 'owner/future', future),
+    ], SECOND, 90));
+
+    const listed = (await listRadarActivities('viewer', nowMillis, 60))
+      .filter((row) => row.source === 'following')
+      .map((row) => row.id)
+      .sort();
+
+    expect(listed).toEqual(['at-cutoff', 'at-now', 'just-inside']);
+    expect(await countUnseenRadarActivities('viewer', nowMillis, 60)).toBe(3);
+  });
+
   it('projects recent live Stars as self activity without copying them into Radar storage', async () => {
     const expiredAt = new Date(Date.parse(SECOND) - 61 * 24 * 60 * 60 * 1_000).toISOString();
     await db.stars.bulkPut([


### PR DESCRIPTION
## Summary

Two storage read-path changes. Both are pure performance work: no product behavior, no stored shape, and no schema version changes.

**One shared library snapshot.** `db.stars.toArray()` together with `db.tags.toArray()` and `db.tagMeta.toArray()` appeared in four independent read paths — the Stars query, `listRadarActivities`, `listRecommendations`, and Watch's live-Stars reconciliation. Opening a surface deserialized the whole library again each time. `src/storage/library-projection.ts` now reads them once and shares the result.

Invalidation is a Dexie dbcore middleware rather than explicit calls: more than twenty write sites across five modules already exist, and every future one would have to remember. The middleware also invalidates in `create`, because that runs per connection and a deleted-and-reopened database must not serve a snapshot captured from the previous one — the radar regression suite caught exactly that.

Surfaces other than the Stars query never had a cache and always observed the latest rows, so tracking writes preserves their semantics exactly. The Stars query keeps its own explicitly invalidated entry on top: its staleness boundary is asserted by `query-cache-regression` and `query-fuzz` (a direct table mutation stays stale until `invalidateCache()`), and it additionally caches an owned-public narrowing nothing else needs.

**Index-bounded Following reads.** `listRadarActivities` and `countUnseenRadarActivities` both discard rows outside a rolling window, but read every saved row for the account and filtered in memory. Both now range-scan the existing `[accountLogin+starredAt]` compound index — declared since v5 and previously unused — and filter only `dismissedAt` and `seenAt`, which no index expresses. The badge count runs on every account reconciliation, so it was the more valuable of the two.

## Measured

6000 stars, 2000 tag rows, 200 saved Following rows. Medians over six rounds after a warm-up round, comparing this branch against a baseline build of its own merge-base in a separate worktree. Two independent runs per side:

| Query | Before | After |
|---|---|---|
| `queryRadar` | 197.2 / 197.9 / 220.0ms | 137.7 / 137.8 / 144.7ms |
| `queryRecommendations` | 43.2 / 45.3 / 55.5ms | 5.5 / 5.7 / 5.8ms |
| badge counts | 5.1 / 5.6 / 5.9ms | 4.5 / 5.1 / 5.6ms |
| Stars query | 58.7 / 59.1 / 60.4ms | 53.6 / 57.1 / 55.8ms |
| One surface switch | 246.0 / 248.3 / 281.4ms | 147.7 / 149.1 / 155.6ms |

For You gains the most because it read the entire `stars` table for the sole purpose of excluding already-starred repositories. A surface switch — Following, then For You, then badges — drops from roughly 250ms to roughly 150ms.

## Tested

- `pnpm typecheck`
- `pnpm test:logic` (2624), `pnpm test:integration` (21), `pnpm test:regressions` (750), `pnpm test:smoke`
- New `library-projection-regression`: repeated reads share one instance, concurrent callers share one read, each of the three tables invalidates, deletes and clears are observed (not only inserts), a write interleaved with an in-flight read is not cached, and an unrelated table write does not invalidate.
- New radar regression pins the window boundary in both directions: rows exactly at the cutoff and exactly at `now` are included, one second outside either edge is excluded, and the badge count agrees with the listing.

## Not tested

- No measurement above 6000 stars, on low-end hardware, or with a cold service worker.
- The probe measured background message round-trips, not rendering.

## Review notes

The middleware invalidates on *any* mutation to those tables, including a write that changes nothing. That is deliberately coarse — correctness first, and the read it costs is the one this change already made cheap.
